### PR TITLE
Luke: localizes the process definitions

### DIFF
--- a/ion/services/dm/ingestion/ingestion_management_service.py
+++ b/ion/services/dm/ingestion/ingestion_management_service.py
@@ -9,7 +9,7 @@ __license__ = 'Apache 2.0'
 '''
 from interface.services.dm.iingestion_management_service import BaseIngestionManagementService
 from pyon.core import bootstrap
-from pyon.core.exception import NotFound
+from pyon.core.exception import NotFound, BadRequest
 from pyon.public import RT, PRED, log, IonObject
 from pyon.public import CFG
 from pyon.core.exception import IonException
@@ -80,10 +80,10 @@ class IngestionManagementService(BaseIngestionManagementService):
         """
 
         if self.process_definition_id is None:
-            process_definition = ProcessDefinition(name='ingestion_worker_process', description='Worker transform process for ingestion of datasets')
-            process_definition.executable['module']='ion.processes.data.ingestion.ingestion_worker'
-            process_definition.executable['class'] = 'IngestionWorker'
-            self.process_definition_id = self.clients.process_dispatcher.create_process_definition(process_definition=process_definition)
+            res, _ = self.clients.resource_registry.find_resources(restype=RT.ProcessDefinition,name='ingestion_worker_process', id_only=True)
+            if not len(res):
+                raise BadRequest('No ingestion work process definition found')
+            self.process_definition_id = res[0]
  
 
         # Give each ingestion configuration its own queue name to receive data on

--- a/ion/services/dm/inventory/data_retriever_service.py
+++ b/ion/services/dm/inventory/data_retriever_service.py
@@ -53,10 +53,10 @@ class DataRetrieverService(BaseDataRetrieverService):
             raise BadRequest('(Data Retriever Service %s): No dataset provided.' % self.name)
 
         if self.process_definition_id is None:
-            self.process_definition = ProcessDefinition(name='data_replay_process', description='Process for the replay of datasets')
-            self.process_definition.executable['module']='ion.processes.data.replay_process'
-            self.process_definition.executable['class'] = 'ReplayProcess'
-            self.process_definition_id = self.clients.process_dispatcher.create_process_definition(process_definition=self.process_definition)
+            res, _  = self.clients.resource_registry.find_resources(restype=RT.ProcessDefinition,name='data_replay_process',id_only=True)
+            if not len(res):
+                raise BadRequest('No replay process defined.')
+            self.process_definition_id = res[0]
 
         dataset = self.clients.dataset_management.read_dataset(dataset_id=dataset_id)
         datastore_name = dataset.datastore_name


### PR DESCRIPTION
If the process definitions were not created as part of the bootstrap, do not attempt to create them, simply raise a BadRequest prompting attention to the issue.

This localizes the places where the process definitions are defined and persisted.
