### PR TITLE
Process Dispatcher emits ION events

### DIFF
--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -52,7 +52,6 @@ class ProcessDispatcherService(BaseProcessDispatcherService):
             pd_conf = None
 
         if pd_conf:
-            print pd_conf
             log.debug("Using Process Dispatcher Bridge backend -- requires running CEI services.")
             self.backend = PDBridgeBackend(pd_conf)
         else:


### PR DESCRIPTION
Adds events to the Process Dispatcher. Clients should subscribe to events for a process before requesting it to be scheduled. The following events can be emitted (from `ProcessStateEnum`):
- `SPAWN` - when a scheduled process is running in a container (somewhere)
- `TERMINATE` - when a process either dies on its own or is killed on request
- `ERROR` - when a process fails to start or dies abnormally

To launch processes, the following behavior is recommended:

``` python
# first call create_process to get the process id
pid = self.pd_cli.create_process(process_definition_id)

# next create an event subscriber for this process
event_sub = EventSubscriber(event_type="ProcessLifecycleEvent",
    callback=self._event_callback, origin=pid,
    origin_type="DispatchedProcess")

# then request the process to be scheduled
self.pd_cli.schedule_process(process_definition_id, process_id=pid)
```

Once scheduled, wait for appropriate (asynchronous) events before trying to use the process. If successful, you will get a `ProcessStateEnum.SPAWN`.

I'm open to suggestions for improving the use of events. This code still needs to be tested under the CEI lightweight launch.
