### PR TITLE
Added stream_id to PointSupplementStreamConstructor calls in transforms

### DIFF
--- a/ion/processes/data/transforms/ctd/ctd_L0_all.py
+++ b/ion/processes/data/transforms/ctd/ctd_L0_all.py
@@ -70,11 +70,14 @@ class ctd_L0_all(TransformDataProcess):
 
         # Use the constructor to put data into a granule
 
-        psc_conductivity = PointSupplementConstructor(point_definition=self.outgoing_stream_conductivity)
+        psc_conductivity = PointSupplementConstructor(point_definition=self.outgoing_stream_conductivity, stream_id=self.streams['conductivity'])
 
-        psc_pressure = PointSupplementConstructor(point_definition=self.outgoing_stream_pressure)
+        psc_pressure = PointSupplementConstructor(point_definition=self.outgoing_stream_pressure, stream_id=self.streams['pressure'])
 
-        psc_temperature = PointSupplementConstructor(point_definition=self.outgoing_stream_temperature)
+        psc_temperature = PointSupplementConstructor(point_definition=self.outgoing_stream_temperature, stream_id=self.streams['temperature'])
+
+        ### The stream id is part of the metadata which much go in each stream granule - this is awkward to do at the
+        ### application level like this!
 
         for i in xrange(len(conductivity)):
             point_id = psc_conductivity.add_point(time=time[i],location=(longitude[i],latitude[i],height[i]))

--- a/ion/processes/data/transforms/ctd/ctd_L1_conductivity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_conductivity.py
@@ -53,7 +53,10 @@ class CTDL1ConductivityTransform(TransformFunction):
         #    1) Standard conversion from 5-character hex string to decimal
         #    2)Scaling
         # Use the constructor to put data into a granule
-        psc = PointSupplementConstructor(point_definition=self.outgoing_stream_def)
+        psc = PointSupplementConstructor(point_definition=self.outgoing_stream_def, stream_id=self.streams['output'])
+        ### Assumes the config argument for output streams is known and there is only one 'output'.
+        ### the stream id is part of the metadata which much go in each stream granule - this is awkward to do at the
+        ### application level like this!
 
         for i in xrange(len(conductivity)):
             scaled_conductivity =  ( conductivity[i] / 100000.0 ) - 0.5

--- a/ion/processes/data/transforms/ctd/ctd_L1_pressure.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_pressure.py
@@ -59,7 +59,10 @@ class CTDL1PressureTransform(TransformFunction):
 
 
         # Use the constructor to put data into a granule
-        psc = PointSupplementConstructor(point_definition=self.outgoing_stream_def)
+        psc = PointSupplementConstructor(point_definition=self.outgoing_stream_def, stream_id=self.streams['output'])
+        ### Assumes the config argument for output streams is known and there is only one 'output'.
+        ### the stream id is part of the metadata which much go in each stream granule - this is awkward to do at the
+        ### application level like this!
 
         for i in xrange(len(pressure)):
             #todo: get pressure range from metadata (if present) and include in calc

--- a/ion/processes/data/transforms/ctd/ctd_L1_temperature.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_temperature.py
@@ -63,7 +63,10 @@ class CTDL1TemperatureTransform(TransformFunction):
         #    2) Scaling: T [C] = (tdec / 10,000) - 10
 
         # Use the constructor to put data into a granule
-        psc = PointSupplementConstructor(point_definition=self.outgoing_stream_def)
+        psc = PointSupplementConstructor(point_definition=self.outgoing_stream_def, stream_id=self.streams['output'])
+        ### Assumes the config argument for output streams is known and there is only one 'output'.
+        ### the stream id is part of the metadata which much go in each stream granule - this is awkward to do at the
+        ### application level like this!
 
         for i in xrange(len(temperature)):
             scaled_temperature = ( temperature[i] / 10000.0) - 10

--- a/ion/processes/data/transforms/ctd/ctd_L2_density.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_density.py
@@ -67,7 +67,10 @@ class DensityTransform(TransformFunction):
         log.warn('Got density: %s' % str(dens))
 
         # Use the constructor to put data into a granule
-        psc = PointSupplementConstructor(point_definition=self.outgoing_stream_def)
+        psc = PointSupplementConstructor(point_definition=self.outgoing_stream_def, stream_id=self.streams['output'])
+        ### Assumes the config argument for output streams is known and there is only one 'output'.
+        ### the stream id is part of the metadata which much go in each stream granule - this is awkward to do at the
+        ### application level like this!
 
         for i in xrange(len(density)):
             point_id = psc.add_point(time=time[i],location=(longitude[i],latitude[i],height[i]))


### PR DESCRIPTION
The stream_id is part of the metadata required for a granule to be handled properly. At present it has to be added at the application level when the granule is created by the PointSupplementStreamConstructor.
