### PR TITLE
New Granule And Record Dictionary Commits

### DIFF
--- a/ion/agents/data/handlers/base_data_handler.py
+++ b/ion/agents/data/handlers/base_data_handler.py
@@ -14,7 +14,7 @@ from pyon.ion.resource import PRED, RT
 from pyon.core.exception import NotFound
 from pyon.util.containers import get_safe
 from pyon.event.event import EventPublisher
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 from interface.objects import Granule, Attachment, AttachmentType
 
@@ -24,8 +24,8 @@ from ion.agents.instrument.exceptions import InstrumentParameterException, Instr
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.granule import build_granule
 
 from ion.agents.data.handlers.handler_utils import calculate_iteration_count, list_file_info, get_time_from_filename
 

--- a/ion/agents/data/handlers/netcdf_data_handler.py
+++ b/ion/agents/data/handlers/netcdf_data_handler.py
@@ -10,9 +10,9 @@
 
 from pyon.public import log
 from pyon.util.containers import get_safe
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from ion.agents.data.handlers.base_data_handler import BaseDataHandler, DataHandlerParameter
 from ion.agents.data.handlers.handler_utils import calculate_iteration_count
 import hashlib

--- a/ion/agents/data/handlers/ruv_data_handler.py
+++ b/ion/agents/data/handlers/ruv_data_handler.py
@@ -8,9 +8,9 @@
 """
 from pyon.public import log
 from pyon.util.containers import get_safe
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from ion.agents.data.handlers.base_data_handler import BaseDataHandler, NoNewDataWarning
 from ion.agents.data.handlers.handler_utils import list_file_info, get_sbuffer, get_time_from_filename
 import numpy as np

--- a/ion/agents/data/handlers/slocum_data_handler.py
+++ b/ion/agents/data/handlers/slocum_data_handler.py
@@ -9,9 +9,9 @@
 
 from pyon.public import log
 from pyon.util.containers import get_safe
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from ion.agents.data.handlers.base_data_handler import BaseDataHandler
 from ion.agents.data.handlers.handler_utils import list_file_info, get_sbuffer, calculate_iteration_count, get_time_from_filename
 import numpy as np, os, re

--- a/ion/agents/data/handlers/test/test_base_data_handler.py
+++ b/ion/agents/data/handlers/test/test_base_data_handler.py
@@ -15,7 +15,7 @@ from pyon.util.unit_test import PyonTestCase
 from pyon.core.exception import NotFound
 import unittest
 
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from ion.agents.instrument.exceptions import InstrumentParameterException, InstrumentDataException, InstrumentCommandException, NotImplementedException, InstrumentException
 from interface.objects import Granule, Attachment
 

--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -59,7 +59,7 @@ from ion.agents.instrument.exceptions import InstrumentParameterException
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 
 #########################

--- a/ion/agents/data/test/test_external_dataset_agent_netcdf.py
+++ b/ion/agents/data/test/test_external_dataset_agent_netcdf.py
@@ -10,7 +10,7 @@
 # Import pyon first for monkey patching.
 from pyon.public import log
 from pyon.ion.resource import PRED, RT
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient

--- a/ion/agents/data/test/test_external_dataset_agent_ruv.py
+++ b/ion/agents/data/test/test_external_dataset_agent_ruv.py
@@ -10,7 +10,7 @@
 # Import pyon first for monkey patching.
 from pyon.public import log
 from pyon.ion.resource import PRED, RT
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient

--- a/ion/agents/data/test/test_external_dataset_agent_slocum.py
+++ b/ion/agents/data/test/test_external_dataset_agent_slocum.py
@@ -10,7 +10,7 @@
 # Import pyon first for monkey patching.
 from pyon.public import log
 from pyon.ion.resource import PRED, RT
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient

--- a/ion/agents/instrument/packet_factory.py
+++ b/ion/agents/instrument/packet_factory.py
@@ -18,9 +18,9 @@ from ion.agents.instrument.common import BaseEnum
 from ion.agents.instrument.exceptions import PacketFactoryException
 from ion.agents.instrument.exceptions import NotImplementedException
 
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool, Taxonomy
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool, Taxonomy
+from ion.services.dm.utility.granule.granule import build_granule
 
 
 class PacketFactoryType(BaseEnum):

--- a/ion/agents/instrument/taxy_factory.py
+++ b/ion/agents/instrument/taxy_factory.py
@@ -15,7 +15,7 @@ __license__ = 'Apache 2.0'
 
 
 from pyon.util.log import log
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 
 # _cache: A cache of taxonomies indexed by the stream name.

--- a/ion/agents/instrument/test/test_packet_factory.py
+++ b/ion/agents/instrument/test/test_packet_factory.py
@@ -15,9 +15,9 @@ from pyon.public import log
 
 from nose.plugins.attrib import attr
 
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 
 from ion.agents.instrument.packet_factory import PacketFactory, PacketFactoryType, LCAPacketFactory
 

--- a/ion/processes/data/ctd_stream_publisher.py
+++ b/ion/processes/data/ctd_stream_publisher.py
@@ -36,9 +36,9 @@ from prototype.sci_data.constructor_apis import PointSupplementConstructor
 
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 
 
 ### Taxonomies are defined before hand out of band... somehow.

--- a/ion/processes/data/example_data_producer.py
+++ b/ion/processes/data/example_data_producer.py
@@ -20,9 +20,9 @@ from interface.objects import Granule
 from ion.processes.data.ctd_stream_publisher import SimpleCtdPublisher
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 from pyon.public import log
 
 import numpy

--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -9,7 +9,7 @@ from pyon.core.bootstrap import get_sys_name
 from pyon.core.interceptor.encode import encode_ion
 from pyon.core.object import ion_serializer
 from pyon.ion.process import SimpleProcess
-from pyon.ion.granule import RecordDictionaryTool
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from pyon.net.endpoint import Subscriber
 from pyon.datastore.datastore import DataStore
 from pyon.util.arg_check import validate_is_instance

--- a/ion/processes/data/ingestion/test/test_science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/test/test_science_granule_ingestion_worker.py
@@ -6,9 +6,9 @@
 @description DESCRIPTION
 '''
 from pyon.util.unit_test import PyonTestCase
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule as bg
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule as bg
 from ion.processes.data.ingestion.science_granule_ingestion_worker import ScienceGranuleIngestionWorker
 
 from mock import Mock

--- a/ion/processes/data/replay/replay_process.py
+++ b/ion/processes/data/replay/replay_process.py
@@ -12,7 +12,7 @@ from interface.services.dm.idataset_management_service import DatasetManagementS
 from pyon.core.exception import BadRequest, IonException, NotFound
 from pyon.util.file_sys import FileSystem,FS
 from pyon.core.interceptor.encode import decode_ion
-from pyon.ion.granule import combine_granules
+from ion.services.dm.utility.granule.granule import combine_granules
 from pyon.core.object import IonObjectDeserializer
 from pyon.core.bootstrap import get_obj_registry
 from gevent.event import Event

--- a/ion/processes/data/sinusoidal_stream_publisher.py
+++ b/ion/processes/data/sinusoidal_stream_publisher.py
@@ -36,9 +36,9 @@ from prototype.sci_data.constructor_apis import PointSupplementConstructor
 
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 from ion.processes.data.ctd_stream_publisher import SimpleCtdPublisher
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 import numpy
 
 

--- a/ion/processes/data/stream_granule_logger.py
+++ b/ion/processes/data/stream_granule_logger.py
@@ -26,7 +26,7 @@ from pyon.ion.process import StandaloneProcess
 from pyon.public import log, StreamSubscriberRegistrar, PRED
 from pyon.util.containers import get_datetime
 from interface.objects import StreamQuery
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
 

--- a/ion/processes/data/transforms/ctd/ctd_L0_all.py
+++ b/ion/processes/data/transforms/ctd/ctd_L0_all.py
@@ -17,9 +17,9 @@ from prototype.sci_data.stream_parser import PointSupplementStreamParser
 #from prototype.sci_data.stream_defs import ctd_stream_definition
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 
 #from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 #pmsc = PubsubManagementServiceClient(node=cc.node)

--- a/ion/processes/data/transforms/ctd/ctd_L1_conductivity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_conductivity.py
@@ -16,9 +16,9 @@ from prototype.sci_data.stream_parser import PointSupplementStreamParser
 #from prototype.sci_data.constructor_apis import PointSupplementConstructor
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 from pyon.util.containers import get_safe
 
 class CTDL1ConductivityTransform(TransformFunction):

--- a/ion/processes/data/transforms/ctd/ctd_L1_pressure.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_pressure.py
@@ -16,9 +16,9 @@ from prototype.sci_data.stream_parser import PointSupplementStreamParser
 from prototype.sci_data.constructor_apis import PointSupplementConstructor
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 from pyon.util.containers import get_safe
 
 

--- a/ion/processes/data/transforms/ctd/ctd_L1_temperature.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_temperature.py
@@ -21,9 +21,9 @@ from seawater.gibbs import SP_from_cndr
 from seawater.gibbs import cte
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 from pyon.util.containers import get_safe
 
 class CTDL1TemperatureTransform(TransformFunction):

--- a/ion/processes/data/transforms/ctd/ctd_L2_density.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_density.py
@@ -20,9 +20,9 @@ from seawater.gibbs import SP_from_cndr, rho, SA_from_SP
 from seawater.gibbs import cte
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 from pyon.util.containers import get_safe
 
 

--- a/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
@@ -18,9 +18,9 @@ from seawater.gibbs import SP_from_cndr, rho, SA_from_SP
 from seawater.gibbs import cte
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 from pyon.util.containers import get_safe
 
 

--- a/ion/processes/data/transforms/example_double_salinity.py
+++ b/ion/processes/data/transforms/example_double_salinity.py
@@ -11,9 +11,9 @@ from prototype.sci_data.stream_parser import PointSupplementStreamParser
 from prototype.sci_data.constructor_apis import PointSupplementConstructor
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 from pyon.util.containers import get_safe
 
 class SalinityDoubler(TransformFunction):

--- a/ion/processes/data/transforms/viz/google_dt.py
+++ b/ion/processes/data/transforms/viz/google_dt.py
@@ -13,18 +13,14 @@ from pyon.public import IonObject, RT, log
 
 from datetime import datetime
 import numpy
-from pyon.ion.granule.granule import build_granule
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.granule import build_granule
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from prototype.sci_data.stream_defs import SBE37_CDM_stream_definition, SBE37_RAW_stream_definition
 
 from prototype.sci_data.stream_parser import PointSupplementStreamParser
 from prototype.sci_data.constructor_apis import PointSupplementConstructor, RawSupplementConstructor
 
-### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
 from pyon.util.containers import get_safe
 
 # Google viz library for google charts

--- a/ion/processes/data/transforms/viz/matplotlib_graphs.py
+++ b/ion/processes/data/transforms/viz/matplotlib_graphs.py
@@ -6,9 +6,9 @@ from pyon.public import IonObject, RT, log
 
 import time
 import numpy
-from pyon.ion.granule.granule import build_granule
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.granule import build_granule
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from pyon.util.containers import get_safe
 from prototype.sci_data.stream_defs import SBE37_CDM_stream_definition, SBE37_RAW_stream_definition
 

--- a/ion/services/ans/test/test_helper.py
+++ b/ion/services/ans/test/test_helper.py
@@ -19,8 +19,8 @@ import imghdr
 import gevent, numpy
 
 from interface.objects import Granule
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from pyon.util.containers import get_safe
 
 

--- a/ion/services/ans/test/test_visualization_service.py
+++ b/ion/services/ans/test/test_visualization_service.py
@@ -28,7 +28,7 @@ import unittest, os
 import imghdr
 import gevent, numpy
 from mock import Mock, sentinel, patch, call
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from pyon.util.containers import get_safe
 
 from pyon.util.context import LocalContextMixin

--- a/ion/services/ans/visualization_service.py
+++ b/ion/services/ans/visualization_service.py
@@ -28,8 +28,8 @@ from gevent.greenlet import Greenlet
 
 from interface.services.ans.ivisualization_service import BaseVisualizationService
 from ion.processes.data.transforms.viz.google_dt import VizTransformGoogleDT
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from pyon.net.endpoint import Subscriber
 from interface.objects import Granule
 from pyon.util.containers import get_safe

--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -21,7 +21,9 @@ from pyon.util.containers import DotDict
 from ion.services.dm.ingestion.test.ingestion_management_test import IngestionManagementIntTest
 from pyon.util.int_test import IonIntegrationTestCase
 from pyon.net.endpoint import Publisher
-from pyon.ion.granule import RecordDictionaryTool, TaxyTool, build_granule
+from ion.services.dm.utility.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from gevent.event import Event
 from nose.plugins.attrib import attr
 

--- a/ion/services/dm/utility/granule/__init__.py
+++ b/ion/services/dm/utility/granule/__init__.py
@@ -1,5 +1,1 @@
 __author__ = 'timgiguere'
-
-from pyon.ion.granule.granule import build_granule, combine_granules
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool

--- a/ion/services/dm/utility/granule/__init__.py
+++ b/ion/services/dm/utility/granule/__init__.py
@@ -1,0 +1,5 @@
+__author__ = 'timgiguere'
+
+from pyon.ion.granule.granule import build_granule, combine_granules
+from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from pyon.ion.granule.taxonomy import TaxyTool

--- a/ion/services/dm/utility/granule/granule.py
+++ b/ion/services/dm/utility/granule/granule.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+'''
+@package pyon.ion.granule.granule
+@file pyon/ion/granule/granule
+@author David Stuebe
+@author Tim Giguere
+@brief https://confluence.oceanobservatories.org/display/CIDev/R2+Construction+Data+Model
+'''
+
+
+from interface.objects import Granule
+from pyon.core.exception import BadRequest
+from pyon.util.arg_check import validate_is_instance
+from pyon.ion.granule.record_dictionary import RecordDictionaryTool
+from pyon.ion.granule.taxonomy import TaxyTool
+
+import numpy as np
+
+
+def build_granule(data_producer_id, taxonomy, record_dictionary):
+    """
+    This method is a simple wrapper that knows how to produce a granule IonObject from a RecordDictionaryTool and a TaxonomyTool
+
+    A granule is a unit of information which conveys part of a coverage.
+
+    A granule contains a record dictionary. The record dictionary is composed of named value sequences.
+    We want the Granule Builder to have a dictionary like behavior for building record dictionaries, using the taxonomy
+    as a map from the name to the ordinal in the record dictionary.
+    """
+
+    #@todo If the taxonomy has an id_ and rev_ send only that.
+    return Granule(data_producer_id=data_producer_id, record_dictionary=record_dictionary._rd, taxonomy=taxonomy._t)
+
+def combine_granules(granule_a, granule_b):
+    """
+    This is a method that combines granules in a very naive manner
+    """
+    validate_is_instance(granule_a,Granule, 'granule_a is not a proper Granule')
+    validate_is_instance(granule_b,Granule, 'granule_b is not a proper Granule')
+
+    tt_a = TaxyTool.load_from_granule(granule_a)
+    tt_b = TaxyTool.load_from_granule(granule_b)
+
+    if tt_a != tt_b:
+        raise BadRequest('Can\'t combine the two granules, they do not have the same taxonomy.')
+
+    rdt_new = RecordDictionaryTool(tt_a)
+    rdt_a = RecordDictionaryTool.load_from_granule(granule_a)
+    rdt_b = RecordDictionaryTool.load_from_granule(granule_b)
+
+
+    for k in rdt_a.iterkeys():
+        rdt_new[k] = np.append(rdt_a[k], rdt_b[k])
+    return build_granule(granule_a.data_producer_id, tt_a, rdt_new)
+
+
+

--- a/ion/services/dm/utility/granule/granule.py
+++ b/ion/services/dm/utility/granule/granule.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 '''
-@package pyon.ion.granule.granule
-@file pyon/ion/granule/granule
+@package ion.services.dm.utility.granule.granule
+@file ion/services/dm/utility/granule/granule.py
 @author David Stuebe
 @author Tim Giguere
 @brief https://confluence.oceanobservatories.org/display/CIDev/R2+Construction+Data+Model
@@ -12,8 +12,8 @@
 from interface.objects import Granule
 from pyon.core.exception import BadRequest
 from pyon.util.arg_check import validate_is_instance
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 import numpy as np
 

--- a/ion/services/dm/utility/granule/record_dictionary.py
+++ b/ion/services/dm/utility/granule/record_dictionary.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
 '''
-@package pyon.ion.granule.record_dictionary
-@file pyon/ion/granule/record_dictionary
+@package ion.services.dm.utility.granule.record_dictionary
+@file ion/services/dm/utility/granule/record_dictionary.py
 @author David Stuebe
 @author Tim Giguere
 @brief https://confluence.oceanobservatories.org/display/CIDev/R2+Construction+Data+Model
 '''
 
 import StringIO
-from pyon.ion.granule.taxonomy import TaxyTool, Taxonomy
+from ion.services.dm.utility.granule.taxonomy import TaxyTool, Taxonomy
 from pyon.util.log import log
 import numpy
 

--- a/ion/services/dm/utility/granule/record_dictionary.py
+++ b/ion/services/dm/utility/granule/record_dictionary.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python
+
+'''
+@package pyon.ion.granule.record_dictionary
+@file pyon/ion/granule/record_dictionary
+@author David Stuebe
+@author Tim Giguere
+@brief https://confluence.oceanobservatories.org/display/CIDev/R2+Construction+Data+Model
+'''
+
+import StringIO
+from pyon.ion.granule.taxonomy import TaxyTool, Taxonomy
+from pyon.util.log import log
+import numpy
+
+_NoneType = type(None)
+class RecordDictionaryTool(object):
+    """
+    A granule is a unit of information which conveys part of a coverage. It is composed of a taxonomy and a nested
+    structure of record dictionaries.
+
+    The record dictionary is composed of named value sequences and other nested record dictionaries.
+
+    The fact that all of the keys in the record dictionary are handles mapped by the taxonomy should never be exposed.
+    The application user refers to everything in the record dictionary by the unique nick name from the taxonomy.
+
+    """
+    def __init__(self,taxonomy, shape=None):
+        """
+        @brief Initialize a new instance of Record Dictionary Tool with a taxonomy and an optional fixed length
+        @param taxonomy is an instance of a TaxonomyTool or Taxonomy (IonObject) used in this record dictionary
+        @param length is an optional fixed length for the value sequences of this record dictionary
+        """
+        if not isinstance(shape, (_NoneType, int, tuple)):
+            raise TypeError('Invalid shape argument, received type "%s"; should be None or int or tuple' % type(shape))
+
+
+        self._rd = {}
+        self._shp = shape
+
+        if isinstance(self._shp, int):
+            self._shp = (self._shp,)
+
+        # hold onto the taxonomy - we need it to build the granule...
+
+        if isinstance(taxonomy, TaxyTool):
+            self._tx = taxonomy
+        elif isinstance(taxonomy, Taxonomy):
+            self._tx = TaxyTool(taxonomy)
+        else:
+            raise TypeError('Invalid taxonomy argument, received type "%s"; should be Taxonomy or TaxyTool' % type(taxonomy))
+
+    @classmethod
+    def load_from_granule(cls, g):
+        """
+        @brief return an instance of Record Dictionary Tool from a granule. Used when a granule is received in a message
+        """
+        result = cls(TaxyTool(g.taxonomy))
+        result._rd = g.record_dictionary
+        if result._rd.has_key(0):
+            result._shp = result._rd[0].shape
+        return result
+
+    def __setitem__(self, name, vals):
+        """
+        Set an item by nick name in the record dictionary
+        """
+
+        if isinstance(vals, RecordDictionaryTool):
+            assert vals._tx == self._tx
+            self._rd[self._tx.get_handle(name)] = vals._rd
+        elif isinstance(vals, numpy.ndarray):
+            #Otherwise it is a value sequence which should have the correct length
+
+            # Matthew says: Assert only equal shape 5/17/12
+
+            if vals.ndim == 0:
+                raise ValueError('The rank of a value sequence array in a record dictionary must be greater than zero. Got name "%s" with rank "%d"' % (name, vals.ndim))
+
+            # Set _shp if it is None
+            if self._shp is None:
+                self._shp = vals.shape
+
+            # Test new value sequence length
+            if self._shp != vals.shape:
+                raise ValueError('Invalid array shape "%s" for name "%s"; Record dictionary defined shape is "%s"' % (vals.shape, name, self._shp))
+
+            self._rd[self._tx.get_handle(name)] = vals
+
+        else:
+
+            raise TypeError('Invalid type "%s" in Record Dictionary Tool setitem with name "%s". Valid types are numpy.ndarray and RecordDictionaryTool' % (type(vals),name))
+
+    def __getitem__(self, name):
+        """
+        Get an item by nick name from the record dictionary.
+        """
+        if isinstance(self._rd[self._tx.get_handle(name)], dict):
+            result = RecordDictionaryTool(taxonomy=self._tx)
+            result._rd = self._rd[self._tx.get_handle(name)]
+            return result
+        else:
+            return self._rd[self._tx.get_handle(name)]
+
+
+    def iteritems(self):
+        """ D.iteritems() -> an iterator over the (key, value) items of D """
+        for k, v in self._rd.iteritems():
+            if isinstance(v, dict):
+                result = RecordDictionaryTool(taxonomy=self._tx)
+                result._rd = v
+                yield self._tx.get_nick_name(k), result
+            else:
+                yield self._tx.get_nick_name(k), v
+
+    def iterkeys(self):
+        """ D.iterkeys() -> an iterator over the keys of D """
+        for k in self._rd.iterkeys():
+            yield self._tx.get_nick_name(k)
+
+    def itervalues(self):
+        """ D.itervalues() -> an iterator over the values of D """
+        for v in self._rd.itervalues():
+            if isinstance(v, dict):
+                result = RecordDictionaryTool(taxonomy=self._tx)
+                result._rd = v
+                yield result
+            else:
+                yield v
+
+    def update(self, E=None, **F):
+        """
+        @brief Dictionary update method exposed for Record Dictionaries
+        @param E is another record dictionary
+        @param F is a dictionary of nicknames and value sequences
+        """
+        if E:
+            if hasattr(E, "keys"):
+                for k in E:
+                    self[k] = E[k]
+            else:
+                for k, v in E.iteritems():
+                    self[k] = v
+
+        if F:
+            for k in F.keys():
+                self[k] = F[k]
+
+    def __contains__(self, nick_name):
+        """ D.__contains__(k) -> True if D has a key k, else False """
+
+        try:
+            handle = self._tx.get_handle(nick_name)
+        except KeyError as ke:
+            # if the nick_name is not in the taxonomy, it is certainly not in the record dictionary
+            return False
+        return handle in self._rd
+
+    def __delitem__(self, y):
+        """ x.__delitem__(y) <==> del x[y] """
+        #not sure if this is right, might just have to remove the name, not the whole handle
+        del self._rd[self._tx.get_handle(y)]
+        #will probably need to delete the name from _tx
+
+    def __iter__(self):
+        """ x.__iter__() <==> iter(x) """
+        for k in self._rd.iterkeys():
+            yield self._tx.get_nick_name(k)
+
+    def __len__(self):
+        """ x.__len__() <==> len(x) """
+        return len(self._rd)
+
+    def __repr__(self):
+        """ x.__repr__() <==> repr(x) """
+        result = "{"
+        for k, v in self.iteritems():
+            result += "\'{0}\': {1},".format(k, v)
+
+        if len(result) > 1:
+            result = result[:-1] + "}"
+
+        return result
+
+    def __str__(self):
+        result = "{"
+        for k, v in self.iteritems():
+            result += "\'{0}\': {1},".format(k, v)
+
+        if len(result) > 1:
+            result = result[:-1] + "}"
+
+        return result
+
+    __hash__ = None
+
+    def pretty_print(self):
+        """
+        @brief Pretty Print the record dictionary for debug or log purposes.
+        """
+
+        fid = StringIO.StringIO()
+        # Use string IO inside a try block in case of exceptions or a large return value.
+        try:
+            fid.write('Start Pretty Print Record Dictionary:\n')
+            self._pprint(fid,offset='')
+            fid.write('End of Pretty Print')
+        except Exception, ex:
+            log.exception('Unexpected Exception in Pretty Print Wrapper!')
+            fid.write('Exception! %s' % ex)
+
+        finally:
+            result = fid.getvalue()
+            fid.close()
+
+
+        return result
+
+    def _pprint(self, fid, offset=None):
+        """
+        Utility method for pretty print
+        """
+        for k, v in self.iteritems():
+            if isinstance(v, RecordDictionaryTool):
+                fid.write('= %sRDT nick named "%s" contains:\n' % (offset,k))
+                new_offset = offset + '+ '
+                v._pprint(fid, offset=new_offset)
+            else:
+                fid.write('= %sRDT nick name: "%s"\n= %svalues: %s\n' % (offset,k, offset, repr(v)))

--- a/ion/services/dm/utility/granule/taxonomy.py
+++ b/ion/services/dm/utility/granule/taxonomy.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 '''
-@package pyon.ion.granule.taxonomy
-@file pyon.ion.granule.taxonomy.py
+@package ion.services.dm.utility.granule.taxonomy
+@file ion/services/dm/utility/granule/taxonomy.py
 @author David Stuebe
 @author Don Brittain
 @author Tim Giguere

--- a/ion/services/dm/utility/granule/taxonomy.py
+++ b/ion/services/dm/utility/granule/taxonomy.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python
+
+'''
+@package pyon.ion.granule.taxonomy
+@file pyon.ion.granule.taxonomy.py
+@author David Stuebe
+@author Don Brittain
+@author Tim Giguere
+@brief https://confluence.oceanobservatories.org/display/CIDev/R2+Construction+Data+Model
+'''
+
+
+import yaml
+from pyon.core.object import ion_serializer, IonObjectDeserializer
+from pyon.core.registry import IonObjectRegistry
+
+from interface.objects import Taxonomy
+from pyon.util.log import log
+
+
+# Create an IonObjectDeserializer used in the prototype loads method...
+ior = IonObjectRegistry()
+ion_deserializer = IonObjectDeserializer(obj_registry=ior)
+
+
+class TaxyTool(object):
+    """
+    @brief Wraps up a Taxonomy (IONObject) in a class which uses that information
+    Definition of the Taxonomy Ion Resource:
+    Taxonomy: !Extends_InformationResource
+      map: {}
+
+    The map is a dictionary which contains handles as keys and name sets as values.
+
+    A name set is a set of objects which can be hashed for inverse lookup and should be serializable for transport and persistence
+
+    In practice they are strings for nicknames and Taxonomy Description objects for complex definitions
+
+    """
+
+    def __init__(self, taxonomy=None):
+        """
+        @brief Initialize the state of the TaxyTool wrapper. Can take an existing taxonomy as an argument.
+        """
+        self._cnt = -1 # Cnt is not the length it a unique id in a map...
+
+        self._inv = {}
+
+        self._by_nick_names = {}
+
+        if taxonomy is None:
+            taxonomy = Taxonomy()
+        else:
+            self._cnt = max(taxonomy.map.keys())
+
+            for h, names in taxonomy.map.iteritems():
+                nick_name, name_set =  names
+
+                self._add_nickname(nick_name, h)
+                self._update_inverse(h, name_set)
+
+        self._t = taxonomy
+
+    @classmethod
+    def load_from_granule(cls, g):
+        """
+        Load a TaxyTool from a granule
+        """
+        return cls(g.taxonomy)
+
+    def _update_inverse(self, h, name_set):
+        """
+        Utility method to update the inverse index of names to handles
+        """
+        for name in name_set:
+
+            #@todo is it safe to use the builtin hash method?
+            assert name.__hash__ is not None, 'This name has no hash method!'
+
+            h_set = self._inv.get(name,set())
+            h_set.add(h)
+
+            self._inv[name] = h_set
+
+
+    def _add_nickname(self, nick_name, h):
+        if nick_name not in self._by_nick_names:
+            self._by_nick_names[nick_name] = h
+        else:
+            raise KeyError('The nick name "%s" is not unique in this taxonomy' % nick_name)
+
+    def add_taxonomy_set(self, nick_name, *args):
+        """
+        @brief Add a new set of names in the taxonomy under a new handle
+        @param nick_name is the first positional argument, it is unique name in the taxonomy
+        @param *args is a list of input arguments. All should be hashable
+        """
+        self._cnt += 1
+        h = self._cnt
+
+        self._add_nickname(nick_name, h)
+
+        self._t.map[h] = (nick_name, {nick_name,})
+
+        self._extend_taxonomy_set(h, *args)
+
+
+
+    def get_handles(self, name):
+        """
+        @brief Get the handles for a name
+        @param name is a string or object which is hashable
+        @return set of handles that have that name
+        """
+        if name in self._inv:
+            return self._inv[name]
+        else:
+            return {-1,}
+
+    def get_handle(self, nick_name):
+        """
+        @brief Get the handle for a given nick name
+        @param nick_name is a unique name in the taxonomy
+        @return handle is a integer identifier
+        """
+
+        return self._by_nick_names[nick_name]
+
+    def get_nick_names(self, name):
+        """
+        @brief Get the nick names for a given name in the taxonomy
+        @param name is a string or object which is hashable
+        @return A set of nick names which are unique in the taxonomy
+        """
+        handles = self.get_handles(name)
+
+        return [self._t.map[h][0] for h in handles]
+
+    def get_names_by_handle(self, handle):
+        """
+        @brief Get the set of names associated with a handle
+        @param handle is a integer identifier
+        @return A set of names which can be strings or hashable objects
+        """
+        return self._t.map[handle][1]
+
+    def get_names_by_nick_name(self, nick_name):
+        """
+        @brief Get the set of names associated with this nick name
+        @param nick_name is a unique name in the taxonomy
+        @return A set of nick names which are unique in the taxonomy
+        """
+        handle = self.get_handle(nick_name)
+        return self._t.map[handle][1]
+
+
+    def get_nick_name(self, handle):
+        """
+        @brief Get the set of nick name associated with a handle
+        @param handle is a integer identifier
+        @return nick name is a unique name in the taxonomy
+        """
+        return self._t.map[handle][0]
+
+    def extend_names_by_nick_name(self, nick_name, *args):
+        """
+        @brief For a given existing nick name in the taxonomy add the additional names in args
+        @param nick_name is a unique name in the taxonomy
+        @param args is a list of names which can be strings or hashable objects
+        @return None
+        """
+
+        handle = self._by_nick_names[nick_name]
+        self._extend_taxonomy_set(handle, *args)
+
+
+    def extend_names_by_anyname(self, name, *args):
+        """
+        @breif For a given existing name in the taxonomy add the additional names in args everywhere that name already appears
+        in the taxonomy
+        @param name is a string or object which is hashable
+        @param args is a list of names which can be strings or hashable objects
+        @return None
+        """
+
+        for handle in self.get_handles(name):
+            self._extend_taxonomy_set(handle, *args)
+
+
+    def _extend_taxonomy_set(self, handle, *args):
+        """
+        Utility method that does the work of extending the a set and updating the inverse
+        """
+
+        for item in args:
+            assert item.__hash__ is not None
+
+        nick_name, tmp_set = self._t.map[handle]
+        # handle the key error in the caller!
+
+        name_set = tmp_set.union(set(args))
+
+        self._t.map[handle] = (nick_name, name_set)
+
+        self._update_inverse(handle, name_set)
+
+
+    def pretty_print(self, offset=''):
+        result = 'Start Pretty Print Taxonomy:'
+        for k, v in self._t.map.iteritems():
+
+            result += '\n= TX nick name: "%s"; handle "%s"' % (v[0], k)
+            for name in v[1]:
+                result += '\n= +name: %s' % name
+
+        result += '\nEnd of Pretty Print'
+        return result
+
+    def dump(self):
+        """
+        @brief Prototype dumping a taxonomy as yaml for instance for an instrument agent to store locally.
+        """
+
+        #@todo - need to serialize sets to yaml???
+        d = ion_serializer.serialize(self._t)
+        return yaml.dump(d)
+
+
+    @classmethod
+    def load(cls,input):
+        """
+        @brief Prototype loading the locally stored yaml for instance for an instrument agent to use in a TaxyTool
+        """
+
+        d = yaml.load(input)
+        t = ion_deserializer.deserialize(d)
+
+        # We know the structure - turn the lists back into sets!
+        try:
+            for k, v in t.map.iteritems():
+                t.map[k] = (v[0], set(v[1]))
+        except IndexError:
+            log.exception("Invalid taxonomy object structure: should be Key:(nickname, {alias',})")
+
+        return cls(t)
+
+    def __eq__(self, other):
+
+        if self is other:
+            return True
+
+        if not isinstance(other, TaxyTool):
+            return False
+
+        if self._t is other._t:
+            return True
+
+        if self._t.map == other._t.map:
+            return True
+
+        return False
+
+    def __ne__(self, other):
+        return not self == other
+
+

--- a/ion/services/sa/acquisition/test/test_external_dataset_agent_mgmt.py
+++ b/ion/services/sa/acquisition/test/test_external_dataset_agent_mgmt.py
@@ -13,7 +13,7 @@ from interface.objects import HdfStorage, CouchStorage
 from pyon.public import log
 from nose.plugins.attrib import attr
 
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 from pyon.public import StreamSubscriberRegistrar
 from prototype.sci_data.stream_defs import ctd_stream_definition

--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -33,7 +33,7 @@ import signal
 from interface.objects import ProcessDefinition
 from interface.objects import AttachmentType
 
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 from ion.services.sa.instrument.instrument_agent_impl import InstrumentAgentImpl
 from ion.services.sa.instrument.instrument_agent_instance_impl import InstrumentAgentInstanceImpl

--- a/ion/services/sa/instrument/test/test_activate_instrument.py
+++ b/ion/services/sa/instrument/test/test_activate_instrument.py
@@ -36,7 +36,7 @@ from pyon.util.int_test import IonIntegrationTestCase
 
 from pyon.agent.agent import ResourceAgentClient
 
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 from pyon.core.exception import BadRequest, NotFound, Conflict
 

--- a/ion/services/sa/test/simple_ctd_data_producer.py
+++ b/ion/services/sa/test/simple_ctd_data_producer.py
@@ -2,9 +2,9 @@
 from ion.processes.data.ctd_stream_publisher import SimpleCtdPublisher
 
 ### For new granule and stream interface
-from pyon.ion.granule.record_dictionary import RecordDictionaryTool
-from pyon.ion.granule.taxonomy import TaxyTool
-from pyon.ion.granule.granule import build_granule
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.granule import build_granule
 from pyon.public import log
 
 import numpy

--- a/ion/services/sa/test/test_ctd_transforms_L0_L1_L2.py
+++ b/ion/services/sa/test/test_ctd_transforms_L0_L1_L2.py
@@ -21,7 +21,7 @@ from nose.plugins.attrib import attr
 
 from pyon.public import StreamSubscriberRegistrar
 
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 from interface.objects import HdfStorage, CouchStorage
 

--- a/ion/services/sa/test/test_ctd_transforms_no_sim.py
+++ b/ion/services/sa/test/test_ctd_transforms_no_sim.py
@@ -16,7 +16,7 @@ from prototype.sci_data.stream_defs import L1_pressure_stream_definition, L1_tem
 from prototype.sci_data.stream_defs import SBE37_CDM_stream_definition, SBE37_RAW_stream_definition
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37Parameter
 
-from pyon.ion.granule.taxonomy import TaxyTool
+from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
 from pyon.public import log
 from nose.plugins.attrib import attr


### PR DESCRIPTION
This PR moves the location of granule.py, record_dictionary.py, and taxonomy.py to coi-services, as well as updating all the references in coi to the new location. It also bumps the ion-defs pointer to incorporate an added attribute to the Granule object, ParameterDictionary. The ParameterDictionary attribute will be taking over for Taxonomy to take advantage of the coverage model. Requires new ion-defs.
