### PR TITLE
Changed 'INT_DATA_AGENT' to 'INT_LONG'

### DIFF
--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -804,7 +804,7 @@ class ExternalDatasetAgentTestBase(object):
         state = retval.result
         self.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
 
-@attr('INT_DATA_AGENT', group='eoi')
+@attr('INT', group='eoi')
 class TestExternalDatasetAgent(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     # DataHandler config
     DVR_CONFIG = {
@@ -836,7 +836,7 @@ class TestExternalDatasetAgent(ExternalDatasetAgentTestBase, IonIntegrationTestC
             'max_records':4,
             }
 
-@attr('INT_DATA_AGENT', group='eoi')
+@attr('INT_LONG', group='eoi')
 class TestExternalDatasetAgent_Fibonacci(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod' : 'ion.agents.data.handlers.base_data_handler',

--- a/ion/agents/data/test/test_external_dataset_agent_netcdf.py
+++ b/ion/agents/data/test/test_external_dataset_agent_netcdf.py
@@ -20,7 +20,7 @@ from ion.agents.data.test.test_external_dataset_agent import ExternalDatasetAgen
 
 from nose.plugins.attrib import attr
 
-@attr('INT_DATA_AGENT', group='eoi')
+@attr('INT_LONG', group='eoi')
 class TestExternalDatasetAgent_Netcdf(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod' : 'ion.agents.data.handlers.netcdf_data_handler',

--- a/ion/agents/data/test/test_external_dataset_agent_ruv.py
+++ b/ion/agents/data/test/test_external_dataset_agent_ruv.py
@@ -19,7 +19,7 @@ from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance
 from ion.agents.data.test.test_external_dataset_agent import ExternalDatasetAgentTestBase, IonIntegrationTestCase
 from nose.plugins.attrib import attr
 
-@attr('INT_DATA_AGENT', group='eoi')
+@attr('INT_LONG', group='eoi')
 class TestExternalDatasetAgent_Ruv(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod' : 'ion.agents.data.handlers.ruv_data_handler',

--- a/ion/agents/data/test/test_external_dataset_agent_slocum.py
+++ b/ion/agents/data/test/test_external_dataset_agent_slocum.py
@@ -19,7 +19,7 @@ from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance
 from ion.agents.data.test.test_external_dataset_agent import ExternalDatasetAgentTestBase, IonIntegrationTestCase
 from nose.plugins.attrib import attr
 
-@attr('INT_DATA_AGENT', group='eoi')
+@attr('INT_LONG', group='eoi')
 class TestExternalDatasetAgent_Slocum(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod' : 'ion.agents.data.handlers.slocum_data_handler',


### PR DESCRIPTION
@MauriceManning

Per our conversation - changed all 'INT_DATA_AGENT' decorators to 'INT_LONG' except for the test for the DummyDataHandler which was changed to 'INT'
