### PR TITLE
Geo searching

### DIFF
--- a/ion/services/dm/presentation/discovery_service.py
+++ b/ion/services/dm/presentation/discovery_service.py
@@ -492,7 +492,7 @@ class DiscoveryService(BaseDiscoveryService):
         return resources
 
     def query_geo_distance(self, source_id='', field='', origin=None, distance='', units='mi',order=None, limit=0, offset=0, id_only=False):
-        validate_true(isinstance(origin,list) or isinstance(origin,tuple), 'Origin is not a list or tuple.')
+        validate_true(isinstance(origin,(tuple,list)) , 'Origin is not a list or tuple.')
         validate_true(len(origin)==2, 'Origin is not of the right size: (2)')
 
         if not self.use_es:
@@ -542,9 +542,9 @@ class DiscoveryService(BaseDiscoveryService):
 
 
     def query_geo_bbox(self, source_id='', field='', top_left=None, bottom_right=None, order=None, limit=0, offset=0, id_only=False):
-        validate_true(isinstance(top_left, list) or isinstance(top_left,tuple), 'Top Left is not a list or a tuple')
+        validate_true(isinstance(top_left, (list,tuple)), 'Top Left is not a list or a tuple')
         validate_true(len(top_left)==2, 'Top Left is not of the right size: (2)')
-        validate_true(isinstance(bottom_right, list) or isinstance(bottom_right,tuple), 'Bottom Right is not a list or a tuple')
+        validate_true(isinstance(bottom_right, (list,tuple)), 'Bottom Right is not a list or a tuple')
         validate_true(len(bottom_right)==2, 'Bottom Right is not of the right size: (2)')
 
         if not self.use_es:

--- a/ion/services/dm/presentation/test/query_test.py
+++ b/ion/services/dm/presentation/test/query_test.py
@@ -132,6 +132,11 @@ class QueryLanguageUnitTest(PyonTestCase):
         retval = self.parser.parse(test_string)
         self.assertTrue(retval == {'and':[], 'or':[], 'query':{'lat':20.0, 'lon':30.0, 'units':'km', 'field':'location', 'index':'index', 'dist':20.0}}, '%s' % retval)
 
+    def test_geo_bbox(self):
+        test_string = "search 'location' geo box top-left lat 40 lon 0 bottom-right lat 0 lon 40 from 'index'"
+        retval = self.parser.parse(test_string)
+        self.assertTrue(retval == {'and':[], 'or':[], 'query':{'field':'location', 'top_left':[0.0, 40.0], 'bottom_right': [40.0, 0.0], 'index':'index'}})
+
 
     def test_extensive(self):
 


### PR DESCRIPTION
Adds the ability to make geospatial bounding box searches

Either:

```
discovery.query_geo_bbox(index_id, field, top_left=[x,y], bottom_right=[x2,y2])
```

or using the DSL

```
search_string = "search 'nominal_location' geo box top-left lat 40 lon 0 bottom-right lat 0 lon 40 from 'devices_index'"
discovery.parse(search_string)
```
