### PR TITLE
Adds skip to deprecated test.

### DIFF
--- a/ion/processes/data/transforms/ctd/test/test_ctd_transforms.py
+++ b/ion/processes/data/transforms/ctd/test/test_ctd_transforms.py
@@ -123,8 +123,7 @@ class ScienceObjectCodecIntTest(IonIntegrationTestCase):
         self.sal_L2 = SalinityTransform()
 
 
-    @attr('LOCOINT')
-    @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Skip test while in CEI LAUNCH mode')
+    @unittest.skip('This version of L0 Transforms are deprecated this test needs to be rewritten')
     def test_process(self):
         '''
         Test that packets are processed by the ctd_L0_all transform
@@ -132,6 +131,7 @@ class ScienceObjectCodecIntTest(IonIntegrationTestCase):
         length = 1
 
         packet = self.px_ctd._get_new_ctd_packet("STR_ID", length)
+        print packet
 
         log.info("Packet: %s" % packet)
 


### PR DESCRIPTION
@mauricemanning Can you look at this and advise on if we should just delete it or rewrite it to use the newer L0 transform, to me the test doesn't look like it's doing much and I think we have other tests which use the transforms.
