### PR TITLE
Luke: Primitive DM end-to-end

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -14,27 +14,34 @@ from pyon.datastore.datastore import DataStore
 from pyon.util.arg_check import validate_is_instance
 from pyon.util.containers import get_ion_ts
 from pyon.util.file_sys import FileSystem, FS
+from pyon.public import log
 from interface.objects import Granule
 from gevent import spawn
 import hashlib
 import msgpack
+import re
 
 
 
 class ScienceGranuleIngestionWorker(SimpleProcess):
-    def on_start(self):
+    def on_start(self): #pragma no cover
         self.queue_name = self.CFG.get_safe('processes.queue_name','ingestion_queue')
         self.datastore_name = self.CFG.get_safe('processes.datastore_name', 'datasets')
 
-        self.subscriber = Subscriber(name=(get_sys_name(), self.queue_name), callback=self.ingest)
+        self.subscriber = Subscriber(name=(get_sys_name(), self.queue_name), callback=self.consume)
         self.db = self.container.datastore_manager.get_datastore(self.datastore_name, DataStore.DS_PROFILE.SCIDATA)
         self.greenlet = spawn(self.subscriber.listen)
 
-    def on_quit(self):
+    def on_quit(self): #pragma no cover
         self.subscriber.close()
         self.greenlet.join(timeout=10)
 
-    def ingest(self, msg, headers):
+    def consume(self, msg, headers):
+        stream_id = headers['routing_key']
+        stream_id = re.sub(r'\.data', '', stream_id)
+        self.ingest(msg,stream_id)
+
+    def ingest(self, msg, stream_id):
         if msg == {}:
             return
         validate_is_instance(msg,Granule,'Incoming message is not compatible with this ingestion worker')
@@ -46,7 +53,7 @@ class ScienceGranuleIngestionWorker(SimpleProcess):
         calculated_sha1 = hashlib.sha1(byte_string).hexdigest().upper()
 
         dataset_granule = {
-           'stream_id'      : msg.data_producer_id,
+           'stream_id'      : stream_id,
            'dataset_id'     : msg.data_producer_id,
            'persisted_sha1' : encoding_type,
            'ts_create'      : get_ion_ts()
@@ -55,13 +62,20 @@ class ScienceGranuleIngestionWorker(SimpleProcess):
 
         filename = FileSystem.get_hierarchical_url(FS.CACHE, calculated_sha1, ".%s" % encoding_type)
 
-        with open(filename, mode='wb') as f:
-            f.write(byte_string)
-            f.close()
+        self.write(filename,byte_string)
+
 
 
     def persist(self, dataset_granule):
         self.db.create_doc(dataset_granule)
+
+    def write(self,filename, data): #pragma no cover
+        try:
+            with open(filename, mode='wb') as f:
+                f.write(data)
+                f.close()
+        except Exception as e:
+            log.error('Problem writing to disk: %s' , e.message)
 
 
 

--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -25,8 +25,8 @@ import re
 
 class ScienceGranuleIngestionWorker(SimpleProcess):
     def on_start(self): #pragma no cover
-        self.queue_name = self.CFG.get_safe('processes.queue_name','ingestion_queue')
-        self.datastore_name = self.CFG.get_safe('processes.datastore_name', 'datasets')
+        self.queue_name = self.CFG.get_safe('process.queue_name','ingestion_queue')
+        self.datastore_name = self.CFG.get_safe('process.datastore_name', 'datasets')
 
         self.subscriber = Subscriber(name=(get_sys_name(), self.queue_name), callback=self.consume)
         self.db = self.container.datastore_manager.get_datastore(self.datastore_name, DataStore.DS_PROFILE.SCIDATA)
@@ -54,8 +54,9 @@ class ScienceGranuleIngestionWorker(SimpleProcess):
 
         dataset_granule = {
            'stream_id'      : stream_id,
-           'dataset_id'     : msg.data_producer_id,
-           'persisted_sha1' : encoding_type,
+           'dataset_id'     : stream_id,
+           'persisted_sha1' : calculated_sha1,
+           'encoding_type'  : encoding_type,
            'ts_create'      : get_ion_ts()
         }
         self.persist(dataset_granule)

--- a/ion/processes/data/ingestion/test/__init__.py
+++ b/ion/processes/data/ingestion/test/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+'''
+@author Luke Campbell <LCampbell@ASAScience.com>
+@file __init__.py
+@date 06/27/12 10:16
+@description DESCRIPTION
+'''

--- a/ion/processes/data/ingestion/test/test_science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/test/test_science_granule_ingestion_worker.py
@@ -55,7 +55,7 @@ class ScienceGranuleIngestionWorkerUnitTest(PyonTestCase):
 
         def check_persist(dataset_granule):
             self.assertTrue(dataset_granule['stream_id'] == 'stream_id')
-            self.assertTrue(dataset_granule['dataset_id'] == 'test_identifier')
+            self.assertTrue(dataset_granule['dataset_id'] == 'stream_id')
         self.worker.persist.side_effect = check_persist
 
         self.worker.ingest(granule,'stream_id')

--- a/ion/processes/data/ingestion/test/test_science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/test/test_science_granule_ingestion_worker.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+'''
+@author Luke Campbell <LCampbell@ASAScience.com>
+@file test_science_granule_ingestion_worker
+@date 06/27/12 10:16
+@description DESCRIPTION
+'''
+from pyon.util.unit_test import PyonTestCase
+from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from pyon.ion.granule.taxonomy import TaxyTool
+from pyon.ion.granule.granule import build_granule
+from ion.processes.data.ingestion.science_granule_ingestion_worker import ScienceGranuleIngestionWorker
+
+from mock import Mock
+from nose.plugins.attrib import attr
+import numpy as np
+
+
+@attr('UNIT',group='dm')
+class ScienceGranuleIngestionWorkerUnitTest(PyonTestCase):
+    def setUp(self):
+        self.worker = ScienceGranuleIngestionWorker()
+
+    @staticmethod
+    def build_granule():
+        tt = TaxyTool()
+        tt.add_taxonomy_set('c')
+        tt.add_taxonomy_set('t')
+        tt.add_taxonomy_set('d')
+
+        rdt = RecordDictionaryTool(taxonomy=tt)
+        rdt['c'] = np.array([0,1])
+        rdt['t'] = np.array([0,1])
+        rdt['d'] = np.array([0,1])
+
+        granule = build_granule(data_producer_id='test_identifier', taxonomy=tt, record_dictionary=rdt)
+        return granule
+
+    def test_consume(self):
+        self.worker.ingest = Mock()
+
+        message = {}
+        headers = {'routing_key' : 'stream_id.data'}
+
+        self.worker.consume(message,headers)
+        self.worker.ingest.assert_called_once_with({},'stream_id')
+    
+    def test_ingest(self):
+        retval = self.worker.ingest({}, '')
+        self.assertTrue(retval is None)
+        granule = self.build_granule()
+
+        self.worker.write   = Mock()
+        self.worker.persist = Mock()
+
+        def check_persist(dataset_granule):
+            self.assertTrue(dataset_granule['stream_id'] == 'stream_id')
+            self.assertTrue(dataset_granule['dataset_id'] == 'test_identifier')
+        self.worker.persist.side_effect = check_persist
+
+        self.worker.ingest(granule,'stream_id')
+
+
+
+        
+
+

--- a/ion/processes/data/replay/replay_process_a.py
+++ b/ion/processes/data/replay/replay_process_a.py
@@ -51,8 +51,8 @@ class ReplayProcess(BaseReplayProcess):
         view_name = 'manifest/by_dataset'
 
         opts = dict(
-            start_key = [self.dataset_id, 0],
-            end_key   = [self.dataset_id, {}],
+            start_key = [self.dataset.primary_view_key, 0],
+            end_key   = [self.dataset.primary_view_key, {}],
             include_docs = True
         )
         if self.start_time is not None:
@@ -64,7 +64,6 @@ class ReplayProcess(BaseReplayProcess):
         #--------------------------------------------------------------------------------
         # Gather all the dataset granules and compile the FS cache
         #--------------------------------------------------------------------------------
-
         for result in datastore.query_view(view_name,opts=opts):
             doc = result.get('doc')
             if doc is not None:
@@ -76,7 +75,7 @@ class ReplayProcess(BaseReplayProcess):
                 self.output.publish(obj)
 
         # Need to terminate the stream, null granule = {}
-        self.output.publish({}) 
+        self.output.publish({})
         return True
 
 
@@ -87,7 +86,7 @@ class ReplayProcess(BaseReplayProcess):
             with open(path, 'r') as f:
                 byte_string = f.read()
         except IOError as e:
-            raise BadRequest(e.message)
+            raise BadRequest('(%s)\n\t\tIOProblem: %s' % (e.message,path))
         return byte_string
 
 

--- a/ion/processes/data/replay/test/replay_process_test.py
+++ b/ion/processes/data/replay/test/replay_process_test.py
@@ -20,6 +20,7 @@ class ReplayProcessUnitTest(PyonTestCase):
         self.replay.dataset_id = 'dataset'
         self.replay.dataset = DotDict()
         self.replay.dataset.datastore_name='datasets'
+        self.replay.dataset.primary_view_key = 'stream_id'
         self.replay.deliver_format = {}
         self.replay.start_time = None
         self.replay.end_time = None

--- a/ion/services/dm/ingestion/test/test_science_granule_ingestion.py
+++ b/ion/services/dm/ingestion/test/test_science_granule_ingestion.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+'''
+@author Luke Campbell <LCampbell@ASAScience.com>
+@file ion/services/dm/ingestion/test/test_science_granule_ingestion.py
+@date 06/27/2012
+@description Testing for ScienceGranuleIngestionWorker
+'''
+
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.util.containers import DotDict
+from pyon.core.bootstrap import get_sys_name
+from pyon.core.exception import Timeout
+from pyon.net.endpoint import Publisher
+from ion.processes.data.ingestion.test.test_science_granule_ingestion_worker import ScienceGranuleIngestionWorkerUnitTest
+from interface.services.dm.iingestion_management_service_a import IngestionManagementServiceAClient
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
+from interface.objects import IngestionQueue
+from nose.plugins.attrib import attr
+
+import time
+import unittest
+import os
+
+@attr('INT',group='dm')
+class ScienceGranuleIngestionIntTest(IonIntegrationTestCase):
+    def setUp(self):
+        self.datastore_name = 'datasets'
+        self.exchange_point = 'science_data'
+        self.exchange_space = 'science_ingestion'
+        self.queue_name     = '%s.%s' % (self.exchange_point,self.exchange_space)
+        self._start_container()
+        self.container.start_rel_from_url('res/deploy/r2dm.yml')
+        
+        self.launch_service()
+
+        self.ingestion_management = IngestionManagementServiceAClient()
+        self.pubsub               = PubsubManagementServiceClient()
+
+
+    def build_granule(self):
+        return ScienceGranuleIngestionWorkerUnitTest.build_granule()
+
+
+    def launch_service(self):
+        self.container.spawn_process(name='ingestion_management_a', module='ion.services.dm.ingestion.ingestion_management_service_a',cls='IngestionManagementServiceA',process_id='ingestion_management_a')
+
+
+    def launch_worker(self):
+        cfg = DotDict()
+
+        cfg.processes.datastore_name = self.datastore_name
+        cfg.processes.queue_name = self.queue_name
+
+        #@todo: replace with CEI friendly calls
+
+        pid = self.container.spawn_process('ingest_worker', 'ion.processes.data.ingestion.science_granule_ingestion_worker','ScienceGranuleIngestionWorker',cfg)
+        return pid
+
+    def create_ingestion_config(self):
+        ingest_queue = IngestionQueue(name=self.exchange_space, type='science_granule')
+        config_id = self.ingestion_management.create_ingestion_configuration(name='standard_ingest', exchange_point_id=self.exchange_point, queues=[ingest_queue])
+        return config_id
+            
+    def create_stream(self):
+        stream_id = self.pubsub.create_stream()
+        return stream_id
+
+    def poll(self, evaluation_callback,  *args, **kwargs):
+        now = time.time()
+        cutoff = now + 5
+        done = False
+        while not done:
+            if evaluation_callback(*args,**kwargs):
+                done = True
+            if now >= cutoff:
+                raise Timeout('No results found within the allotted time')
+            now = time.time()
+        return True
+
+
+    @attr('LOCOINT')
+    @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Skip test while in CEI LAUNCH mode')
+    def test_basic_ingestion(self):
+        self.launch_worker()
+        publisher = Publisher()
+
+        # Create an ingestion configuration
+        config_id = self.create_ingestion_config()
+        
+        # Create the data stream to be ingested
+        stream_id = self.create_stream()
+
+        # Enable persistence of the stream
+        self.ingestion_management.persist_data_stream(stream_id=stream_id,ingestion_configuration_id=config_id)
+
+        # Make a granule to be persisted
+        granule = self.build_granule()
+
+        # Publish the granule
+        publisher.publish(granule,to_name=('%s.science_data' % get_sys_name(),'%s.data' % stream_id))
+
+        # Check the persistence
+        datastore = self.container.datastore_manager.get_datastore(self.datastore_name)
+
+        self.assertTrue(self.poll(datastore.query_view, 'manifest/by_dataset'))
+        
+
+
+
+
+
+
+
+
+
+
+
+

--- a/ion/services/dm/ingestion/test/test_science_granule_ingestion.py
+++ b/ion/services/dm/ingestion/test/test_science_granule_ingestion.py
@@ -48,8 +48,8 @@ class ScienceGranuleIngestionIntTest(IonIntegrationTestCase):
     def launch_worker(self):
         cfg = DotDict()
 
-        cfg.processes.datastore_name = self.datastore_name
-        cfg.processes.queue_name = self.queue_name
+        cfg.process.datastore_name = self.datastore_name
+        cfg.process.queue_name = self.queue_name
 
         #@todo: replace with CEI friendly calls
 

--- a/ion/services/dm/test/collaboration_test.py
+++ b/ion/services/dm/test/collaboration_test.py
@@ -13,10 +13,11 @@ from nose.plugins.attrib import attr
 from gevent.event import AsyncResult
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 from interface.services.dm.iingestion_management_service import IngestionManagementServiceClient
+from interface.services.dm.iingestion_management_service_a import IngestionManagementServiceAClient
 from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
 from interface.services.dm.idata_retriever_service import DataRetrieverServiceClient
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
-from interface.objects import ProcessDefinition, CouchStorage
+from interface.objects import ProcessDefinition, IngestionQueue, Granule
 import unittest
 import os
 
@@ -26,19 +27,25 @@ class DMCollaborationIntTest(IonIntegrationTestCase):
     def setUp(self):
         self._start_container()
         config = DotDict()
-        config.bootstrap.processes.ingestion.module = 'ion.processes.data.ingestion.ingestion_worker_a'
         config.bootstrap.processes.replay.module    = 'ion.processes.data.replay.replay_process_a'
         self.container.start_rel_from_url('res/deploy/r2dm.yml', config)
 
 
-        self.datastore_name = 'test_datasets'
+        self.datastore_name       = 'datasets'
         self.pubsub_management    = PubsubManagementServiceClient()
         self.ingestion_management = IngestionManagementServiceClient()
         self.dataset_management   = DatasetManagementServiceClient()
         self.process_dispatcher   = ProcessDispatcherServiceClient()
         self.data_retriever       = DataRetrieverServiceClient()
+        self.exchange_space       = 'science_ingestion'
+        self.exchange_point       = 'science_data'
+        self.process_definitions  = {}
 
     def subscriber_action(self, msg, header):
+        if msg == {}:
+            return # End of replay
+        self.assertTrue(isinstance(msg,Granule))
+
         if not hasattr(self,'received'):
             self.received = 0
         if not hasattr(self, 'async_done'):
@@ -46,7 +53,52 @@ class DMCollaborationIntTest(IonIntegrationTestCase):
         self.received += 1
         if self.received >= 2:
             self.async_done.set(True)
+
+    def create_process_definitions(self):
+        producer_definition = ProcessDefinition(name='Example Data Producer')
+        producer_definition.executable = {
+            'module':'ion.processes.data.example_data_producer',
+            'class' :'ExampleDataProducer'
+        }
+
+        process_definition_id = self.process_dispatcher.create_process_definition(process_definition=producer_definition)
+        self.process_definitions['data_producer'] = process_definition_id
+
+        ingestion_worker_definition = ProcessDefinition(name='ingestion worker')
+        ingestion_worker_definition.executable = {
+            'module':'ion.processes.data.ingestion.science_granule_ingestion_worker',
+            'class' :'ScienceGranuleIngestionWorker'
+        }
+        process_definition_id = self.process_dispatcher.create_process_definition(process_definition=ingestion_worker_definition)
+        self.process_definitions['ingestion_worker'] = process_definition_id
+
+
+    def launch_processes(self, stream_id):
+        # First launch the ingestors
+        config = DotDict()
+        config.process.datastore_name = 'datasets'
+        config.process.queue_name = '%s.%s' %(self.exchange_point, self.exchange_space)
+
+        self.process_dispatcher.schedule_process(self.process_definitions['ingestion_worker'],configuration=config)
+
+        # Next launch the producer(s)
+        config = DotDict()
+        config.process.stream_id = stream_id
+
+        self.process_dispatcher.schedule_process(self.process_definitions['data_producer'],configuration=config)
+
+
+    def launch_ingestion_service(self):
+        self.container.spawn_process(name='ingestion_management_a', module='ion.services.dm.ingestion.ingestion_management_service_a', cls='IngestionManagementServiceA', process_id='ingestion_management_a')
+
+        self.ingestion_management = IngestionManagementServiceAClient()
+
             
+    def create_ingestion_config(self):
+        ingest_queue = IngestionQueue(name=self.exchange_space, type='science_granule')
+        config_id = self.ingestion_management.create_ingestion_configuration(name='standard_ingest', exchange_point_id=self.exchange_point, queues=[ingest_queue])
+        return config_id
+
 
     #--------------------------------------------------------------------------------
     # I have to skip CEI mode in the interim because of the couch config madness, it's going away shortly.
@@ -59,52 +111,48 @@ class DMCollaborationIntTest(IonIntegrationTestCase):
         self.async_done = AsyncResult()
         sysname = get_sys_name()
 
+        #--------------------------------------------------------------------------------
+        # Bootstrapping
+        #--------------------------------------------------------------------------------
+        # Set up the process definitions the services and process launchers will use
+        self.create_process_definitions()
+        # Launch the new ingestion service (not part of r2dm or r2deploy)
+        self.launch_ingestion_service()
 
-        datastore = self.container.datastore_manager.get_datastore(self.datastore_name,'SCIDATA')
-
-
-        producer_definition = ProcessDefinition(name='Example Data Producer')
-        producer_definition.executable = {
-            'module':'ion.processes.data.example_data_producer',
-            'class' :'ExampleDataProducer'
-        }
-
-        process_definition_id = self.process_dispatcher.create_process_definition(process_definition=producer_definition)
+        # Make a transport stream
+        stream_id = self.pubsub_management.create_stream()
         
-        ingestion_configuration_id = self.ingestion_management.create_ingestion_configuration(
-            exchange_point_id = 'science_data',
-            couch_storage=CouchStorage(datastore_name=self.datastore_name,datastore_profile='SCIDATA'),
-            number_of_workers=1
-        )
+        # Launch the processes
+        self.launch_processes(stream_id)
 
-        self.ingestion_management.activate_ingestion_configuration(
-                ingestion_configuration_id=ingestion_configuration_id)
+        # Grab a handle on the datastore
+        datastore = self.container.datastore_manager.get_datastore(self.datastore_name)
 
-        stream_id = self.pubsub_management.create_stream(name='data stream')
+
+        #--------------------------------------------------------------------------------
+        # Create the ingestion config for this exchange
+        #--------------------------------------------------------------------------------
         
+        ingestion_configuration_id = self.create_ingestion_config()
+
+        #--------------------------------------------------------------------------------
+        # Persist the data stream
+        #--------------------------------------------------------------------------------
+
+        self.ingestion_management.persist_data_stream(stream_id=stream_id, ingestion_configuration_id=ingestion_configuration_id)
+
+        #@todo: Normally ingestion will handle the dataset creation but in the interim the 
         dataset_id = self.dataset_management.create_dataset(
             stream_id = stream_id, 
             datastore_name = self.datastore_name,
         )
+        #--------------------------------------------------------------------------------
+        # Define the replay
+        #--------------------------------------------------------------------------------
+        
+        replay_id, replay_stream_id = self.data_retriever.define_replay(dataset_id = dataset_id)
 
-        self.ingestion_management.create_dataset_configuration(
-            dataset_id = dataset_id,
-            archive_data = True,
-            archive_metadata = True,
-            ingestion_configuration_id = ingestion_configuration_id
-        )
-
-        configuration = {
-            'process': {
-                'stream_id' : stream_id
-            }
-        }
-
-        self.process_dispatcher.schedule_process(process_definition_id, configuration=configuration)
-
-        replay_id, stream_id = self.data_retriever.define_replay(dataset_id = dataset_id)
-
-        subscriber = Subscriber(name=('%s.science_data' % sysname, 'test_queue'), callback=self.subscriber_action, binding='%s.data' % stream_id)
+        subscriber = Subscriber(name=('%s.science_data' % sysname, 'test_queue'), callback=self.subscriber_action, binding='%s.data' % replay_stream_id)
         gevent.spawn(subscriber.listen)
 
         done = False
@@ -115,5 +163,9 @@ class DMCollaborationIntTest(IonIntegrationTestCase):
 
         self.data_retriever.start_replay(replay_id)
 
-        self.async_done.get(timeout=10)
+        try:
+            self.async_done.get(timeout=10)
+        except gevent.Timeout:
+            self.assertTrue(False, 'Results not gathered')
+
 


### PR DESCRIPTION
Adds the new IngestionManagement and replay/ingest processes.

The integration test which incorporates the changes is in `ion/services/dm/test/collaboration_test.py`. 

When we're refactored and ready to fully adopt the new ingestion management we will just rename `IngestionManagementServiceA` to `IngestionManagementService` and everything should be a go.
