### PR TITLE
DataHandler UNIT tests; ExternalDatasetAgent decorator change

### DIFF
--- a/ion/agents/data/handlers/base_data_handler.py
+++ b/ion/agents/data/handlers/base_data_handler.py
@@ -464,9 +464,6 @@ class BaseDataHandler(object):
         """
         Iterates over the data_generator and publishes granules to the stream indicated in stream_id
         """
-        if not hasattr(data_generator,'__iter__'):
-            raise InstrumentDataException('Invalid return from _get_data: returned object must have \'__iter__\' attribute')
-
         for count, gran in enumerate(data_generator):
             if isinstance(gran, Granule):
                 publisher.publish(gran)

--- a/ion/agents/data/handlers/base_data_handler.py
+++ b/ion/agents/data/handlers/base_data_handler.py
@@ -434,7 +434,7 @@ class BaseDataHandler(object):
         will use repeatedly (such as a dataset object) in cls._new_data_constraints and/or cls._get_data
         Objects should be added to the config so they are available later in the workflow
         """
-        raise NotImplementedError('{0}.{1} must implement \'_init_acquisition_cycle\''.format(cls.__module__,cls.__name__))
+        raise NotImplementedException('{0}.{1} must implement \'_init_acquisition_cycle\''.format(cls.__module__,cls.__name__))
 
     @classmethod
     def _new_data_constraints(cls, config):
@@ -446,7 +446,7 @@ class BaseDataHandler(object):
         @param config dict of configuration parameters - may be used to generate the returned 'constraints' dict
         @retval dict that contains the constraints for retrieval of new data from the external dataset
         """
-        raise NotImplementedError('{0}.{1} must implement \'_new_data_constraints\''.format(cls.__module__,cls.__name__))
+        raise NotImplementedException('{0}.{1} must implement \'_new_data_constraints\''.format(cls.__module__,cls.__name__))
 
     @classmethod
     def _get_data(cls, config):
@@ -456,13 +456,16 @@ class BaseDataHandler(object):
         @param config dict containing configuration parameters, may include constraints, formatters, etc
         @return an iterable that returns well-formed Granule objects on each iteration
         """
-        raise NotImplementedError('{0}.{1} must implement \'_get_data\''.format(cls.__module__,cls.__name__))
+        raise NotImplementedException('{0}.{1} must implement \'_get_data\''.format(cls.__module__,cls.__name__))
 
     @classmethod
     def _publish_data(cls, publisher, data_generator):
         """
         Iterates over the data_generator and publishes granules to the stream indicated in stream_id
         """
+        if data_generator is None or not hasattr(data_generator,'__iter__'):
+            raise InstrumentDataException('Invalid object returned from _get_data: returned object cannot be None and must have \'__iter__\' attribute')
+
         for count, gran in enumerate(data_generator):
             if isinstance(gran, Granule):
                 publisher.publish(gran)

--- a/ion/agents/data/handlers/base_data_handler.py
+++ b/ion/agents/data/handlers/base_data_handler.py
@@ -19,7 +19,7 @@ from pyon.event.event import EventPublisher
 from pyon.ion.granule.taxonomy import TaxyTool
 
 from ion.agents.instrument.instrument_driver import DriverAsyncEvent, DriverParameter
-from ion.agents.instrument.exceptions import InstrumentParameterException, InstrumentCommandException
+from ion.agents.instrument.exceptions import InstrumentParameterException, InstrumentCommandException, InstrumentDataException, NotImplementedException
 
 ### For new granule and stream interface
 from pyon.ion.granule.record_dictionary import RecordDictionaryTool
@@ -335,6 +335,7 @@ class BaseDataHandler(object):
                     log.debug('Get parameter with key: {0}'.format(pn))
                     result[pn] = self._params[pn]
                 except KeyError:
+                    log.debug('\'{0}\' not found in self._params'.format(pn))
                     raise InstrumentParameterException('{0} is not a valid parameter for this DataHandler.'.format(pn))
 
         return result
@@ -382,9 +383,7 @@ class BaseDataHandler(object):
         Called from:
                       InstrumentAgent._handler_get_resource_params
         """
-        # TODO: Should raise NotImplementedException here, return temporarily for prototyping
-#        raise NotImplementedException('get_resource_params() not implemented in BaseDataHandler')
-        return [DataHandlerParameter.POLLING_INTERVAL]
+        return self._params.keys()
 
     def get_resource_commands(self, *args, **kwargs):
         """

--- a/ion/agents/data/handlers/base_data_handler.py
+++ b/ion/agents/data/handlers/base_data_handler.py
@@ -101,11 +101,7 @@ class BaseDataHandler(object):
         log.debug('cmd_dvr received command \'{0}\' with: args={1} kwargs={2}'.format(cmd, args, kwargs))
 
         reply = None
-        if cmd == 'configure':
-            # Delegate to BaseDataHandler.configure()
-#            reply = self.configure(*args, **kwargs)
-            pass
-        elif cmd == 'initialize':
+        if cmd == 'initialize':
             # Delegate to BaseDataHandler.initialize()
             reply = self.initialize(*args, **kwargs)
         elif cmd == 'get':
@@ -123,23 +119,18 @@ class BaseDataHandler(object):
         elif cmd == 'execute_acquire_data':
             # Delegate to BaseDataHandler.execute_acquire_data()
             reply = self.execute_acquire_data(*args, **kwargs)
-        elif cmd == 'execute_acquire_sample':
-            #TODO: Can we change these names?  acquire_data would be a better name for EOI...
-            # Delegate to BaseDataHandler.execute_acquire_sample()
-            reply = self.execute_acquire_sample(*args, **kwargs)
         elif cmd == 'execute_start_autosample':
-            #TODO: Can we change these names?  stop_polling would be a better name for EOI...
             # Delegate to BaseDataHandler.execute_start_autosample()
             reply = self.execute_start_autosample(*args, **kwargs)
         elif cmd == 'execute_stop_autosample':
-            #TODO: Can we change these names?  stop_polling would be a better name for EOI...
             # Delegate to BaseDataHandler.execute_stop_autosample()
             reply = self.execute_stop_autosample(*args, **kwargs)
-        elif cmd in ['connect','disconnect','get_current_state','discover']:
+        elif cmd in ['configure','connect','disconnect','get_current_state','discover','execute_acquire_sample']:
             # Disregard
+            log.info('Command \'{0}\' not used by DataHandler'.format(cmd))
             pass
         else:
-            desc='Command unknown by DataHandler: {0}'.format(cmd)
+            desc='Command \'{0}\' unknown by DataHandler'.format(cmd)
             log.info(desc)
             raise InstrumentCommandException(desc)
 
@@ -250,20 +241,6 @@ class BaseDataHandler(object):
         g = spawn(self._acquire_data, config, publisher, self._unlock_new_data_callback)
         log.debug('** Spawned {0}'.format(g))
         self._glet_queue.append(g)
-
-    def execute_acquire_sample(self, *args, **kwargs):
-        #TODO: Add documentation
-        #TODO: Fix raises statements
-        """
-        Called from:
-                      InstrumentAgent._handler_observatory_execute_resource
-                       |-->  ExternalDataAgent._handler_streaming_execute_resource
-        """
-        # This returns the sample to the agent as an event
-        sample = {'stream_name':'data_stream','p': [-6.945], 'c': [0.08707], 't': [20.002], 'time': [1333752198.450622]}
-        self._dh_event(DriverAsyncEvent.SAMPLE, sample)
-        # This does 'rpc' style event
-        return sample
 
     def execute_start_autosample(self, *args, **kwargs):
         #TODO: Add documentation

--- a/ion/agents/data/handlers/base_data_handler.py
+++ b/ion/agents/data/handlers/base_data_handler.py
@@ -373,8 +373,8 @@ class BaseDataHandler(object):
                     to_raise.append(key)
 
         if len(to_raise) > 0:
-            log.debug('Raise ParameterError for un-set parameters: {0}'.format(to_raise))
-            raise ParameterError('Invalid parameter(s) could not be set: {0}'.format(to_raise))
+            log.debug('Raise InstrumentParameterException for un-set parameters: {0}'.format(to_raise))
+            raise InstrumentParameterException('Invalid parameter(s) could not be set: {0}'.format(to_raise))
 
     def get_resource_params(self, *args, **kwargs):
         """
@@ -419,7 +419,7 @@ class BaseDataHandler(object):
             config['constraints'] = constraints
 
         if not constraints:
-            raise ParameterError("Data constraints not set properly")
+            raise InstrumentParameterException("Data constraints not set properly")
 
         cls._publish_data(publisher, cls._get_data(config))
 
@@ -469,7 +469,7 @@ class BaseDataHandler(object):
             if isinstance(gran, Granule):
                 publisher.publish(gran)
             else:
-                log.warn('Could not publish object returned by _get_data: {0}')
+                log.warn('Could not publish object returned by _get_data: {0}'.format(gran))
 
             #TODO: Persist the 'state' of this operation so that it can be re-established in case of failure
 

--- a/ion/agents/data/handlers/base_data_handler.py
+++ b/ion/agents/data/handlers/base_data_handler.py
@@ -416,10 +416,9 @@ class BaseDataHandler(object):
         if not constraints:
             gevent.getcurrent().link(unlock_new_data_callback)
             constraints = cls._new_data_constraints(config)
+            if constraints is None:
+                raise InstrumentParameterException("Data constraints returned from _new_data_constraints cannot be None")
             config['constraints'] = constraints
-
-        if not constraints:
-            raise InstrumentParameterException("Data constraints not set properly")
 
         cls._publish_data(publisher, cls._get_data(config))
 
@@ -432,30 +431,33 @@ class BaseDataHandler(object):
     @classmethod
     def _init_acquisition_cycle(cls, config):
         """
-        Initialize anything the data handler will need to use, such as a dataset
+        Allows the concrete implementation to initialize/prepare objects the data handler
+        will use repeatedly (such as a dataset object) in cls._new_data_constraints and/or cls._get_data
+        Objects should be added to the config so they are available later in the workflow
         """
-        raise NotImplementedError("Initialize acquisition cycle not implemented in data handler")
+        raise NotImplementedError('{0}.{1} must implement \'_init_acquisition_cycle\''.format(cls.__module__,cls.__name__))
 
     @classmethod
     def _new_data_constraints(cls, config):
         #TODO: Document what "constraints" looks like (yml)!!
         """
         Determines the appropriate constraints for acquiring any "new data" from the external dataset
+        Returned value cannot be None and is assigned to config['constraints']
         The format of the constraints are documented:
-        @param config Dict of configuration parameters - may be used to generate the returned 'constraints' dict
-        @retval Dict that constrains retrieval of new data from the external dataset
+        @param config dict of configuration parameters - may be used to generate the returned 'constraints' dict
+        @retval dict that contains the constraints for retrieval of new data from the external dataset
         """
-        raise NotImplementedException
+        raise NotImplementedError('{0}.{1} must implement \'_new_data_constraints\''.format(cls.__module__,cls.__name__))
 
     @classmethod
     def _get_data(cls, config):
         """
         Iterable function that acquires data from a source iteratively based on constraints provided by config
         Passed into BaseDataHandler._publish_data and iterated to publish samples.
-        @param config Dict containing configuration parameters, may include constraints, formatters, etc
+        @param config dict containing configuration parameters, may include constraints, formatters, etc
         @return an iterable that returns well-formed Granule objects on each iteration
         """
-        raise NotImplementedException
+        raise NotImplementedError('{0}.{1} must implement \'_get_data\''.format(cls.__module__,cls.__name__))
 
     @classmethod
     def _publish_data(cls, publisher, data_generator):

--- a/ion/agents/data/handlers/ruv_data_handler.py
+++ b/ion/agents/data/handlers/ruv_data_handler.py
@@ -14,8 +14,17 @@ from pyon.ion.granule.granule import build_granule
 from pyon.ion.granule.record_dictionary import RecordDictionaryTool
 from ion.agents.data.handlers.base_data_handler import BaseDataHandler
 import numpy as np
+import re
+from StringIO import StringIO
 
 class RuvDataHandler(BaseDataHandler):
+    @classmethod
+    def _init_acquisition_cycle(cls, config):
+        ext_dset_res = get_safe(config, 'external_dataset_res', None)
+        if ext_dset_res:
+            ds_url = ext_dset_res.dataset_description.parameters['dataset_path']
+            log.debug('Instantiate a SlocumParser for dataset: \'{0}\''.format(ds_url))
+            config['parser'] = RuvParser(ds_url)
 
     @classmethod
     def _new_data_constraints(cls, config):
@@ -23,12 +32,204 @@ class RuvDataHandler(BaseDataHandler):
 
     @classmethod
     def _get_data(cls, config):
-        return None
+        parser=get_safe(config, 'parser')
+        if parser:
+            log.warn('Header Info:\n{0}'.format(parser.header_map))
+            log.warn('Tables Available: {0}'.format(parser.table_map.keys()))
 
-    @classmethod
-    def _init_dataset_object(cls, config):
-        """
-        Initialize a dataset object specific to the data handler
-        Result is assigned to dh_cfg.dataset_object
-        """
-        return None
+        return []
+
+
+
+class RuvParser(object):
+    _col_type_map = {
+        'LLUV RDL9':{
+            'LOND':('Longitude','deg',),
+            'LATD':('Latitude','deg',),
+            'VELU':('U comp','cm/s',),
+            'VELV':('V comp','cm/s',),
+            'VFLG':('VectorFlag','GridCode'),
+            'ESPC':('Spatial Quality',),
+            'ETMP':('Temporal Quality',),
+            'MAXV':('Velocity Maximum',),
+            'MINV':('Velocity Minimum',),
+            'ERSC':('Spatial Count',),
+            'ERTC':('Temporal Count',),
+            'XDST':('X Distance','km',),
+            'YDST':('Y Distance','km',),
+            'RNGE':('Range','km',),
+            'BEAR':('Bearing','True',),
+            'VELO':('Velocity','cm/s',),
+            'HEAD':('Direction','True',),
+            'SPRC':('Spectra RngCell',),
+            },
+        'rads rad1':{
+            'TIME':('Time FromStart','seconds',),
+            'AMP1':('Calculated Amp1','1/v^2',),
+            'AMP2':('Calculated Amp2','1/v^2',),
+            'PH13':('Calculated Phase13','deg',),
+            'PH23':('Corrected Phase23','deg',),
+            'CPH1':('Corrected Phase1','deg',),
+            'CPH2':('Corrected Phase2','deg',),
+            'SNF1':('Noise Floor NF1','dBm',),
+            'SNF2':('Noise Floor NF2','dBm',),
+            'SNF3':('Noise Floor NF3','dBm',),
+            'SSN1':('SignalToNoise SN1','dB',),
+            'SSN2':('SignalToNoise SN2','dB',),
+            'SSN3':('SignalToNoise SN3','dB',),
+            'DGRC':('Diag Range Cell',),
+            'DOPV':('Valid Dopplr Cells',),
+            'DDAP':('Dual Angle Prcnt','%',),
+            'RADV':('Radial Vector Count',),
+            'RAPR':('RadsV per Range',),
+            'RARC':('Rads Range Cells',),
+            'RADR':('Max Range','km',),
+            'RMCV':('Vel Max','cm/s',),
+            'RACV':('Vel Aver','cm/s',),
+            'RABA':('Bearing Average','deg CWN',),
+            'RTYP':('Radial Type',),
+            'STYP':('Spectra Type',),
+            'TYRS':('Year',),
+            'TMON':('Mo',),
+            'TDAY':('Dy',),
+            'THRS':('Hr',),
+            'TMIN':('Mn',),
+            'TSEC':('S',),
+            },
+        'rcvr rcv2':{
+            'TIME':('LogTime','Minutes',),
+            'RTMP':('Rcvr','iC',),
+            'MTMP':('Awg3','iC',),
+            'XTRP':('XmtTrip','HexCode',),
+            'RUNT':('Awg3Run','Seconds',),
+            'SP24':('Supply','Volts',),
+            'SP05':('+5VDC','Volts',),
+            'SN05':('-5VDC','Volts',),
+            'SP12':('+12VDC','Volts',),
+            'XPHT':('XInt','iC',),
+            'XAHT':('XAmp','iC',),
+            'XAFW':('XForw','Watts',),
+            'XARW':('XRefl','Watts',),
+            'XP28':('X+Ampl','Volts',),
+            'XP05':('X+5VDC','Volts',),
+            'GRMD':('GpsRcv Mode',),
+            'GDMD':('GpsDsp Mode',),
+            'GSLK':('GpsSat Lock',),
+            'GSUL':('GpsSat Unlock',),
+            'PLLL':('PLL Unlock',),
+            'HTMP':('HiRcvr','iC',),
+            'HUMI':('Humid','%',),
+            'RBIA':('Supply','Amps',),
+            'EXTA':('Extern InputA',),
+            'EXTB':('Extern InputB',),
+            'CRUN':('CompRunTime Minutes',),
+            'TYRS':('Year',),
+            'TMON':('Mo',),
+            'TDAY':('Dy',),
+            'THRS':('Hr',),
+            'TMIN':('Mn',),
+            'TSEC':('S',),
+            },
+        }
+
+    header_map = {}
+    table_map = {}
+
+    _ctf_re=re.compile('%CTF: ?([0-9]+(?:\.[0-9]*)?)')
+
+    _h_line_re=re.compile('%([a-zA-Z:]*) ?(.*)')
+
+    _tbl_type_re=re.compile('%TableType: ?(.*)')
+    _tbl_num_cols_re=re.compile('%TableColumns: ?(\d*)')
+    _tbl_num_rows_re=re.compile('%TableRows: ?(\d*)')
+    _tbl_col_types_re=re.compile('%TableColumnTypes: ?(.*)')
+    _tbl_strt_re=re.compile('%TableStart: ?\d*')
+    _tbl_end_re=re.compile('%TableEnd: ?\d*')
+    _tbl_hdrs_re=re.compile('%%[ \t]*?(.*)')
+
+    def _parse_header(self, header_str):
+        header_lines=header_str.splitlines(True)
+        for line in header_lines:
+            m=self._h_line_re.search(line)
+            self.header_map[m.group(1)]=m.group(2)
+
+    def _parse_table(self, tbl_key, tbl_str):
+        num_cols=self._tbl_num_cols_re.search(tbl_str)
+        num_rows=self._tbl_num_rows_re.search(tbl_str)
+        col_types=self._tbl_col_types_re.search(tbl_str)
+        tbl_s=self._tbl_strt_re.search(tbl_str)
+        tbl_e=self._tbl_end_re.search(tbl_str)
+
+#        print "----"
+#        print 'tbl_key: {0}'.format(tbl_key)
+#        print 'num_cols: {0}'.format(num_cols.group(1))
+#        print 'num_row: {0}'.format(num_rows.group(1))
+#        print 'col_types: {0}'.format(col_types.group(1))
+#        print 'tbl_start: {0}'.format(tbl_s.end()+1)
+#        print 'tbl_end: {0}'.format(tbl_e.start())
+
+        # Pull out the core table
+        tbl_core = tbl_str[tbl_s.end()+1:tbl_e.start()-1]
+
+        ctypes=col_types.group(1).split()
+        tbl_hdrs=self._tbl_hdrs_re.findall(tbl_core)
+        tbl_p_map = {}
+        data_map = {}
+        for i in xrange(len(ctypes)):
+            tbl_p_map[ctypes[i]] = self._col_type_map[tbl_key][ctypes[i]]
+            data_map[ctypes[i]] = np.genfromtxt(StringIO(tbl_core.replace('%','')), skip_header=len(tbl_hdrs), usecols=i, missing_values='999.000')
+
+        self.table_map[tbl_key] = {'params':tbl_p_map, 'data':data_map}
+
+    def __init__(self, url):
+
+        fstr = None
+        open_op = None
+        if url.startswith('http'):
+            open_op = urllib2.urlopen
+        else:
+            open_op = open
+
+        if open_op:
+            with open_op(url) as f:
+                fstr=f.read()
+        else:
+            raise RuvParseException('Unknown argument type: {0}'.format(url))
+
+        if not fstr:
+            raise RuvParseException('Error reading file: {0}'.format(url))
+
+        # Verify that this is a CTF v 1.00 file
+        ctf_m=self._ctf_re.search(fstr)
+        if ctf_m is None:
+            raise RuvParseException('\'{0}\' does not have %CTF flag'.format(url))
+
+        if not ctf_m.group(1) == '1.00':
+            raise RuvParseException('\'{0}\' not CTF version 1.00'.format(url))
+
+        # Find the TableTypes - allows discovery of other pieces
+        tbl_types=self._tbl_type_re.finditer(fstr)
+        if not tbl_types:
+            raise RuvParseException('\'{0}\' does not contain %TableTypes keywords'.format(url))
+        ttps=[]
+        for m in tbl_types:
+            ttps.append((m.group(0),m.group(1),m.start(),m.end()))
+
+        tbl_ends=self._tbl_end_re.finditer(fstr)
+        if not tbl_ends:
+            raise RuvParseException('\'{0}\' does not contain any %TableEnd keywords'.format(url))
+        tends=[]
+        for m in tbl_ends:
+            tends.append((m.group(0),m.end()))
+
+        # There should be the same number of results for ttype & tend
+        assert len(ttps) == len(tends)
+
+        header_str = fstr[0:ttps[0][2]]
+        self._parse_header(header_str)
+        for i in xrange(len(ttps)):
+            key=ttps[i][1]
+            self._parse_table(key, fstr[ttps[i][2]:tends[i][1]])
+
+class RuvParseException(Exception):
+    pass

--- a/ion/agents/data/handlers/slocum_data_handler.py
+++ b/ion/agents/data/handlers/slocum_data_handler.py
@@ -22,8 +22,51 @@ PACKET_CONFIG = {
     'data_stream' : ('prototype.sci_data.stream_defs', 'ctd_stream_packet')
 }
 
-class SlocumParser(object):
+class SlocumDataHandler(BaseDataHandler):
+    @classmethod
+    def _init_acquisition_cycle(cls, config):
+        ext_dset_res = get_safe(config, 'external_dataset_res', None)
+        if ext_dset_res:
+            ds_url = ext_dset_res.dataset_description.parameters['dataset_path']
+            log.debug('Instantiate a SlocumParser for dataset: \'{0}\''.format(ds_url))
+            config['parser'] = SlocumParser(ds_url)
 
+
+    @classmethod
+    def _new_data_constraints(cls, config):
+        return {}
+
+    @classmethod
+    def _get_data(cls, config):
+        parser = get_safe(config, 'parser', None)
+        ext_dset_res = get_safe(config, 'external_dataset_res', None)
+        if ext_dset_res and parser:
+            #CBM: Not in use yet...
+#            t_vname = ext_dset_res.dataset_description.parameters['temporal_dimension']
+#            x_vname = ext_dset_res.dataset_description.parameters['zonal_dimension']
+#            y_vname = ext_dset_res.dataset_description.parameters['meridional_dimension']
+#            z_vname = ext_dset_res.dataset_description.parameters['vertical_dimension']
+#            var_lst = ext_dset_res.dataset_description.parameters['variables']
+
+            max_rec = get_safe(config, 'max_records', 1)
+            dprod_id = get_safe(config, 'data_producer_id', 'unknown data producer')
+            tx_yml = get_safe(config, 'taxonomy')
+            ttool = TaxyTool.load(tx_yml) #CBM: Assertion inside RDT.__setitem__ requires same instance of TaxyTool
+
+            cnt = cls._calc_iter_cnt(len(parser.sensor_map), max_rec)
+            for x in xrange(cnt):
+                rdt = RecordDictionaryTool(taxonomy=ttool)
+
+                for name in parser.sensor_map:
+                    d = parser.data_map[name][x*max_rec:(x+1)*max_rec]
+                    rdt[name]=d
+
+                g = build_granule(data_producer_id=dprod_id, taxonomy=ttool, record_dictionary=rdt)
+                yield g
+        else:
+            log.warn('No parser object found in config')
+
+class SlocumParser(object):
     # John K's documentation says there are 16 header lines, but I believe there are actually 17
     # The 17th indicating the 'dtype' of the data for that column
     header_size = 17
@@ -70,48 +113,3 @@ class SlocumParser(object):
             self.sensor_map[sensor_names[i]]=(units[i],dtypes[i])
             dat = np.genfromtxt(fname=StringIO(fstr),skip_header=self.header_size,usecols=i,dtype=dtypes[i],missing_values='NaN')#,usemask=True)
             self.data_map[sensor_names[i]]=dat
-
-
-class SlocumDataHandler(BaseDataHandler):
-    @classmethod
-    def _init_acquisition_cycle(cls, config):
-        ext_dset_res = get_safe(config, 'external_dataset_res', None)
-        if ext_dset_res:
-            ds_url = ext_dset_res.dataset_description.parameters['dataset_path']
-            log.debug('Instantiate a SlocumParser for dataset: \'{0}\''.format(ds_url))
-            config['parser'] = SlocumParser(ds_url)
-
-
-    @classmethod
-    def _new_data_constraints(cls, config):
-        return {}
-
-    @classmethod
-    def _get_data(cls, config):
-        parser = get_safe(config, 'parser', None)
-        ext_dset_res = get_safe(config, 'external_dataset_res', None)
-        if ext_dset_res and parser:
-            #CBM: Not in use yet...
-#            t_vname = ext_dset_res.dataset_description.parameters['temporal_dimension']
-#            x_vname = ext_dset_res.dataset_description.parameters['zonal_dimension']
-#            y_vname = ext_dset_res.dataset_description.parameters['meridional_dimension']
-#            z_vname = ext_dset_res.dataset_description.parameters['vertical_dimension']
-#            var_lst = ext_dset_res.dataset_description.parameters['variables']
-
-            max_rec = get_safe(config, 'max_records', 1)
-            dprod_id = get_safe(config, 'data_producer_id', 'unknown data producer')
-            tx_yml = get_safe(config, 'taxonomy')
-            ttool = TaxyTool.load(tx_yml) #CBM: Assertion inside RDT.__setitem__ requires same instance of TaxyTool
-
-            cnt = cls._calc_iter_cnt(len(parser.sensor_map), max_rec)
-            for x in xrange(cnt):
-                rdt = RecordDictionaryTool(taxonomy=ttool)
-
-                for name in parser.sensor_map:
-                    d = parser.data_map[name][x*max_rec:(x+1)*max_rec]
-                    rdt[name]=d
-
-                g = build_granule(data_producer_id=dprod_id, taxonomy=ttool, record_dictionary=rdt)
-                yield g
-        else:
-            log.warn('No parser object found in config')

--- a/ion/agents/data/handlers/test/__init__.py
+++ b/ion/agents/data/handlers/test/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+"""
+@package 
+@file __init__.py
+@author Christopher Mueller
+@brief 
+"""

--- a/ion/agents/data/handlers/test/test_base_data_handler.py
+++ b/ion/agents/data/handlers/test/test_base_data_handler.py
@@ -186,12 +186,7 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         self._bdh.execute_acquire_data.assert_called_once()
         self.assertIsNone(ret)
 
-    def test_cmd_dvr_execute_acquire_sample(self):
-        self._bdh.execute_acquire_sample = Mock()
-        self._bdh.execute_acquire_sample.return_value = None
-        ret = self._bdh.cmd_dvr('execute_acquire_sample')
-        self._bdh.execute_acquire_sample.assert_called_once()
-        self.assertIsNone(ret)
+        self.assertEquals(ret, sentinel.ret_val)
 
     def test_cmd_dvr_execute_start_autosample(self):
         self._bdh.execute_start_autosample = Mock()
@@ -205,6 +200,11 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         self._bdh.execute_stop_autosample.return_value = None
         ret = self._bdh.cmd_dvr('execute_stop_autosample')
         self._bdh.execute_stop_autosample.assert_called_once()
+    @patch('ion.agents.data.handlers.base_data_handler.log')
+    def test_cmd_dvr_execute_acquire_sample(self, log_mock):
+        ret = self._bdh.cmd_dvr('execute_acquire_sample')
+        self.assertIsNone(ret)
+        self.assertEqual(log_mock.info.call_args[0][0], self._unused_cmd_log_output('execute_acquire_sample'))
         self.assertIsNone(ret)
 
     def test_cmd_dvr_connect(self):
@@ -244,10 +244,6 @@ class TestBaseDataHandlerUnit(PyonTestCase):
 
         self.assertIsNone(ret)
 
-    def test_execute_acquire_sample(self):
-        self._bdh._dh_event = Mock()
-        ret = self._bdh.execute_acquire_sample()
-        self.assertEqual(ret, {'stream_name':'data_stream','p': [-6.945], 'c': [0.08707], 't': [20.002], 'time': [1333752198.450622]})
 
     @patch('ion.agents.data.handlers.base_data_handler.spawn')
     def test_execute_start_autosample(self, mock):
@@ -283,7 +279,7 @@ class TestBaseDataHandlerUnit(PyonTestCase):
 
     def test_get_resource_commands(self):
         ret = self._bdh.get_resource_commands()
-        self.assertEqual(ret, ['acquire_data', 'acquire_sample', 'start_autosample', 'stop_autosample'])
+        self.assertEqual(ret, ['acquire_data', 'start_autosample', 'stop_autosample'])
 
     def test__init_acquisition_cycle(self):
         config = {}

--- a/ion/agents/data/handlers/test/test_base_data_handler.py
+++ b/ion/agents/data/handlers/test/test_base_data_handler.py
@@ -10,20 +10,24 @@
 
 from pyon.public import log, CFG
 from nose.plugins.attrib import attr
-from mock import patch, Mock, call
+from mock import patch, Mock, call, sentinel, ANY
 from pyon.util.unit_test import PyonTestCase
+from pyon.core.exception import NotFound
 import unittest
 
-from ion.agents.instrument.exceptions import InstrumentParameterException, InstrumentDataException, InstrumentCommandException, NotImplementedException
+from pyon.ion.granule.taxonomy import TaxyTool
+from ion.agents.instrument.exceptions import InstrumentParameterException, InstrumentDataException, InstrumentCommandException, NotImplementedException, InstrumentException
 from interface.objects import Granule, Attachment
 
-from ion.agents.data.handlers.base_data_handler import BaseDataHandler, ConfigurationError
+from ion.agents.data.handlers.base_data_handler import BaseDataHandler, ConfigurationError, DummyDataHandler, FibonacciDataHandler
 # Standard imports.
 
 # 3rd party imports.
 from gevent import spawn
 from gevent.event import AsyncResult
+from gevent.coros import Semaphore
 import gevent
+import numpy
 
 @attr('UNIT', group='eoi')
 class TestBaseDataHandlerUnit(PyonTestCase):
@@ -42,6 +46,25 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         self._bdh._event_callback = Mock()
         self._bdh._dh_event(type='test_type', value='test_value')
 
+    @patch.object(BaseDataHandler, 'execute_acquire_data')
+    @patch('ion.agents.data.handlers.base_data_handler.time')
+    def test__poll(self, time_mock, execute_acquire_data_mock):
+        bdh=BaseDataHandler(None, None, None)
+        bdh._params = {'POLLING_INTERVAL':1}
+        glet = spawn(bdh._poll)
+
+        self.counter = 0
+        def inc_counter(*args):
+            self.counter += 1
+            if self.counter == 2:
+                bdh._polling = False
+
+        time_mock.sleep.side_effect = inc_counter
+
+        glet.join(timeout=5)
+
+        self.assertTrue(execute_acquire_data_mock.call_count >= 2)
+
     def test__publish_data_with_granules(self):
         publisher = Mock()
 
@@ -55,7 +78,8 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         expected = [call(granule1), call(granule2), call(granule3)]
         self.assertEqual(publisher.publish.call_args_list, expected)
 
-    def test__publish_data_no_granules(self):
+    @patch('ion.agents.data.handlers.base_data_handler.log')
+    def test__publish_data_no_granules(self, log_mock):
         publisher = Mock()
 
         granule1 = Mock()
@@ -66,6 +90,7 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         BaseDataHandler._publish_data(publisher=publisher, data_generator=data_generator)
 
         self.assertEqual(publisher.publish.call_count, 0)
+        self.assertEqual(log_mock.warn.call_count, 3)
 
     def test__publish_data_no_generator(self):
         publisher = Mock()
@@ -121,10 +146,9 @@ class TestBaseDataHandlerUnit(PyonTestCase):
 
     @patch.object(BaseDataHandler, '_init_acquisition_cycle')
     @patch.object(BaseDataHandler, '_get_data')
-    @patch.object(BaseDataHandler, '_publish_data')
     @patch.object(BaseDataHandler, '_new_data_constraints')
     @patch('ion.agents.data.handlers.base_data_handler.gevent')
-    def test__acquire_data_no_constraints(self, gevent_mock, _new_data_constraints_mock, _publish_data_mock, _get_data_mock, _init_acquisition_cycle_mock):
+    def test__acquire_data_raise_exception(self, gevent_mock, _new_data_constraints_mock, _get_data_mock, _init_acquisition_cycle_mock):
         granule1 = Mock(spec=Granule)
         granule2 = Mock(spec=Granule)
         granule3 = Mock(spec=Granule)
@@ -140,97 +164,131 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         unlock_new_data_callback = Mock()
         self.assertRaises(InstrumentParameterException, BaseDataHandler._acquire_data, config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
 
-    def test_cmd_dvr_configure(self):
-        ret = self._bdh.cmd_dvr('configure')
-        self.assertIsNone(ret)
+    @patch('ion.agents.data.handlers.base_data_handler.EventPublisher')
+    @patch.object(BaseDataHandler, '_init_acquisition_cycle')
+    @patch.object(BaseDataHandler, '_get_data')
+    @patch.object(BaseDataHandler, '_publish_data')
+    def test__acquire_data_with_constraints_testing_flag(self, _publish_data_mock, _get_data_mock, _init_acquisition_cycle_mock, EventPublisher_mock):
+        granule1 = Mock(spec=Granule)
+        granule2 = Mock(spec=Granule)
+        granule3 = Mock(spec=Granule)
+        data_generator = [granule1, granule2, granule3]
+
+        _get_data_mock.return_value = data_generator
+
+        config = {'constraints' : 'test_constraints', 'TESTING':True}
+        publisher = Mock()
+        unlock_new_data_callback = Mock()
+        EventPublisher_mock.publish_event = Mock()
+        BaseDataHandler._acquire_data(config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
+
+        _init_acquisition_cycle_mock.assert_called_once_with(config)
+        _get_data_mock.assert_called_once_with(config)
+        _publish_data_mock.assert_called_once_with(publisher, data_generator)
+        EventPublisher_mock.publish_event.assert_called_once()
 
     def test_cmd_dvr_initialize(self):
         self._bdh.initialize = Mock()
-        self._bdh.initialize.return_value = None
+        self._bdh.initialize.return_value = sentinel.ret_val
         ret = self._bdh.cmd_dvr('initialize')
         self._bdh.initialize.assert_called_once()
-        self.assertIsNone(ret)
+        self.assertEquals(ret, sentinel.ret_val)
 
     def test_cmd_dvr_get(self):
         self._bdh.get = Mock()
-        self._bdh.get.return_value = None
+        self._bdh.get.return_value = sentinel.ret_val
         ret = self._bdh.cmd_dvr('get')
         self._bdh.get.assert_called_once()
-        self.assertIsNone(ret)
+        self.assertEquals(ret, sentinel.ret_val)
 
     def test_cmd_dvr_set(self):
         self._bdh.set = Mock()
-        self._bdh.set.return_value = None
+        self._bdh.set.return_value = sentinel.ret_val
         ret = self._bdh.cmd_dvr('set')
         self._bdh.set.assert_called_once()
-        self.assertIsNone(ret)
+        self.assertEquals(ret, sentinel.ret_val)
 
     def test_cmd_dvr_get_resource_params(self):
         self._bdh.get_resource_params = Mock()
-        self._bdh.get_resource_params.return_value = None
+        self._bdh.get_resource_params.return_value = sentinel.ret_val
         ret = self._bdh.cmd_dvr('get_resource_params')
         self._bdh.get_resource_params.assert_called_once()
-        self.assertIsNone(ret)
+        self.assertEquals(ret, sentinel.ret_val)
 
     def test_cmd_dvr_get_resource_commands(self):
         self._bdh.get_resource_commands = Mock()
-        self._bdh.get_resource_commands.return_value = None
+        self._bdh.get_resource_commands.return_value = sentinel.ret_val
         ret = self._bdh.cmd_dvr('get_resource_commands')
         self._bdh.get_resource_commands.assert_called_once()
-        self.assertIsNone(ret)
+        self.assertEquals(ret, sentinel.ret_val)
 
     def test_cmd_dvr_execute_acquire_data(self):
         self._bdh.execute_acquire_data = Mock()
-        self._bdh.execute_acquire_data.return_value = None
+        self._bdh.execute_acquire_data.return_value = sentinel.ret_val
         ret = self._bdh.cmd_dvr('execute_acquire_data')
         self._bdh.execute_acquire_data.assert_called_once()
-        self.assertIsNone(ret)
-
         self.assertEquals(ret, sentinel.ret_val)
 
     def test_cmd_dvr_execute_start_autosample(self):
         self._bdh.execute_start_autosample = Mock()
-        self._bdh.execute_start_autosample.return_value = None
+        self._bdh.execute_start_autosample.return_value = sentinel.ret_val
         ret = self._bdh.cmd_dvr('execute_start_autosample')
         self._bdh.execute_start_autosample.assert_called_once()
-        self.assertIsNone(ret)
+        self.assertEquals(ret, sentinel.ret_val)
 
     def test_cmd_dvr_execute_stop_autosample(self):
         self._bdh.execute_stop_autosample = Mock()
-        self._bdh.execute_stop_autosample.return_value = None
+        self._bdh.execute_stop_autosample.return_value = sentinel.ret_val
         ret = self._bdh.cmd_dvr('execute_stop_autosample')
         self._bdh.execute_stop_autosample.assert_called_once()
+        self.assertEquals(ret, sentinel.ret_val)
+
+    def _unused_cmd_log_output(self, cmd):
+        return 'Command \'{0}\' not used by DataHandler'.format(cmd)
+
     @patch('ion.agents.data.handlers.base_data_handler.log')
     def test_cmd_dvr_execute_acquire_sample(self, log_mock):
         ret = self._bdh.cmd_dvr('execute_acquire_sample')
         self.assertIsNone(ret)
         self.assertEqual(log_mock.info.call_args[0][0], self._unused_cmd_log_output('execute_acquire_sample'))
-        self.assertIsNone(ret)
 
-    def test_cmd_dvr_connect(self):
+    @patch('ion.agents.data.handlers.base_data_handler.log')
+    def test_cmd_dvr_configure(self, log_mock):
+        ret = self._bdh.cmd_dvr('configure')
+        self.assertIsNone(ret)
+        self.assertEqual(log_mock.info.call_args[0][0], self._unused_cmd_log_output('configure'))
+
+    @patch('ion.agents.data.handlers.base_data_handler.log')
+    def test_cmd_dvr_connect(self, log_mock):
         ret = self._bdh.cmd_dvr('connect')
         self.assertIsNone(ret)
+        self.assertEqual(log_mock.info.call_args[0][0], self._unused_cmd_log_output('connect'))
 
-    def test_cmd_dvr_disconnect(self):
+    @patch('ion.agents.data.handlers.base_data_handler.log')
+    def test_cmd_dvr_disconnect(self, log_mock):
         ret = self._bdh.cmd_dvr('disconnect')
         self.assertIsNone(ret)
+        self.assertEqual(log_mock.info.call_args[0][0], self._unused_cmd_log_output('disconnect'))
 
-    def test_cmd_dvr_get_current_state(self):
+    @patch('ion.agents.data.handlers.base_data_handler.log')
+    def test_cmd_dvr_get_current_state(self, log_mock):
         ret = self._bdh.cmd_dvr('get_current_state')
         self.assertIsNone(ret)
+        self.assertEqual(log_mock.info.call_args[0][0], self._unused_cmd_log_output('get_current_state'))
 
-    def test_cmd_dvr_discover(self):
+    @patch('ion.agents.data.handlers.base_data_handler.log')
+    def test_cmd_dvr_discover(self, log_mock):
         ret = self._bdh.cmd_dvr('discover')
         self.assertIsNone(ret)
+        self.assertEqual(log_mock.info.call_args[0][0], self._unused_cmd_log_output('discover'))
 
-    def test_cmd_dvr_command_not_found(self):
-        ret = None
-        self.assertRaises(InstrumentCommandException, self._bdh.cmd_dvr, 'not_found')
-
-        self.assertIsNone(ret)
+    def test_cmd_dvr_unknown_command(self):
+        self.assertRaises(InstrumentCommandException, self._bdh.cmd_dvr, 'unknown_command')
 
     def test_initialize(self):
         ret = self._bdh.initialize()
+        self.assertIsInstance(self._bdh._glet_queue, list)
+        self.assertIsInstance(self._bdh._semaphore, Semaphore)
         self.assertIsNone(ret)
 
     def test_configure_with_args(self):
@@ -239,11 +297,7 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         self.assertIsNone(ret)
 
     def test_configure_no_args(self):
-        ret = None
         self.assertRaises(InstrumentParameterException, self._bdh.configure)
-
-        self.assertIsNone(ret)
-
 
     @patch('ion.agents.data.handlers.base_data_handler.spawn')
     def test_execute_start_autosample(self, mock):
@@ -297,11 +351,17 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         config = {}
         self.assertRaises(NotImplementedException, BaseDataHandler._get_data, config)
 
-    def test__calc_iter_cnt(self):
+    def test__calc_iter_cnt_even(self):
         total_recs = 100
         max_rec = 10
         ret = BaseDataHandler._calc_iter_cnt(total_recs=total_recs, max_rec=max_rec)
         self.assertEqual(ret, 10)
+
+    def test__calc_iter_cnt_remainder(self):
+        total_recs = 101
+        max_rec = 10
+        ret = BaseDataHandler._calc_iter_cnt(total_recs=total_recs, max_rec=max_rec)
+        self.assertEqual(ret, 11)
 
     def test__unlock_new_data_callback(self):
         self._bdh._semaphore = Mock()
@@ -325,8 +385,7 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         })
 
     def test_get_not_list_or_tuple(self):
-        with self.assertRaises(InstrumentParameterException) as cm:
-            self._bdh.get('not_found')
+        self.assertRaises(InstrumentParameterException, self._bdh.get, 'not_found')
 
     def test_get_polling_interval(self):
         #TODO: Need to change back to enums instead of strings. Problem with BaseEnum.
@@ -378,22 +437,35 @@ class TestBaseDataHandlerUnit(PyonTestCase):
         self._bdh.execute_acquire_data({'stream_id' : 'test_stream_id', 'constraints' : 'test_constraints'})
         self._stream_registrar.create_publisher.assert_called_once_with(stream_id='test_stream_id')
 
-    def test_execute_acquire_data_with_stream_id_new_acquiring(self):
+    def test_execute_acquire_data_with_stream_id_new_already_acquiring(self):
         self._bdh._semaphore = Mock()
         self._bdh._semaphore.acquire.return_value = False
         self._bdh.execute_acquire_data({'stream_id' : 'test_stream_id'})
         self._bdh._semaphore.acquire.assert_called_once_with(blocking=False)
 
     @patch('ion.agents.data.handlers.base_data_handler.spawn')
-    def test_execute_acquire_data_with_stream_id_new_not_acquiring(self, mock):
+    def test_execute_acquire_data_with_stream_id_new_not_already_acquiring(self, mock):
         self._bdh._semaphore = Mock()
         self._bdh._semaphore.acquire.return_value = True
         attachment = Attachment()
         attachment.keywords = ['NewDataCheck', 'NotFound']
-        self._rr_cli.find_objects.return_value = [attachment], ''
+        attachment2 = Attachment()
+        attachment2.keywords = ['NotTheRightKeyword']
+        self._rr_cli.find_objects.return_value = [attachment2, attachment], ''
         self._bdh._glet_queue = Mock()
         self._bdh.execute_acquire_data({'stream_id' : 'test_stream_id'})
 
+        self._bdh._semaphore.acquire.assert_called_once_with(blocking=False)
+        self._rr_cli.find_objects.assert_called_once()
+
+    @patch('ion.agents.data.handlers.base_data_handler.spawn')
+    def test_execute_acquire_data_with_stream_id_new_not_already_acquiring_res_not_found(self, mock):
+        self._bdh._semaphore = Mock()
+        self._bdh._semaphore.acquire.return_value = True
+
+        self._rr_cli.find_objects.side_effect = NotFound
+
+        self.assertRaises(InstrumentException, self._bdh.execute_acquire_data, {'stream_id' : 'test_stream_id'})
         self._bdh._semaphore.acquire.assert_called_once_with(blocking=False)
         self._rr_cli.find_objects.assert_called_once()
 
@@ -407,3 +479,85 @@ class TestBaseDataHandlerUnit(PyonTestCase):
 
         self._bdh._semaphore.acquire.assert_called_once_with(blocking=False)
         self._rr_cli.find_objects.assert_called_once()
+
+@attr('UNIT',group='eoi')
+class TestDummyDataHandlerUnit(PyonTestCase):
+    def setUp(self):
+        pass
+
+    @patch.object(DummyDataHandler, '_init_acquisition_cycle')
+    def test__init_acquisition_cycle(self, _init_acquisition_cycle_mock):
+        config = {}
+        DummyDataHandler._init_acquisition_cycle(config)
+        _init_acquisition_cycle_mock.assert_called_once_with(config)
+
+    def test__new_data_constraints(self):
+        max_rec = 10
+        config = {'max_records':max_rec}
+        ret = DummyDataHandler._new_data_constraints(config)
+        self.assertTrue('array_len' in ret)
+        i=ret['array_len']
+        self.assertIsInstance(i, int)
+        self.assertTrue(max_rec+1 <= i <= max_rec+10)
+
+    @patch('ion.agents.data.handlers.base_data_handler.RecordDictionaryTool')
+    @patch('ion.agents.data.handlers.base_data_handler.TaxyTool')
+    @patch('ion.agents.data.handlers.base_data_handler.build_granule')
+    def test__get_data(self, build_granule_mock, TaxyTool_mock, RecordDictionaryTool_mock):
+        config={'constraints':{'array_len':6},'max_records':4,'data_producer_id':sentinel.dprod_id,'taxonomy':sentinel.taxy_tool}
+
+        TaxyTool_mock.load.return_value = sentinel.ttool_ret_val
+        RecordDictionaryTool_mock.side_effect = lambda **kwargs: {}
+
+        for x in DummyDataHandler._get_data(config):
+            RecordDictionaryTool_mock.assert_called_with(taxonomy=sentinel.ttool_ret_val)
+            build_granule_mock.assert_called_with(taxonomy=sentinel.ttool_ret_val, data_producer_id=sentinel.dprod_id, record_dictionary=ANY)
+            cargs=build_granule_mock.call_args
+            self.assertIn('data', cargs[1]['record_dictionary'])
+            self.assertIsInstance(cargs[1]['record_dictionary']['data'], numpy.ndarray)
+
+        self.assertEquals(build_granule_mock.call_count, 2)
+        self.assertEquals(RecordDictionaryTool_mock.call_count, 2)
+
+        TaxyTool_mock.load.assert_called_once_with(sentinel.taxy_tool)
+
+
+
+@attr('UNIT',group='eoi')
+class TestFibonacciDataHandlerUnit(PyonTestCase):
+    def setUp(self):
+        pass
+
+    @patch.object(FibonacciDataHandler, '_init_acquisition_cycle')
+    def test__init_acquisition_cycle(self, _init_acquisition_cycle_mock):
+        config = {}
+        FibonacciDataHandler._init_acquisition_cycle(config)
+        _init_acquisition_cycle_mock.assert_called_once_with(config)
+
+    def test__new_data_constraints(self):
+        ret = FibonacciDataHandler._new_data_constraints({})
+        self.assertTrue('count' in ret)
+        i=ret['count']
+        self.assertIsInstance(i, int)
+        self.assertTrue(5 <= i <= 20)
+
+    @patch('ion.agents.data.handlers.base_data_handler.RecordDictionaryTool')
+    @patch('ion.agents.data.handlers.base_data_handler.TaxyTool')
+    @patch('ion.agents.data.handlers.base_data_handler.build_granule')
+    def test__get_data(self, build_granule_mock, TaxyTool_mock, RecordDictionaryTool_mock):
+        config={'constraints':{'count':6},'max_records':4,'data_producer_id':sentinel.dprod_id,'taxonomy':sentinel.taxy_tool}
+
+        TaxyTool_mock.load.return_value = sentinel.ttool_ret_val
+        RecordDictionaryTool_mock.side_effect = lambda **kwargs: {}
+
+        for x in FibonacciDataHandler._get_data(config):
+            RecordDictionaryTool_mock.assert_called_with(taxonomy=sentinel.ttool_ret_val)
+            build_granule_mock.assert_called_with(taxonomy=sentinel.ttool_ret_val, data_producer_id=sentinel.dprod_id, record_dictionary=ANY)
+            cargs=build_granule_mock.call_args
+            self.assertIn('data', cargs[1]['record_dictionary'])
+            self.assertIsInstance(cargs[1]['record_dictionary']['data'], numpy.ndarray)
+
+        self.assertEquals(build_granule_mock.call_count, 2)
+        self.assertEquals(RecordDictionaryTool_mock.call_count, 2)
+
+        TaxyTool_mock.load.assert_called_once_with(sentinel.taxy_tool)

--- a/ion/agents/data/handlers/test/test_base_data_handler.py
+++ b/ion/agents/data/handlers/test/test_base_data_handler.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
 """
-@package ion.agents.data.test.test_base_data_handler
-@file ion/agents/data/test/test_base_data_handler.py
+@package ion.agents.data.handlers.test.test_base_data_handler
+@file ion/agents/data/handlers/test/test_base_data_handler.py
 @author Tim Giguere
 @author Christopher Mueller
-@brief Test cases for R2 BaseDataHandler
+@brief Test cases for BaseDataHandler
 """
 
 from pyon.public import log, CFG

--- a/ion/agents/data/handlers/test/test_netcdf_data_handler.py
+++ b/ion/agents/data/handlers/test/test_netcdf_data_handler.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+"""
+@package ion.agents.data.handlers.test.test_netcdf_data_handler
+@file ion/agents/data/handlers/test/test_netcdf_data_handler
+@author Christopher Mueller
+@brief Test cases for netcdf_data_handler
+"""
+
+from pyon.public import log
+from pyon.util.unit_test import PyonTestCase
+from nose.plugins.attrib import attr
+from mock import patch, Mock, call
+import unittest
+
+from ion.agents.data.handlers.netcdf_data_handler import NetcdfDataHandler
+from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance, ExternalDataProvider, DataProduct, DataSourceModel, ContactInformation, UpdateDescription, DatasetDescription, ExternalDataset, Institution, DataSource
+from netCDF4 import Dataset
+
+@attr('UNIT', group='eoi')
+class TestNetcdfDataHandlerUnit(PyonTestCase):
+
+    def setUp(self):
+        self.__rr_cli = Mock()
+        pass
+
+    def test__init_acquisition_cycle_no_ext_ds_res(self):
+        config = {}
+        NetcdfDataHandler._init_acquisition_cycle(config)
+        self.assertEqual(config,config)
+
+    def test__init_acquisition_cycle_ext_ds_res(self):
+        edres = ExternalDataset(name='test_ed_res', dataset_description=DatasetDescription(), update_description=UpdateDescription(), contact=ContactInformation())
+        edres.dataset_description.parameters['dataset_path'] = 'test_data/usgs.nc'
+        config = {'external_dataset_res':edres}
+        NetcdfDataHandler._init_acquisition_cycle(config)
+        self.assertIn('dataset_object', config)
+        self.assertTrue(isinstance(config['dataset_object'], Dataset))
+
+    def test__new_data_constraints(self):
+        pass
+
+    def test__get_data(self):
+        pass
+

--- a/ion/agents/data/handlers/test/test_ruv_data_handler.py
+++ b/ion/agents/data/handlers/test/test_ruv_data_handler.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+"""
+@package ion.agents.data.handlers.test.test_ruv_data_handler
+@file ion/agents/data/handlers/test/test_ruv_data_handler
+@author Christopher Mueller
+@brief Test cases for ruv_data_handler
+"""
+
+from pyon.public import log
+from pyon.util.unit_test import PyonTestCase
+from nose.plugins.attrib import attr
+from mock import patch, Mock, call
+import unittest
+
+from ion.agents.data.handlers.ruv_data_handler import RuvDataHandler, RuvParser
+from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance, ExternalDataProvider, DataProduct, DataSourceModel, ContactInformation, UpdateDescription, DatasetDescription, ExternalDataset, Institution, DataSource
+
+@attr('UNIT', group='eoi')
+class TestRuvDataHandlerUnit(PyonTestCase):
+
+    def setUp(self):
+        self.__rr_cli = Mock()
+        pass
+
+    def test__init_acquisition_cycle_no_ext_ds_res(self):
+        config = {}
+        RuvDataHandler._init_acquisition_cycle(config)
+        self.assertEqual(config,config)
+
+    @patch('ion.agents.data.handlers.ruv_data_handler.RuvParser')
+    def test__init_acquisition_cycle_ext_ds_res(self, RuvParser_mock):
+        edres = ExternalDataset(name='test_ed_res', dataset_description=DatasetDescription(), update_description=UpdateDescription(), contact=ContactInformation())
+        edres.dataset_description.parameters['dataset_path'] = 'test_data/RDLi_SEAB_2011_08_24_1600.ruv'
+        config = {'external_dataset_res':edres}
+        RuvDataHandler._init_acquisition_cycle(config)
+
+        RuvParser_mock.assert_called_once_with(edres.dataset_description.parameters['dataset_path'])
+        self.assertIn('parser', config)
+        self.assertTrue(config['parser'], RuvParser_mock())
+
+    def test__new_data_constraints(self):
+        ret = RuvDataHandler._new_data_constraints({})
+        self.assertIsInstance(ret, dict)
+
+    def test__get_data(self):
+        pass
+

--- a/ion/agents/data/handlers/test/test_slocum_data_handler.py
+++ b/ion/agents/data/handlers/test/test_slocum_data_handler.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+"""
+@package ion.agents.data.handlers.test.test_slocum_data_handler
+@file ion/agents/data/handlers/test/test_slocum_data_handler
+@author Christopher Mueller
+@brief Test cases for slocum_data_handler
+"""
+
+from pyon.public import log
+from pyon.util.unit_test import PyonTestCase
+from nose.plugins.attrib import attr
+from mock import patch, Mock, call, sentinel
+import unittest
+
+from ion.agents.data.handlers.slocum_data_handler import SlocumDataHandler, SlocumParser
+from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance, ExternalDataProvider, DataProduct, DataSourceModel, ContactInformation, UpdateDescription, DatasetDescription, ExternalDataset, Institution, DataSource
+
+@attr('UNIT', group='eoi')
+class TestSlocumDataHandlerUnit(PyonTestCase):
+
+    def setUp(self):
+        self.__rr_cli = Mock()
+        pass
+
+    def test__init_acquisition_cycle_no_ext_ds_res(self):
+        config = {}
+        SlocumDataHandler._init_acquisition_cycle(config)
+        self.assertEqual(config,config)
+
+    @patch('ion.agents.data.handlers.slocum_data_handler.SlocumParser')
+    def test__init_acquisition_cycle_ext_ds_res(self, SlocumParser_mock):
+        edres = ExternalDataset(name='test_ed_res', dataset_description=DatasetDescription(), update_description=UpdateDescription(), contact=ContactInformation())
+        edres.dataset_description.parameters['dataset_path'] = 'test_data/ru05-2012-021-0-0-sbd.dat'
+        config = {'external_dataset_res':edres}
+        SlocumDataHandler._init_acquisition_cycle(config)
+
+        SlocumParser_mock.assert_called_once_with(edres.dataset_description.parameters['dataset_path'])
+        self.assertIn('parser', config)
+        self.assertEquals(config['parser'],SlocumParser_mock())
+
+    def test__new_data_constraints(self):
+        ret = SlocumDataHandler._new_data_constraints({})
+        self.assertIsInstance(ret, dict)
+
+    def test__get_data(self):
+        pass
+

--- a/ion/agents/data/test/test_base_data_handler.py
+++ b/ion/agents/data/test/test_base_data_handler.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python
+
+"""
+@package ion.agents.data.test.test_base_data_handler
+@file ion/agents/data/test/test_base_data_handler.py
+@author Tim Giguere
+@author Christopher Mueller
+@brief Test cases for R2 BaseDataHandler
+"""
+
+from pyon.public import log, CFG
+from nose.plugins.attrib import attr
+from mock import patch, Mock, call
+from pyon.util.unit_test import PyonTestCase
+import unittest
+
+from ion.services.mi.exceptions import InstrumentParameterException, InstrumentDataException, InstrumentCommandException, NotImplementedException
+from interface.objects import Granule, Attachment
+
+from ion.agents.data.handlers.base_data_handler import BaseDataHandler, ConfigurationError
+
+from pyon.core.exception import InstParameterError, NotFound
+# Standard imports.
+
+# 3rd party imports.
+from gevent import spawn
+from gevent.event import AsyncResult
+import gevent
+
+@attr('UNIT', group='eoi')
+class TestBaseDataHandlerUnit(PyonTestCase):
+
+    def setUp(self):
+        self._rr_cli = Mock()
+        self._stream_registrar = Mock()
+        dh_config = {'external_dataset_res_id' : 'external_ds'}
+        self._bdh = BaseDataHandler(rr_cli=self._rr_cli, stream_registrar=self._stream_registrar, dh_config=dh_config)
+
+    def test_set_event_callback(self):
+        self._bdh.set_event_callback('test_callback')
+        self.assertEqual(self._bdh._event_callback, 'test_callback')
+
+    def test__dh_config(self):
+        self._bdh._event_callback = Mock()
+        self._bdh._dh_event(type='test_type', value='test_value')
+
+    def test_publish_data_with_granules(self):
+        publisher = Mock()
+
+        granule1 = Mock(spec=Granule)
+        granule2 = Mock(spec=Granule)
+        granule3 = Mock(spec=Granule)
+        data_generator = [granule1, granule2, granule3]
+
+        BaseDataHandler._publish_data(publisher=publisher, data_generator=data_generator)
+
+        expected = [call(granule1), call(granule2), call(granule3)]
+        self.assertEqual(publisher.publish.call_args_list, expected)
+
+    def test_publish_data_no_granules(self):
+        publisher = Mock()
+
+        granule1 = Mock()
+        granule2 = Mock()
+        granule3 = Mock()
+        data_generator = [granule1, granule2, granule3]
+
+        BaseDataHandler._publish_data(publisher=publisher, data_generator=data_generator)
+
+        self.assertEqual(publisher.publish.call_count, 0)
+
+    def test_publish_data_no_generator(self):
+        publisher = Mock()
+        data_generator = Mock()
+
+        with self.assertRaises(TypeError) as cm:
+            BaseDataHandler._publish_data(publisher=publisher, data_generator=data_generator)
+
+    def test_acquire_data_with_constraints(self):
+        granule1 = Mock(spec=Granule)
+        granule2 = Mock(spec=Granule)
+        granule3 = Mock(spec=Granule)
+        data_generator = [granule1, granule2, granule3]
+
+        BaseDataHandler._init_acquisition_cycle = Mock()
+        BaseDataHandler._get_data = Mock(auto_spec=data_generator)
+        BaseDataHandler._get_data.return_value = data_generator
+        BaseDataHandler._publish_data = Mock()
+
+        config = {'constraints' : 'test_constraints'}
+        publisher = Mock()
+        unlock_new_data_callback = Mock()
+        BaseDataHandler._acquire_data(config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
+
+        BaseDataHandler._init_acquisition_cycle.assert_called_once_with(config)
+        BaseDataHandler._get_data.assert_called_once_with(config)
+        BaseDataHandler._publish_data.assert_called_once_with(publisher, data_generator)
+
+    @patch('ion.agents.data.handlers.base_data_handler.gevent')
+    def test_acquire_data_no_constraints(self, mock_gevent):
+        granule1 = Mock(spec=Granule)
+        granule2 = Mock(spec=Granule)
+        granule3 = Mock(spec=Granule)
+        data_generator = [granule1, granule2, granule3]
+
+        mock_gevent.getcurrent = Mock()
+
+        BaseDataHandler._init_acquisition_cycle = Mock()
+        BaseDataHandler._new_data_constraints = Mock()
+        BaseDataHandler._new_data_constraints.return_value = {'constraints' : 'test_constraints'}
+        BaseDataHandler._get_data = Mock(auto_spec=data_generator)
+        BaseDataHandler._get_data.return_value = data_generator
+        BaseDataHandler._publish_data = Mock()
+
+        config = {}
+        publisher = Mock()
+        unlock_new_data_callback = Mock()
+        BaseDataHandler._acquire_data(config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
+
+        BaseDataHandler._init_acquisition_cycle.assert_called_once_with(config)
+        BaseDataHandler._new_data_constraints.assert_called_once_with(config)
+        BaseDataHandler._get_data.assert_called_once_with(config)
+        BaseDataHandler._publish_data.assert_called_once_with(publisher, data_generator)
+
+    @patch('ion.agents.data.handlers.base_data_handler.gevent')
+    def test_acquire_data_raise_exception(self, mock_gevent):
+
+        granule1 = Mock(spec=Granule)
+        granule2 = Mock(spec=Granule)
+        granule3 = Mock(spec=Granule)
+        data_generator = [granule1, granule2, granule3]
+
+        mock_gevent.getcurrent = Mock()
+
+        BaseDataHandler._init_acquisition_cycle = Mock()
+        BaseDataHandler._new_data_constraints = Mock()
+        BaseDataHandler._new_data_constraints.return_value = None
+        BaseDataHandler._get_data = Mock(auto_spec=data_generator)
+        BaseDataHandler._get_data.return_value = data_generator
+        BaseDataHandler._publish_data = Mock()
+
+        config = {}
+        publisher = Mock()
+        unlock_new_data_callback = Mock()
+        with self.assertRaises(InstrumentParameterException) as cm:
+            BaseDataHandler._acquire_data(config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
+
+    def test_cmd_dvr_configure(self):
+        ret = self._bdh.cmd_dvr('configure')
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_initialize(self):
+        self._bdh.initialize = Mock()
+        self._bdh.initialize.return_value = None
+        ret = self._bdh.cmd_dvr('initialize')
+        self._bdh.initialize.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_get(self):
+        self._bdh.get = Mock()
+        self._bdh.get.return_value = None
+        ret = self._bdh.cmd_dvr('get')
+        self._bdh.get.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_set(self):
+        self._bdh.set = Mock()
+        self._bdh.set.return_value = None
+        ret = self._bdh.cmd_dvr('set')
+        self._bdh.set.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_get_resource_params(self):
+        self._bdh.get_resource_params = Mock()
+        self._bdh.get_resource_params.return_value = None
+        ret = self._bdh.cmd_dvr('get_resource_params')
+        self._bdh.get_resource_params.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_get_resource_commands(self):
+        self._bdh.get_resource_commands = Mock()
+        self._bdh.get_resource_commands.return_value = None
+        ret = self._bdh.cmd_dvr('get_resource_commands')
+        self._bdh.get_resource_commands.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_execute_acquire_data(self):
+        self._bdh.execute_acquire_data = Mock()
+        self._bdh.execute_acquire_data.return_value = None
+        ret = self._bdh.cmd_dvr('execute_acquire_data')
+        self._bdh.execute_acquire_data.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_execute_acquire_sample(self):
+        self._bdh.execute_acquire_sample = Mock()
+        self._bdh.execute_acquire_sample.return_value = None
+        ret = self._bdh.cmd_dvr('execute_acquire_sample')
+        self._bdh.execute_acquire_sample.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_execute_start_autosample(self):
+        self._bdh.execute_start_autosample = Mock()
+        self._bdh.execute_start_autosample.return_value = None
+        ret = self._bdh.cmd_dvr('execute_start_autosample')
+        self._bdh.execute_start_autosample.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_execute_stop_autosample(self):
+        self._bdh.execute_stop_autosample = Mock()
+        self._bdh.execute_stop_autosample.return_value = None
+        ret = self._bdh.cmd_dvr('execute_stop_autosample')
+        self._bdh.execute_stop_autosample.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_connect(self):
+        ret = self._bdh.cmd_dvr('connect')
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_disconnect(self):
+        ret = self._bdh.cmd_dvr('disconnect')
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_get_current_state(self):
+        ret = self._bdh.cmd_dvr('get_current_state')
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_discover(self):
+        ret = self._bdh.cmd_dvr('discover')
+        self.assertIsNone(ret)
+
+    def test_cmd_dvr_command_not_found(self):
+        ret = None
+        with self.assertRaises(InstrumentCommandException) as cm:
+            ret = self._bdh.cmd_dvr('not_found')
+
+        self.assertIsNone(ret)
+
+    def test_initialize(self):
+        ret = self._bdh.initialize()
+        self.assertIsNone(ret)
+
+    def test_configure_with_args(self):
+        dh_config = {'test': 'test_configure'}
+        ret = self._bdh.configure(dh_config)
+        self.assertIsNone(ret)
+
+    def test_configure_no_args(self):
+        ret = None
+        with self.assertRaises(InstrumentParameterException) as cm:
+            ret = self._bdh.configure()
+
+        self.assertIsNone(ret)
+
+    def test_execute_acquire_sample(self):
+        self._bdh._dh_event = Mock()
+        ret = self._bdh.execute_acquire_sample()
+        self.assertEqual(ret, {'stream_name':'data_stream','p': [-6.945], 'c': [0.08707], 't': [20.002], 'time': [1333752198.450622]})
+
+    @patch('ion.agents.data.handlers.base_data_handler.spawn')
+    def test_execute_start_autosample(self, mock):
+        self._bdh._polling = False
+        self._bdh._polling_glet = None
+        ret = self._bdh.execute_start_autosample()
+        mock.assert_called_once()
+        self.assertIsNone(ret)
+
+    def test_execute_start_autosample_polling(self):
+        self._bdh._polling = True
+        self._bdh._polling_glet = None
+        ret = self._bdh.execute_start_autosample()
+        self.assertIsNone(ret)
+
+    def test_execute_start_autosample_polling_glet(self):
+        self._bdh._polling = False
+        self._bdh._polling_glet = 'something'
+        ret = self._bdh.execute_start_autosample()
+        self.assertIsNone(ret)
+
+    def test_execute_stop_autosample(self):
+        self._bdh._polling = True
+        self._bdh._polling_glet = Mock()
+        ret = self._bdh.execute_stop_autosample()
+        self.assertIsNone(ret)
+        self.assertFalse(self._bdh._polling)
+        self.assertIsNone(self._bdh._polling_glet)
+
+    def test_get_resource_params(self):
+        ret = self._bdh.get_resource_params()
+        self.assertEqual(ret, [('POLLING_INTERVAL',)])
+
+    def test_get_resource_commands(self):
+        ret = self._bdh.get_resource_commands()
+        self.assertEqual(ret, ['acquire_data', 'acquire_sample', 'start_autosample', 'stop_autosample'])
+
+    def test__init_acquisition_cycle(self):
+        config = {}
+        with self.assertRaises(NotImplementedError) as cm:
+            BaseDataHandler._init_acquisition_cycle(config)
+
+        ex = cm.exception
+        self.assertEqual(ex.message, "Initialize acquisition cycle not implemented in data handler")
+
+    def test__new_data_constraints(self):
+        config = {}
+        with self.assertRaises(NotImplementedException) as cm:
+            BaseDataHandler._new_data_constraints(config)
+
+    def test__get_data(self):
+        config = {}
+        with self.assertRaises(NotImplementedException) as cm:
+            BaseDataHandler._get_data(config)
+
+    def test__calc_iter_cnt(self):
+        total_recs = 100
+        max_rec = 10
+        ret = BaseDataHandler._calc_iter_cnt(total_recs=total_recs, max_rec=max_rec)
+        self.assertEqual(ret, 10)
+
+    def test__unlock_new_data_callback(self):
+        self._bdh._semaphore = Mock()
+        self._bdh._unlock_new_data_callback(None)
+        self._bdh._semaphore.release.assert_called_once()
+
+    def test_get_all(self):
+        #TODO: Need to change back to enums instead of strings. Problem with BaseEnum.
+        ret = self._bdh.get(['DRIVER_PARAMETER_ALL'])
+        self.assertEqual(ret, {
+            'POLLING_INTERVAL' : 3600,
+            'PATCHABLE_CONFIG_KEYS' : ['stream_id','constraints']
+        })
+
+    def test_get_all_with_no_arguments(self):
+        ret = self._bdh.get()
+
+        self.assertEqual(ret, {
+            'POLLING_INTERVAL' : 3600,
+            'PATCHABLE_CONFIG_KEYS' : ['stream_id','constraints']
+        })
+
+    def test_get_not_list_or_tuple(self):
+        with self.assertRaises(InstrumentParameterException) as cm:
+            self._bdh.get('not_found')
+
+    def test_get_polling_interval(self):
+        #TODO: Need to change back to enums instead of strings. Problem with BaseEnum.
+        ret = self._bdh.get(['POLLING_INTERVAL'])
+        self.assertEqual(ret, {'POLLING_INTERVAL' : 3600})
+
+    def test_get_patchable_config_keys(self):
+        #TODO: Need to change back to enums instead of strings. Problem with BaseEnum.
+        ret = self._bdh.get(['PATCHABLE_CONFIG_KEYS'])
+        self.assertEqual(ret, {'PATCHABLE_CONFIG_KEYS' : ['stream_id','constraints']})
+
+    def test_get_polling_and_patchable_config_keys(self):
+        #TODO: Need to change back to enums instead of strings. Problem with BaseEnum.
+        ret = self._bdh.get(['POLLING_INTERVAL', 'PATCHABLE_CONFIG_KEYS'])
+        self.assertEqual(ret, {
+            'POLLING_INTERVAL' : 3600,
+            'PATCHABLE_CONFIG_KEYS' : ['stream_id','constraints']
+        })
+
+    def test_get_key_error(self):
+        with self.assertRaises(InstrumentParameterException) as cm:
+            self._bdh.get(['not_found'])
+
+    def test_set_no_parameter(self):
+        with self.assertRaises(InstrumentParameterException) as cm:
+            self._bdh.set()
+
+    def test_set_not_dictionary(self):
+        with self.assertRaises(InstrumentParameterException) as cm:
+            self._bdh.set('not_found')
+
+    def test_set_polling(self):
+        #TODO: Need to change back to enums instead of strings. Problem with BaseEnum.
+        self._bdh.set({'POLLING_INTERVAL' : 7200})
+        self.assertEqual(self._bdh.get(['POLLING_INTERVAL']), {'POLLING_INTERVAL' : 7200})
+
+    def test_set_not_found(self):
+        with self.assertRaises(InstrumentParameterException) as cm:
+            self._bdh.set({'not_found': 1})
+
+    def test_execute_acquire_data_not_dictionary(self):
+        with self.assertRaises(ConfigurationError) as cm:
+            self._bdh.execute_acquire_data('not_found')
+
+    @patch('ion.agents.data.handlers.base_data_handler.spawn')
+    def test_execute_acquire_data_with_stream_id_not_new(self, mock):
+        self._bdh._semaphore = Mock()
+        self._bdh._glet_queue = Mock()
+        self._bdh.execute_acquire_data({'stream_id' : 'test_stream_id', 'constraints' : 'test_constraints'})
+        self._stream_registrar.create_publisher.assert_called_once_with(stream_id='test_stream_id')
+
+    def test_execute_acquire_data_with_stream_id_new_acquiring(self):
+        self._bdh._semaphore = Mock()
+        self._bdh._semaphore.acquire.return_value = False
+        self._bdh.execute_acquire_data({'stream_id' : 'test_stream_id'})
+        self._bdh._semaphore.acquire.assert_called_once_with(blocking=False)
+
+    @patch('ion.agents.data.handlers.base_data_handler.spawn')
+    def test_execute_acquire_data_with_stream_id_new_not_acquiring(self, mock):
+        self._bdh._semaphore = Mock()
+        self._bdh._semaphore.acquire.return_value = True
+        attachment = Attachment()
+        attachment.keywords = ['NewDataCheck', 'NotFound']
+        self._rr_cli.find_objects.return_value = [attachment], ''
+        self._bdh._glet_queue = Mock()
+        self._bdh.execute_acquire_data({'stream_id' : 'test_stream_id'})
+
+        self._bdh._semaphore.acquire.assert_called_once_with(blocking=False)
+        self._rr_cli.find_objects.assert_called_once()
+
+    @patch('ion.agents.data.handlers.base_data_handler.spawn')
+    def test_execute_acquire_data_no_attachments(self, mock):
+        self._bdh._semaphore = Mock()
+        self._bdh._semaphore.acquire.return_value = True
+        self._rr_cli.find_objects.return_value = [], ''
+        self._bdh._glet_queue = Mock()
+        self._bdh.execute_acquire_data({'stream_id' : 'test_stream_id'})
+
+        self._bdh._semaphore.acquire.assert_called_once_with(blocking=False)
+        self._rr_cli.find_objects.assert_called_once()

--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -121,24 +121,13 @@ class ExternalDatasetAgentTestBase(object):
     def setUp(self):
         """
         Initialize test members.
-        Start port agent.
-        Start container and client.
-        Start streams and subscribers.
-        Start agent, client.
         """
-
-        # Start port agent, add stop to cleanup.
-#        self._pagent = None
-#        self._start_pagent()
-#        self.addCleanup(self._stop_pagent)
 
 #        log.warn('Starting the container')
         # Start container.
         self._start_container()
 
-        # Bring up services in a deploy file (no need to message)
-#        self.container.start_rel_from_url('res/deploy/r2dm.yml')
-#        self.container.start_rel_from_url('res/deploy/r2eoi.yml')
+        # Bring up services in a deploy file
 #        log.warn('Starting the rel')
         self.container.start_rel_from_url('res/deploy/r2deploy.yml')
 
@@ -147,27 +136,6 @@ class ExternalDatasetAgentTestBase(object):
         self._pubsub_client = PubsubManagementServiceClient(node=self.container.node)
 #        log.warn('Init a ContainerAgentClient')
         self._container_client = ContainerAgentClient(node=self.container.node, name=self.container.name)
-
-#        # Define stream_config.
-#        self._stream_config = {}
-
-        # Sample async and subscription
-#        self._no_samples = None
-#        self._async_data_result = AsyncResult()
-#        self._data_greenlets = []
-#        self._samples_received = []
-#        self._data_subscribers = []
-#        # This assigns self._stream_config based on the contents of PACKET_CONFIG and starts subscribers on those streams
-#        self._start_data_subscribers()
-#        self.addCleanup(self._stop_data_subscribers)
-
-        # Event async and subscription
-#        self._no_events = None
-#        self._async_event_result = AsyncResult()
-#        self._events_received = []
-#        self._event_subscribers = []
-#        self._start_event_subscribers()
-#        self.addCleanup(self._stop_event_subscribers)
 
         # Data async and subscription  TODO: Replace with new subscriber
         self._finished_count = None
@@ -228,84 +196,6 @@ class ExternalDatasetAgentTestBase(object):
         log.info('Started StreamGranuleLogger \'{0}\' subscribed to stream_id={1}'.format(pid, stream_id))
 
         return stream_id
-
-    def _start_data_subscribers(self):
-        """
-        """
-        # A callback for processing subscribed-to data.
-        def consume_data(message, headers):
-            log.info('Subscriber received data message: %s.', str(message))
-            self._samples_received.append(message)
-            if self._no_samples and self._no_samples == len(self._samples_received):
-                self._async_data_result.set()
-
-        # Create a stream subscriber registrar to create subscribers.
-        subscriber_registrar = StreamSubscriberRegistrar(process=self.container,
-            node=self.container.node)
-
-        # Create streams and subscriptions for each stream named in driver.
-        self._stream_config = {}
-        self._data_subscribers = []
-        for (stream_name, val) in PACKET_CONFIG.iteritems():
-            stream_def = ctd_stream_definition(stream_id=None)
-            stream_def_id = pubsub_client.create_stream_definition(
-                container=stream_def)
-            stream_id = pubsub_client.create_stream(
-                name=stream_name,
-                stream_definition_id=stream_def_id,
-                original=True,
-                encoding='ION R2')
-            self._stream_config[stream_name] = stream_id
-
-            # Create subscriptions for each stream.
-            exchange_name = '%s_queue' % stream_name
-            sub = subscriber_registrar.create_subscriber(exchange_name=exchange_name,
-                callback=consume_data)
-            self._listen(sub)
-            self._data_subscribers.append(sub)
-            query = StreamQuery(stream_ids=[stream_id])
-            sub_id = pubsub_client.create_subscription(\
-                query=query, exchange_name=exchange_name)
-            pubsub_client.activate_subscription(sub_id)
-
-    def _listen(self, sub):
-        """
-        Pass in a subscriber here, this will make it listen in a background greenlet.
-        """
-        gl = spawn(sub.listen)
-        self._data_greenlets.append(gl)
-        sub._ready_event.wait(timeout=5)
-        return gl
-
-    def _stop_data_subscribers(self):
-        """
-        Stop the data subscribers on cleanup.
-        """
-        for sub in self._data_subscribers:
-            sub.stop()
-        for gl in self._data_greenlets:
-            gl.kill()
-
-    def _start_event_subscribers(self):
-        """
-        Create subscribers for agent and driver events.
-        """
-        def consume_event(*args, **kwargs):
-            log.info('Test received ION event: args=%s  kwargs=%s.', ''.join([str(x)+' ' for x in args]), str(kwargs))
-            self._events_received.append(args[0])
-            if self._no_events and self._no_events == len(self._event_received):
-                self._async_event_result.set()
-
-        event_sub = EventSubscriber(event_type="DeviceEvent", callback=consume_event)
-        event_sub.activate()
-        self._event_subscribers.append(event_sub)
-
-    def _stop_event_subscribers(self):
-        """
-        Stop event subscribers on cleanup.
-        """
-        for sub in self._event_subscribers:
-            sub.deactivate()
 
     def _start_finished_event_subscriber(self):
 
@@ -517,105 +407,6 @@ class ExternalDatasetAgentTestBase(object):
         state = retval.result
         self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
 
-    @unittest.skip('wip - likely to move to UNIT')
-    def test_acquire_new_data(self):
-        cmd=AgentCommand(command='initialize')
-        _ = self._ia_client.execute_agent(cmd)
-
-        cmd = AgentCommand(command='go_active')
-        _ = self._ia_client.execute_agent(cmd)
-
-        cmd = AgentCommand(command='run')
-        _ = self._ia_client.execute_agent(cmd)
-
-        rr_cli = ResourceRegistryServiceClient()
-
-        for key, value in self.NDC.iteritems():
-            # build attachment
-            att = Attachment(name='newDataCheck',
-                content=value,
-                keywords=['NewDataCheck'],
-                attachment_type=AttachmentType.ASCII
-            )
-
-            # create in registry
-            try:
-                ncd_att_id = rr_cli.create_attachment(self.EDA_RESOURCE_ID, att)
-                log.warn('Created attachment: {0}'.format(ncd_att_id))
-            except NotFound as ex:
-                log.warn('Not a valid resource id - it\'s just a test!!')
-
-            # run acquire_data
-            log.info('Send an unconstrained request for data (\'new data\')')
-            cmd = AgentCommand(command='acquire_data')
-            self._ia_client.execute(cmd)
-
-        self._finished_count = len(self.NDC)
-
-        cmd = AgentCommand(command='reset')
-        _ = self._ia_client.execute_agent(cmd)
-        cmd = AgentCommand(command='get_current_state')
-        retval = self._ia_client.execute_agent(cmd)
-        state = retval.result
-        self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
-
-    @unittest.skip('Not used in DataHandler')
-    def test_acquire_sample(self):
-        # Test observatory polling function.
-
-        cmd = AgentCommand(command='get_current_state')
-        retval = self._ia_client.execute_agent(cmd)
-        state = retval.result
-        self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
-
-        cmd = AgentCommand(command='initialize')
-        retval = self._ia_client.execute_agent(cmd)
-        cmd = AgentCommand(command='get_current_state')
-        retval = self._ia_client.execute_agent(cmd)
-        state = retval.result
-        self.assertEqual(state, InstrumentAgentState.INACTIVE)
-
-        cmd = AgentCommand(command='go_active')
-        retval = self._ia_client.execute_agent(cmd)
-        cmd = AgentCommand(command='get_current_state')
-        retval = self._ia_client.execute_agent(cmd)
-        state = retval.result
-        self.assertEqual(state, InstrumentAgentState.IDLE)
-
-        cmd = AgentCommand(command='run')
-        retval = self._ia_client.execute_agent(cmd)
-        cmd = AgentCommand(command='get_current_state')
-        retval = self._ia_client.execute_agent(cmd)
-        state = retval.result
-        self.assertEqual(state, InstrumentAgentState.OBSERVATORY)
-
-        # Lets get 3 samples.
-        self._no_samples = 3
-
-        # Poll for a few samples.
-        cmd = AgentCommand(command='acquire_sample')
-        reply = self._ia_client.execute(cmd)
-        self.assertSampleDict(reply.result)
-
-        cmd = AgentCommand(command='acquire_sample')
-        reply = self._ia_client.execute(cmd)
-        self.assertSampleDict(reply.result)
-
-        cmd = AgentCommand(command='acquire_sample')
-        reply = self._ia_client.execute(cmd)
-        self.assertSampleDict(reply.result)
-
-        # Assert we got 3 samples.
-        self._async_data_result.get(timeout=10)
-        self.assertTrue(len(self._samples_received)==3)
-
-        cmd = AgentCommand(command='reset')
-        retval = self._ia_client.execute_agent(cmd)
-        cmd = AgentCommand(command='get_current_state')
-        retval = self._ia_client.execute_agent(cmd)
-        state = retval.result
-        self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
-
     def test_streaming(self):
         # Test instrument driver execute interface to start and stop streaming mode.
         cmd = AgentCommand(command='get_current_state')
@@ -731,13 +522,6 @@ class ExternalDatasetAgentTestBase(object):
         self._ia_client.set_param(new_params)
         check_new_params = self._ia_client.get_param(params)
         self.assertParamVals(check_new_params, new_params)
-
-        #        # Reset the parameters back to their original values.
-        #        self._ia_client.set_param(orig_params)
-        #        reply = self._ia_client.get_param(DataHandlerParameter.POLLING_INTERVAL)
-        #        reply.pop(DataHandlerParameter.POLLING_INTERVAL)
-        #        orig_config.pop(DataHandlerParameter.POLLING_INTERVAL)
-        #        self.assertParamVals(reply, orig_config)
 
         cmd = AgentCommand(command='reset')
         retval = self._ia_client.execute_agent(cmd)
@@ -1001,11 +785,6 @@ class ExternalDatasetAgentTestBase(object):
         state = retval.result
         self.assertEqual(state, InstrumentAgentState.OBSERVATORY)
 
-#        # OK, I can do this now.
-#        cmd = AgentCommand(command='acquire_sample')
-#        reply = self._ia_client.execute(cmd)
-#        self.assertSampleDict(reply.result)
-
         # 404 unknown agent command.
         cmd = AgentCommand(command='kiss_edward')
         retval = self._ia_client.execute_agent(cmd)
@@ -1026,7 +805,7 @@ class ExternalDatasetAgentTestBase(object):
         state = retval.result
         self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
 
-@attr('INT_EOI', group='eoi')
+@attr('INT_DATA_AGENT', group='eoi')
 class TestExternalDatasetAgent(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     # DataHandler config
     DVR_CONFIG = {
@@ -1058,7 +837,7 @@ class TestExternalDatasetAgent(ExternalDatasetAgentTestBase, IonIntegrationTestC
             'max_records':4,
             }
 
-@attr('INT_EOI', group='eoi')
+@attr('INT_DATA_AGENT', group='eoi')
 class TestExternalDatasetAgent_Fibonacci(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod' : 'ion.agents.data.handlers.base_data_handler',

--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -30,7 +30,8 @@ from gevent import spawn
 from gevent.event import AsyncResult
 import gevent
 from nose.plugins.attrib import attr
-from mock import patch
+from mock import patch, Mock, call
+from pyon.util.unit_test import PyonTestCase
 
 # ION imports.
 from interface.objects import StreamQuery, Attachment, AttachmentType
@@ -52,7 +53,7 @@ from ion.agents.instrument.instrument_agent import InstrumentAgentState
 from ion.agents.data.handlers.base_data_handler import DataHandlerParameter
 
 # todo: rethink this
-from ion.agents.data.handlers.base_data_handler import PACKET_CONFIG
+from ion.agents.data.handlers.base_data_handler import PACKET_CONFIG, BaseDataHandler
 
 from pyon.ion.granule.taxonomy import TaxyTool
 
@@ -1023,6 +1024,79 @@ class ExternalDatasetAgentTestBase(object):
         retval = self._ia_client.execute_agent(cmd)
         state = retval.result
         self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
+
+@attr('UNIT_EOI', group='eoi')
+class TextExternalDatasetAgentUnit(PyonTestCase):
+
+    def setUp(self):
+        pass
+
+    def test_publish_data(self):
+        publisher = Mock()
+        config = {'stream_id' : 'test_publish_data'}
+
+        granule1 = Mock()
+        granule2 = Mock()
+        granule3 = Mock()
+        data_generator = [(1, granule1), (2, granule2), (3, granule3)]
+
+        BaseDataHandler._publish_data(publisher=publisher, config=config, data_generator=data_generator)
+
+        expected = [call((1, granule1)), call((2, granule2)), call((3, granule3))]
+        self.assertEqual(publisher.publish.call_args_list, expected)
+
+    def test_acquire_data_with_constraints(self):
+        #_init_acquistion_cycle
+        #get_safe(config, 'constraints')
+        #_publish_data
+        #_get_data
+
+        config = {'constraints' : 'test_contraints'}
+        publisher = Mock()
+        unlock_new_data_callback = Mock()
+        BaseDataHandler._acquire_data(config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
+
+    def test_acquire_data_no_constraints(self):
+        #init_acquistion_cycle(config)
+        #get_safe(config, 'constraints')
+        #gevent.getcurrent().link
+        #_new_data_constraints(config)
+        config = None
+        publisher = Mock()
+        unlock_new_data_callback = Mock()
+        BaseDataHandler._acquire_data(config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
+        pass
+
+
+#    @classmethod
+#    def _acquire_data(cls, config, publisher, unlock_new_data_callback):
+#        """
+#        Ensures required keys (such as stream_id) are available from config, configures the publisher and then calls:
+#             BaseDataHandler._new_data_constraints (only if config does not contain 'constraints')
+#             BaseDataHandler._publish_data passing BaseDataHandler._get_data as a parameter
+#        @param config Dict containing configuration parameters, may include constraints, formatters, etc
+#        @param unlock_new_data_callback BaseDataHandler callback function to allow conditional unlocking of the BaseDataHandler._semaphore
+#        """
+#        log.debug('start _acquire_data: config={0}'.format(config))
+#
+#        cls._init_acquisition_cycle(config)
+#
+#        constraints = get_safe(config,'constraints')
+#        if not constraints:
+#            gevent.getcurrent().link(unlock_new_data_callback)
+#            constraints = cls._new_data_constraints(config)
+#            config['constraints'] = constraints
+#
+#        if not constraints:
+#            raise ParameterError("Data constraints not set properly")
+#
+#        cls._publish_data(publisher, config, cls._get_data(config))
+#
+#        # Publish a 'TestFinished' event
+#        if get_safe(config,'TESTING'):
+#            log.debug('Publish TestingFinished event')
+#            pub = EventPublisher('DeviceCommonLifecycleEvent')
+#            pub.publish_event(origin='BaseDataHandler._acquire_data', description='TestingFinished')
 
 @attr('INT_EOI', group='eoi')
 class TestExternalDatasetAgent(ExternalDatasetAgentTestBase, IonIntegrationTestCase):

--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -70,7 +70,6 @@ PARAMS = {
 # To validate the list of resource commands
 CMDS = {
     'acquire_data':str,
-    'acquire_sample':str,
     'start_autosample':str,
     'stop_autosample':str
 }

--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -30,8 +30,8 @@ from gevent import spawn
 from gevent.event import AsyncResult
 import gevent
 from nose.plugins.attrib import attr
-from mock import patch, Mock, call
-from pyon.util.unit_test import PyonTestCase
+from mock import patch
+import unittest
 
 # ION imports.
 from interface.objects import StreamQuery, Attachment, AttachmentType, Granule
@@ -50,14 +50,10 @@ from pyon.event.event import EventSubscriber
 # MI imports
 from ion.agents.instrument.instrument_agent import InstrumentAgentState
 
-from ion.agents.data.handlers.base_data_handler import DataHandlerParameter
-
 # todo: rethink this
-from ion.agents.data.handlers.base_data_handler import PACKET_CONFIG, BaseDataHandler
+from ion.agents.data.handlers.base_data_handler import PACKET_CONFIG
 
 from pyon.ion.granule.taxonomy import TaxyTool
-
-import unittest
 
 
 #########################
@@ -1024,87 +1020,6 @@ class ExternalDatasetAgentTestBase(object):
         retval = self._ia_client.execute_agent(cmd)
         state = retval.result
         self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
-
-@attr('UNIT_EOI', group='eoi')
-class TestExternalDatasetAgentUnit(PyonTestCase):
-
-    def setUp(self):
-        pass
-
-    def test_publish_data(self):
-        publisher = Mock()
-
-        granule1 = Mock(spec=Granule)
-        granule2 = Mock(spec=Granule)
-        granule3 = Mock(spec=Granule)
-        data_generator = [granule1, granule2, granule3]
-
-        BaseDataHandler._publish_data(publisher=publisher, data_generator=data_generator)
-
-        expected = [call(granule1), call(granule2), call(granule3)]
-        self.assertEqual(publisher.publish.call_args_list, expected)
-
-    def test_acquire_data_with_constraints(self):
-        #_init_acquistion_cycle
-        #get_safe(config, 'constraints')
-        #_publish_data
-        #_get_data
-
-        granule1 = Mock(spec=Granule)
-        granule2 = Mock(spec=Granule)
-        granule3 = Mock(spec=Granule)
-        data_generator = [granule1, granule2, granule3]
-
-        BaseDataHandler._init_acquisition_cycle = Mock()
-        BaseDataHandler._get_data = Mock(auto_spec=data_generator)
-        BaseDataHandler._publish_data = Mock()
-
-        config = {'constraints' : 'test_contraints'}
-        publisher = Mock()
-        unlock_new_data_callback = Mock()
-        BaseDataHandler._acquire_data(config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
-
-    def test_acquire_data_no_constraints(self):
-        #init_acquistion_cycle(config)
-        #get_safe(config, 'constraints')
-        #gevent.getcurrent().link
-        #_new_data_constraints(config)
-        config = None
-        publisher = Mock()
-        unlock_new_data_callback = Mock()
-        BaseDataHandler._acquire_data(config=config, publisher=publisher, unlock_new_data_callback=unlock_new_data_callback)
-        pass
-
-
-#    @classmethod
-#    def _acquire_data(cls, config, publisher, unlock_new_data_callback):
-#        """
-#        Ensures required keys (such as stream_id) are available from config, configures the publisher and then calls:
-#             BaseDataHandler._new_data_constraints (only if config does not contain 'constraints')
-#             BaseDataHandler._publish_data passing BaseDataHandler._get_data as a parameter
-#        @param config Dict containing configuration parameters, may include constraints, formatters, etc
-#        @param unlock_new_data_callback BaseDataHandler callback function to allow conditional unlocking of the BaseDataHandler._semaphore
-#        """
-#        log.debug('start _acquire_data: config={0}'.format(config))
-#
-#        cls._init_acquisition_cycle(config)
-#
-#        constraints = get_safe(config,'constraints')
-#        if not constraints:
-#            gevent.getcurrent().link(unlock_new_data_callback)
-#            constraints = cls._new_data_constraints(config)
-#            config['constraints'] = constraints
-#
-#        if not constraints:
-#            raise ParameterError("Data constraints not set properly")
-#
-#        cls._publish_data(publisher, config, cls._get_data(config))
-#
-#        # Publish a 'TestFinished' event
-#        if get_safe(config,'TESTING'):
-#            log.debug('Publish TestingFinished event')
-#            pub = EventPublisher('DeviceCommonLifecycleEvent')
-#            pub.publish_event(origin='BaseDataHandler._acquire_data', description='TestingFinished')
 
 @attr('INT_EOI', group='eoi')
 class TestExternalDatasetAgent(ExternalDatasetAgentTestBase, IonIntegrationTestCase):

--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -34,7 +34,7 @@ from mock import patch, Mock, call
 from pyon.util.unit_test import PyonTestCase
 
 # ION imports.
-from interface.objects import StreamQuery, Attachment, AttachmentType
+from interface.objects import StreamQuery, Attachment, AttachmentType, Granule
 from interface.services.icontainer_agent import ContainerAgentClient
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
@@ -1026,23 +1026,22 @@ class ExternalDatasetAgentTestBase(object):
         self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
 
 @attr('UNIT_EOI', group='eoi')
-class TextExternalDatasetAgentUnit(PyonTestCase):
+class TestExternalDatasetAgentUnit(PyonTestCase):
 
     def setUp(self):
         pass
 
     def test_publish_data(self):
         publisher = Mock()
-        config = {'stream_id' : 'test_publish_data'}
 
-        granule1 = Mock()
-        granule2 = Mock()
-        granule3 = Mock()
-        data_generator = [(1, granule1), (2, granule2), (3, granule3)]
+        granule1 = Mock(spec=Granule)
+        granule2 = Mock(spec=Granule)
+        granule3 = Mock(spec=Granule)
+        data_generator = [granule1, granule2, granule3]
 
-        BaseDataHandler._publish_data(publisher=publisher, config=config, data_generator=data_generator)
+        BaseDataHandler._publish_data(publisher=publisher, data_generator=data_generator)
 
-        expected = [call((1, granule1)), call((2, granule2)), call((3, granule3))]
+        expected = [call(granule1), call(granule2), call(granule3)]
         self.assertEqual(publisher.publish.call_args_list, expected)
 
     def test_acquire_data_with_constraints(self):
@@ -1050,6 +1049,15 @@ class TextExternalDatasetAgentUnit(PyonTestCase):
         #get_safe(config, 'constraints')
         #_publish_data
         #_get_data
+
+        granule1 = Mock(spec=Granule)
+        granule2 = Mock(spec=Granule)
+        granule3 = Mock(spec=Granule)
+        data_generator = [granule1, granule2, granule3]
+
+        BaseDataHandler._init_acquisition_cycle = Mock()
+        BaseDataHandler._get_data = Mock(auto_spec=data_generator)
+        BaseDataHandler._publish_data = Mock()
 
         config = {'constraints' : 'test_contraints'}
         publisher = Mock()

--- a/ion/agents/data/test/test_external_dataset_agent_netcdf.py
+++ b/ion/agents/data/test/test_external_dataset_agent_netcdf.py
@@ -20,7 +20,7 @@ from ion.agents.data.test.test_external_dataset_agent import ExternalDatasetAgen
 
 from nose.plugins.attrib import attr
 
-@attr('INT_EOI', group='eoi')
+@attr('INT_DATA_AGENT', group='eoi')
 class TestExternalDatasetAgent_Netcdf(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod' : 'ion.agents.data.handlers.netcdf_data_handler',

--- a/ion/agents/data/test/test_external_dataset_agent_ruv.py
+++ b/ion/agents/data/test/test_external_dataset_agent_ruv.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 """
-@package ion.agents.data.test.test_external_dataset_agent_slocum
-@file ion/agents/data/test/test_external_dataset_agent_slocum.py
+@package ion.agents.data.test.test_external_dataset_agent_ruv
+@file ion/agents/data/test/test_external_dataset_agent_ruv.py
 @author Christopher Mueller
 @brief 
 """
@@ -20,10 +20,10 @@ from ion.agents.data.test.test_external_dataset_agent import ExternalDatasetAgen
 from nose.plugins.attrib import attr
 
 @attr('INT_EOI', group='eoi')
-class TestExternalDatasetAgent_Slocum(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
+class TestExternalDatasetAgent_Ruv(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
-        'dvr_mod' : 'ion.agents.data.handlers.slocum_data_handler',
-        'dvr_cls' : 'SlocumDataHandler',
+        'dvr_mod' : 'ion.agents.data.handlers.ruv_data_handler',
+        'dvr_cls' : 'RuvDataHandler',
         }
 
     HIST_CONSTRAINTS_1 = {}
@@ -58,74 +58,20 @@ class TestExternalDatasetAgent_Slocum(ExternalDatasetAgentTestBase, IonIntegrati
         dsrc.contact.email = 'tgiguere@asascience.com'
 
         # Create ExternalDataset
-        ds_name = 'slocum_test_dataset'
+        ds_name = 'ruv_test_dataset'
         dset = ExternalDataset(name=ds_name, dataset_description=DatasetDescription(), update_description=UpdateDescription(), contact=ContactInformation())
 
-        dset.dataset_description.parameters['dataset_path'] = 'test_data/ru05-2012-021-0-0-sbd.dat'
+        dset.dataset_description.parameters['dataset_path'] = 'test_data/RDLi_SEAB_2011_08_24_1600.ruv'
         dset.dataset_description.parameters['temporal_dimension'] = None
         dset.dataset_description.parameters['zonal_dimension'] = None
         dset.dataset_description.parameters['meridional_dimension'] = None
         dset.dataset_description.parameters['vertical_dimension'] = None
         dset.dataset_description.parameters['variables'] = [
-            'c_wpt_y_lmc',
-            'sci_water_cond',
-            'm_y_lmc',
-            'u_hd_fin_ap_inflection_holdoff',
-            'sci_m_present_time',
-            'm_leakdetect_voltage_forward',
-            'sci_bb3slo_b660_scaled',
-            'c_science_send_all',
-            'm_gps_status',
-            'm_water_vx',
-            'm_water_vy',
-            'c_heading',
-            'sci_fl3slo_chlor_units',
-            'u_hd_fin_ap_gain',
-            'm_vacuum',
-            'u_min_water_depth',
-            'm_gps_lat',
-            'm_veh_temp',
-            'f_fin_offset',
-            'u_hd_fin_ap_hardover_holdoff',
-            'c_alt_time',
-            'm_present_time',
-            'm_heading',
-            'sci_bb3slo_b532_scaled',
-            'sci_fl3slo_cdom_units',
-            'm_fin',
-            'x_cycle_overrun_in_ms',
-            'sci_water_pressure',
-            'u_hd_fin_ap_igain',
-            'sci_fl3slo_phyco_units',
-            'm_battpos',
-            'sci_bb3slo_b470_scaled',
-            'm_lat',
-            'm_gps_lon',
-            'sci_ctd41cp_timestamp',
-            'm_pressure',
-            'c_wpt_x_lmc',
-            'c_ballast_pumped',
-            'x_lmc_xy_source',
-            'm_lon',
-            'm_avg_speed',
-            'sci_water_temp',
-            'u_pitch_ap_gain',
-            'm_roll',
-            'm_tot_num_inflections',
-            'm_x_lmc',
-            'u_pitch_ap_deadband',
-            'm_final_water_vy',
-            'm_final_water_vx',
-            'm_water_depth',
-            'm_leakdetect_voltage',
-            'u_pitch_max_delta_battpos',
-            'm_coulomb_amphr',
-            'm_pitch',
         ]
 
         # Create DataSourceModel
-        dsrc_model = DataSourceModel(name='slocum_model')
-        dsrc_model.model = 'SLOCUM'
+        dsrc_model = DataSourceModel(name='ruv_model')
+        dsrc_model.model = 'RUV'
         dsrc_model.data_handler_module = 'N/A'
         dsrc_model.data_handler_class = 'N/A'
 
@@ -146,7 +92,7 @@ class TestExternalDatasetAgent_Slocum(ExternalDatasetAgentTestBase, IonIntegrati
         #        dams_cli.assign_external_data_agent_to_agent_instance(external_data_agent_id=self.eda_id, agent_instance_id=self.eda_inst_id)
 
         # Generate the data product and associate it to the ExternalDataset
-        dprod = DataProduct(name='slocum_parsed_product', description='parsed slocum product')
+        dprod = DataProduct(name='ruv_parsed_product', description='parsed ruv product')
         dproduct_id = dpms_cli.create_data_product(data_product=dprod)
 
         dams_cli.assign_data_product(input_resource_id=ds_id, data_product_id=dproduct_id, create_stream=True)
@@ -160,65 +106,12 @@ class TestExternalDatasetAgent_Slocum(ExternalDatasetAgentTestBase, IonIntegrati
 
         ttool = TaxyTool()
 
-        ttool.add_taxonomy_set('c_wpt_y_lmc'),
-        ttool.add_taxonomy_set('sci_water_cond'),
-        ttool.add_taxonomy_set('m_y_lmc'),
-        ttool.add_taxonomy_set('u_hd_fin_ap_inflection_holdoff'),
-        ttool.add_taxonomy_set('sci_m_present_time'),
-        ttool.add_taxonomy_set('m_leakdetect_voltage_forward'),
-        ttool.add_taxonomy_set('sci_bb3slo_b660_scaled'),
-        ttool.add_taxonomy_set('c_science_send_all'),
-        ttool.add_taxonomy_set('m_gps_status'),
-        ttool.add_taxonomy_set('m_water_vx'),
-        ttool.add_taxonomy_set('m_water_vy'),
-        ttool.add_taxonomy_set('c_heading'),
-        ttool.add_taxonomy_set('sci_fl3slo_chlor_units'),
-        ttool.add_taxonomy_set('u_hd_fin_ap_gain'),
-        ttool.add_taxonomy_set('m_vacuum'),
-        ttool.add_taxonomy_set('u_min_water_depth'),
-        ttool.add_taxonomy_set('m_gps_lat'),
-        ttool.add_taxonomy_set('m_veh_temp'),
-        ttool.add_taxonomy_set('f_fin_offset'),
-        ttool.add_taxonomy_set('u_hd_fin_ap_hardover_holdoff'),
-        ttool.add_taxonomy_set('c_alt_time'),
-        ttool.add_taxonomy_set('m_present_time'),
-        ttool.add_taxonomy_set('m_heading'),
-        ttool.add_taxonomy_set('sci_bb3slo_b532_scaled'),
-        ttool.add_taxonomy_set('sci_fl3slo_cdom_units'),
-        ttool.add_taxonomy_set('m_fin'),
-        ttool.add_taxonomy_set('x_cycle_overrun_in_ms'),
-        ttool.add_taxonomy_set('sci_water_pressure'),
-        ttool.add_taxonomy_set('u_hd_fin_ap_igain'),
-        ttool.add_taxonomy_set('sci_fl3slo_phyco_units'),
-        ttool.add_taxonomy_set('m_battpos'),
-        ttool.add_taxonomy_set('sci_bb3slo_b470_scaled'),
-        ttool.add_taxonomy_set('m_lat'),
-        ttool.add_taxonomy_set('m_gps_lon'),
-        ttool.add_taxonomy_set('sci_ctd41cp_timestamp'),
-        ttool.add_taxonomy_set('m_pressure'),
-        ttool.add_taxonomy_set('c_wpt_x_lmc'),
-        ttool.add_taxonomy_set('c_ballast_pumped'),
-        ttool.add_taxonomy_set('x_lmc_xy_source'),
-        ttool.add_taxonomy_set('m_lon'),
-        ttool.add_taxonomy_set('m_avg_speed'),
-        ttool.add_taxonomy_set('sci_water_temp'),
-        ttool.add_taxonomy_set('u_pitch_ap_gain'),
-        ttool.add_taxonomy_set('m_roll'),
-        ttool.add_taxonomy_set('m_tot_num_inflections'),
-        ttool.add_taxonomy_set('m_x_lmc'),
-        ttool.add_taxonomy_set('u_pitch_ap_deadband'),
-        ttool.add_taxonomy_set('m_final_water_vy'),
-        ttool.add_taxonomy_set('m_final_water_vx'),
-        ttool.add_taxonomy_set('m_water_depth'),
-        ttool.add_taxonomy_set('m_leakdetect_voltage'),
-        ttool.add_taxonomy_set('u_pitch_max_delta_battpos'),
-        ttool.add_taxonomy_set('m_coulomb_amphr'),
-        ttool.add_taxonomy_set('m_pitch'),
+        ttool.add_taxonomy_set('data','test data')
 
         #CBM: Eventually, probably want to group this crap somehow - not sure how yet...
 
         # Create the logger for receiving publications
-        self.create_stream_and_logger(name='slocum',stream_id=stream_id)
+        self.create_stream_and_logger(name='ruv',stream_id=stream_id)
 
         self.EDA_RESOURCE_ID = ds_id
         self.EDA_NAME = ds_name

--- a/ion/agents/data/test/test_external_dataset_agent_ruv.py
+++ b/ion/agents/data/test/test_external_dataset_agent_ruv.py
@@ -19,7 +19,7 @@ from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance
 from ion.agents.data.test.test_external_dataset_agent import ExternalDatasetAgentTestBase, IonIntegrationTestCase
 from nose.plugins.attrib import attr
 
-@attr('INT_EOI', group='eoi')
+@attr('INT_DATA_AGENT', group='eoi')
 class TestExternalDatasetAgent_Ruv(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod' : 'ion.agents.data.handlers.ruv_data_handler',

--- a/ion/agents/data/test/test_external_dataset_agent_slocum.py
+++ b/ion/agents/data/test/test_external_dataset_agent_slocum.py
@@ -19,7 +19,7 @@ from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance
 from ion.agents.data.test.test_external_dataset_agent import ExternalDatasetAgentTestBase, IonIntegrationTestCase
 from nose.plugins.attrib import attr
 
-@attr('INT_EOI', group='eoi')
+@attr('INT_DATA_AGENT', group='eoi')
 class TestExternalDatasetAgent_Slocum(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod' : 'ion.agents.data.handlers.slocum_data_handler',

--- a/ion/agents/eoi/handler/test/test_dap_external_data_handler.py
+++ b/ion/agents/eoi/handler/test/test_dap_external_data_handler.py
@@ -16,7 +16,7 @@ import numpy
 from numpy import array
 
 
-@attr('UNIT', group='eoi')
+@attr('UNIT_EOI_DEPRECATED', group='eoi')
 class TestDapExternalDataHandler(PyonTestCase):
 
     #_dsh_list = {}

--- a/ion/agents/eoi/handler/test/test_hfr_radial_data_handler.py
+++ b/ion/agents/eoi/handler/test/test_hfr_radial_data_handler.py
@@ -11,7 +11,7 @@ import numpy
 import tempfile
 
 
-@attr('UNIT', group='eoi')
+@attr('UNIT_EOI_DEPRECATED', group='eoi')
 class TestHfrRadialDataHandler(PyonTestCase):
 
     def setUp(self):

--- a/ion/agents/eoi/handler/test/test_usgs_integration.py
+++ b/ion/agents/eoi/handler/test/test_usgs_integration.py
@@ -21,7 +21,7 @@ import os
 import time
 import unittest
 
-@attr('INT',group='eoi')
+@attr('INT_EOI_DEPRECATED',group='eoi')
 class USGSIntegrationTest(IonIntegrationTestCase):
     def setUp(self):
         self._start_container()

--- a/ion/agents/eoi/test/test_external_observatory_agent.py
+++ b/ion/agents/eoi/test/test_external_observatory_agent.py
@@ -27,7 +27,7 @@ class FakeProcess(LocalContextMixin):
     name = ''
     id='someid'
 
-@attr('INT', group='eoi')
+@attr('INT_EOI_DEPRECATED', group='eoi')
 class TestIntExternalObservatoryAgent(IonIntegrationTestCase):
 
     def setUp(self):

--- a/ion/services/eoi/test/test_external_observatory_agent_service.py
+++ b/ion/services/eoi/test/test_external_observatory_agent_service.py
@@ -27,7 +27,7 @@ from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance
 __author__ = 'Christopher Mueller'
 __licence__ = 'Apache 2.0'
 
-@attr('UNIT',group='eoi')
+@attr('UNIT_EOI_DEPRECATED',group='eoi')
 class TestExternalObservatoryAgentService(PyonTestCase):
     
     def setUp(self):
@@ -98,7 +98,7 @@ class FakeProcess(LocalContextMixin):
     name = ''
     id='someid'
 
-@attr('INT', group='eoi')
+@attr('INT_EOI_DEPRECATED', group='eoi')
 class TestIntExternalObservatoryAgentService(IonIntegrationTestCase):
 
     def setUp(self):

--- a/ion/services/sa/acquisition/data_acquisition_management_service.py
+++ b/ion/services/sa/acquisition/data_acquisition_management_service.py
@@ -172,7 +172,7 @@ class DataAcquisitionManagementService(BaseDataAcquisitionManagementService):
 
         @param input_resource_id    str
         @param data_product_id    str
-        @retval data_producer_id    str
+        @retval if create_stream==True, the stream_id, otherwise None
         """
         # Verify that both ids are valid
         input_resource_obj = self.clients.resource_registry.read(input_resource_id)
@@ -216,13 +216,14 @@ class DataAcquisitionManagementService(BaseDataAcquisitionManagementService):
 
         #Create the stream if requested
         log.debug("assign_data_product: create_stream %s" % create_stream)
+        stream_id = None
         if create_stream:
             stream_id = self.clients.pubsub_management.create_stream(name=data_product_obj.name,  description=data_product_obj.description)
             log.debug("assign_data_product: create stream stream_id %s" % stream_id)
             # Associate the Stream with the main Data Product
             self.clients.resource_registry.create_association(data_product_id,  PRED.hasStream, stream_id)
 
-        return
+        return stream_id
 
     def unassign_data_product(self, input_resource_id='', data_product_id='', delete_stream=False):
         """


### PR DESCRIPTION
Added UNIT tests for the base DataHandler and all concrete DataHandlers
Changed the @attr decorator on the ExternalDatasetAgent INT tests to "INT_DATA_AGENT"
Removed 'execute_acquire_sample' (and all associated tests) from ExternalDatasetAgent - not relevant for this type of agent
Minor change to DAMS - return stream_id from assign_data_product if 'create_stream' == True

@daf
