### PR TITLE
Luke: Refactor in retrieve (ready for merge)

### DIFF
--- a/ion/services/dm/ingestion/test/ingestion_management_test.py
+++ b/ion/services/dm/ingestion/test/ingestion_management_test.py
@@ -143,6 +143,24 @@ class IngestionManagementIntTest(IonIntegrationTestCase):
         self.ingest_name = 'basic'
         self.exchange    = 'testdata'
 
+    @staticmethod
+    def clean_subscriptions():
+        ingestion_management = IngestionManagementServiceClient()
+        pubsub = PubsubManagementServiceClient()
+        rr     = ResourceRegistryServiceClient()
+        ingestion_config_ids = ingestion_management.list_ingestion_configurations(id_only=True)
+        for ic in ingestion_config_ids:
+
+            assocs = rr.find_associations(subject=ic, predicate=PRED.hasSubscription, id_only=False)
+            for assoc in assocs:
+                rr.delete_association(assoc)
+                try:
+                    pubsub.deactivate_subscription(assoc.o)
+                except:
+                    pass
+                pubsub.delete_subscription(assoc.o)
+
+
     def create_ingest_config(self):
         self.queue = IngestionQueue(name='test', type='testdata')
 

--- a/ion/services/dm/inventory/data_retriever_service.py
+++ b/ion/services/dm/inventory/data_retriever_service.py
@@ -126,7 +126,7 @@ class DataRetrieverService(BaseDataRetrieverService):
 
         self.clients.resource_registry.delete(replay_id)
 
-    def start_retrieve(self, dataset_id='', query=None, delivery_format=None):
+    def retrieve(self, dataset_id='', query=None, delivery_format=None):
 
         if query is None:
             query = {}

--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -16,12 +16,11 @@ from interface.services.coi.iresource_registry_service import ResourceRegistrySe
 from pyon.datastore.datastore import DataStore
 from interface.objects import ProcessDefinition, Granule
 from pyon.util.containers import DotDict
+from ion.services.dm.ingestion.test.ingestion_management_test import IngestionManagementIntTest
 from pyon.util.int_test import IonIntegrationTestCase
 from nose.plugins.attrib import attr
 
 import time
-import unittest
-import os
 
 @attr('INT',group='dm')
 class TestDMEnd2End(IonIntegrationTestCase):
@@ -36,6 +35,14 @@ class TestDMEnd2End(IonIntegrationTestCase):
         self.dataset_management   = DatasetManagementServiceClient()
         self.ingestion_management = IngestionManagementServiceClient()
         self.data_retriever       = DataRetrieverServiceClient()
+        self.pids                 = []
+        
+
+    def tearDown(self):
+        for pid in self.pids:
+            self.process_dispatcher.cancel_process(pid)
+        IngestionManagementIntTest.clean_subscriptions()
+        
 
     def launch_producer(self, stream_id=''):
         #--------------------------------------------------------------------------------
@@ -55,7 +62,8 @@ class TestDMEnd2End(IonIntegrationTestCase):
 
         config = DotDict()
         config.process.stream_id =  stream_id
-        self.process_dispatcher.schedule_process(process_definition_id=process_definition_id, configuration=config)
+        pid = self.process_dispatcher.schedule_process(process_definition_id=process_definition_id, configuration=config)
+        self.pids.append(pid)
 
     def get_ingestion_config(self):
         #--------------------------------------------------------------------------------


### PR DESCRIPTION
Retrieve was refactored from `start_retrieve`.  I patched and added better support for domain variable slicing via `time`.  We don't have a specific set of taxonomies or stream definitions yet so it is hard-coded as `time` which is till really intuitive.  The default if `time` is not a field in the record dictionary is to use the time when the granule arrived.
