### PR TITLE
Luke: Adds error handling to ingestion workers

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -81,14 +81,15 @@ class ScienceGranuleIngestionWorker(SimpleProcess):
     def persist(self, dataset_granule):
         try:
             self.db.create_doc(dataset_granule)
+            return
         except ResourceNotFound as e:
             log.error('The datastore was removed while ingesting.')
             self.db = self.container.datastore_manager.get_datastore(self.datastore_name, DataStore.DS_PROFILE.SCIDATA)
-            log.error('Trying to ingest once more')
-            try:
-                self.db.create_doc(dataset_granule)
-            except ResourceNotFound as e:
-                log.error(e.message) # Oh well I tried
+        log.error('Trying to ingest once more')
+        try:
+            self.db.create_doc(dataset_granule)
+        except ResourceNotFound as e:
+            log.error(e.message) # Oh well I tried
 
 
 

--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -15,10 +15,10 @@ from pyon.datastore.datastore import DataStore
 from pyon.util.arg_check import validate_is_instance
 from pyon.util.containers import get_ion_ts, get_safe
 from pyon.util.file_sys import FileSystem, FS
-from pyon.public import log, PRED
-from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
+from pyon.public import log 
 from interface.objects import Granule
 from gevent import spawn
+from couchdb import ResourceNotFound
 import hashlib
 import msgpack
 import re
@@ -79,7 +79,18 @@ class ScienceGranuleIngestionWorker(SimpleProcess):
 
 
     def persist(self, dataset_granule):
-        self.db.create_doc(dataset_granule)
+        try:
+            self.db.create_doc(dataset_granule)
+        except ResourceNotFound as e:
+            log.error('The datastore was removed while ingesting.')
+            self.db = self.container.datastore_manager.get_datastore(self.datastore_name, DataStore.DS_PROFILE.SCIDATA)
+            log.error('Trying to ingest once more')
+            try:
+                self.db.create_doc(dataset_granule)
+            except ResourceNotFound as e:
+                log.error(e.message) # Oh well I tried
+
+
 
     def write(self,filename, data): #pragma no cover
         try:


### PR DESCRIPTION
Science Ingestion Workers are supposed to be resilient processes.  They do not maintain state per se but they have a datastore instance object which they use to persist metadata about the incoming granules. When the datastore is removed or altered while the worker is still alive couchdb will raise an issue with the datastore not existing so this exception handling provides a mechanism to be resilient to this case.

In the case of CEI integration testing, the datastore is wiped between tests which was causing issues for the workers which are persistent across all tests.  This should address that issue.
