### PR TITLE
Converted utility modules which publish ctd data and build granules: taxonomy --> param dictionaries

### DIFF
--- a/ion/processes/data/ctd_stream_publisher.py
+++ b/ion/processes/data/ctd_stream_publisher.py
@@ -54,8 +54,8 @@ parameter_dictionary = craft.create_parameters()
 
 class SimpleCtdPublisher(TransformStreamPublisher):
     def on_start(self):
-        exchange_point = self.CFG.get_safe('process.exchange_point', 'science_data')
-        self.CFG.process.exchange_point = exchange_point
+        self.exchange_point = self.CFG.get_safe('process.exchange_point', 'science_data')
+        self.CFG.process.exchange_point = self.exchange_point
         super(SimpleCtdPublisher,self).on_start()
         self.stream_id = self.CFG.get_safe('process.stream_id',{})
         self.interval  = self.CFG.get_safe('process.interval', 1.0)

--- a/ion/processes/data/example_data_producer.py
+++ b/ion/processes/data/example_data_producer.py
@@ -20,29 +20,22 @@ from interface.objects import Granule
 from ion.processes.data.ctd_stream_publisher import SimpleCtdPublisher
 
 ### For new granule and stream interface
-from ion.services.dm.utility.granule_utils import RecordDictionaryTool, TaxyTool, build_granule, CoverageCraft
+from ion.services.dm.utility.granule_utils import RecordDictionaryTool, build_granule, CoverageCraft
 from pyon.public import log
+from coverage_model.parameter import ParameterContext, ParameterDictionary
+from coverage_model.parameter_types import QuantityType
+from coverage_model.basic_types import AxisTypeEnum
 
 import numpy
 import random
 import time
 import gevent
 
-### Taxonomies are defined before hand out of band... somehow.
-tx = TaxyTool()
-tx.add_taxonomy_set('temp','long name for temp')
-tx.add_taxonomy_set('cond','long name for cond')
-tx.add_taxonomy_set('lat','long name for latitude')
-tx.add_taxonomy_set('lon','long name for longitude')
-tx.add_taxonomy_set('pres','long name for pres')
-tx.add_taxonomy_set('time','long name for time')
-# This is an example of using groups it is not a normative statement about how to use groups
-tx.add_taxonomy_set('group1','This group contains coordinates...')
-tx.add_taxonomy_set('group0','This group contains data...')
-
-tx.add_taxonomy_set('raw_fixed','Fixed length bytes in an array of records')
-tx.add_taxonomy_set('raw_blob','Unlimited length bytes in an array')
-
+craft = CoverageCraft
+sdom, tdom = craft.create_domains()
+sdom = sdom.dump()
+tdom = tdom.dump()
+parameter_dictionary = craft.create_parameters()
 
 class BetterDataProducer(SimpleCtdPublisher):
     def _trigger_func(self, stream_id):
@@ -92,15 +85,15 @@ class ExampleDataProducer(SimpleCtdPublisher):
             lon = numpy.array([random.uniform(0.0, 360.0) for i in xrange(length)])
             tvar = numpy.array([self.last_time + i for i in xrange(1,length+1)])
             self.last_time = max(tvar)
-            rdt = RecordDictionaryTool(taxonomy=tx)
+            rdt = RecordDictionaryTool(param_dictionary=parameter_dictionary)
 
             # This is an example of using groups it is not a normative statement about how to use groups
 
 
 
             rdt['temp'] = t
-            rdt['cond'] = c
-            rdt['pres'] = p
+            rdt['conductivity'] = c
+            rdt['pressure'] = p
 
             #add a value sequence of raw bytes - not sure the type below is correct?
             with open('/dev/urandom','r') as rand:
@@ -117,7 +110,7 @@ class ExampleDataProducer(SimpleCtdPublisher):
             rdt['lon'] = lon
 
 
-            g = build_granule(data_producer_id=stream_id, taxonomy=tx, record_dictionary=rdt)
+            g = build_granule(data_producer_id=stream_id, param_dictionary=parameter_dictionary, record_dictionary=rdt)
 
             log.info('Sending %d values!' % length)
             if(isinstance(g,Granule)):

--- a/ion/processes/data/transforms/ctd/ctd_L1_conductivity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_conductivity.py
@@ -37,6 +37,7 @@ class CTDL1ConductivityTransform(TransformFunction):
     #outgoing_stream_def = L1_conductivity_stream_definition()
 
     def __init__(self):
+        super(CTDL1ConductivityTransform, self).__init__()
 
         ### Parameter dictionaries
         self.defining_parameter_dictionary()

--- a/ion/processes/data/transforms/ctd/ctd_L1_pressure.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_pressure.py
@@ -37,6 +37,7 @@ class CTDL1PressureTransform(TransformFunction):
     outgoing_stream_def = L1_pressure_stream_definition()
 
     def __init__(self):
+        super(CTDL1PressureTransform, self).__init__()
 
         ### Parameter dictionaries
         self.defining_parameter_dictionary()

--- a/ion/processes/data/transforms/ctd/ctd_L1_temperature.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_temperature.py
@@ -44,6 +44,7 @@ class CTDL1TemperatureTransform(TransformFunction):
 
 
     def __init__(self):
+        super(CTDL1TemperatureTransform, self).__init__()
 
         ### Parameter dictionaries
         self.defining_parameter_dictionary()

--- a/ion/processes/data/transforms/ctd/ctd_L2_density.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_density.py
@@ -42,6 +42,7 @@ class DensityTransform(TransformFunction):
     outgoing_stream_def = L2_density_stream_definition()
 
     def __init__(self):
+        super(DensityTransform, self).__init__()
 
 #        ### Taxonomies are defined before hand out of band... somehow.
 #        tx = TaxyTool()

--- a/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
@@ -38,7 +38,7 @@ class SalinityTransform(TransformFunction):
     incoming_stream_def = SBE37_CDM_stream_definition()
 
     def __init__(self):
-
+        super(SalinityTransform, self).__init__()
 
 #        ### Taxonomies are defined before hand out of band... somehow.
 #        tx = TaxyTool()

--- a/ion/services/dm/utility/granule_utils.py
+++ b/ion/services/dm/utility/granule_utils.py
@@ -174,6 +174,11 @@ class CoverageCraft(object):
         data_ctxt.fill_value = 0x0
         pdict.add_context(data_ctxt)
 
+        pres_ctxt = ParameterContext('pressure', param_type=QuantityType(value_encoding=np.float32))
+        pres_ctxt.uom = 'Pascal'
+        pres_ctxt.fill_value = 0x0
+        pdict.add_context(pres_ctxt)
+
         return pdict
         
     @classmethod

--- a/ion/services/sa/test/simple_ctd_data_producer.py
+++ b/ion/services/sa/test/simple_ctd_data_producer.py
@@ -33,6 +33,7 @@ class SimpleCtdDataProducer(SimpleCtdPublisher):
         super(SimpleCtdDataProducer,self).on_start()
         self.stream_id = self.CFG.get_safe('process.stream_id',{})
 
+        log.warning("Got the stream_id from config: %s" % self.stream_id)
 
     #overriding trigger function here to use new granule
     def _trigger_func(self, stream_id):
@@ -79,7 +80,8 @@ class SimpleCtdDataProducer(SimpleCtdPublisher):
 #            rdt['coordinates'] = rdt0
 #            rdt['data'] = rdt1
 
-            log.debug("SimpleCtdDataProducer: logging published Record Dictionary:\n %s", rdt.pretty_print())
+#            log.debug("SimpleCtdDataProducer: logging published Record Dictionary:\n %s", rdt.pretty_print())
+#            log.debug("SimpleCtdDataProducer: logging published Record Dictionary:\n %s", rdt)
 
             g = build_granule(data_producer_id=stream_id, param_dictionary=parameter_dictionary, record_dictionary=rdt)
 

--- a/ion/services/sa/test/simple_ctd_data_producer.py
+++ b/ion/services/sa/test/simple_ctd_data_producer.py
@@ -28,12 +28,7 @@ class SimpleCtdDataProducer(SimpleCtdPublisher):
     It is not infrastructure - it is a demonstration of the infrastructure applied to an example.
     """
     def on_start(self):
-        exchange_point = self.CFG.get_safe('process.exchange_point', 'science_data')
-        self.CFG.process.exchange_point = exchange_point
         super(SimpleCtdDataProducer,self).on_start()
-        self.stream_id = self.CFG.get_safe('process.stream_id',{})
-
-        log.warning("Got the stream_id from config: %s" % self.stream_id)
 
     #overriding trigger function here to use new granule
     def _trigger_func(self, stream_id):

--- a/ion/services/sa/test/test_ctd_transforms_no_sim.py
+++ b/ion/services/sa/test/test_ctd_transforms_no_sim.py
@@ -181,6 +181,8 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
         log.debug('test_createTransformsThenActivateInstrument: new Stream Definition id = %s' % ctd_stream_def_id)
         log.debug('Creating new CDM data product with a stream definition')
 
+#        stream_id = self.pubsubclient.create_stream(stream_definition_id=ctd_stream_def_id)
+
         craft = CoverageCraft
         sdom, tdom = craft.create_domains()
         sdom = sdom.dump()
@@ -198,21 +200,24 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
 
         log.debug('new ctd_parsed_data_product_id = %s' % ctd_parsed_data_product)
 
-        #self.damsclient.assign_data_product(input_resource_id=instDevice_id, data_product_id=ctd_parsed_data_product)
+#        self.damsclient.assign_data_product(input_resource_id=instDevice_id, data_product_id=ctd_parsed_data_product)
 
-        #self.dataproductclient.activate_data_product_persistence(data_product_id=ctd_parsed_data_product))
+        self.dataproductclient.activate_data_product_persistence(data_product_id=ctd_parsed_data_product)
 
-        # Retrieve the id of the OUTPUT stream from the out Data Product
-        #        stream_ids, _ = self.rrclient.find_objects(ctd_parsed_data_product, PRED.hasStream, None, True)
-        #        log.debug('test_createTransformsThenActivateInstrument: Data product streams1 = %s' % stream_ids)
-        #        self.parsed_stream_id = stream_ids[0]
+#        Retrieve the id of the OUTPUT stream from the out Data Product
+        stream_ids, _ = self.rrclient.find_objects(ctd_parsed_data_product, PRED.hasStream, None, True)
+        log.debug('test_createTransformsThenActivateInstrument: Data product streams1 = %s' % stream_ids)
+        self.parsed_stream_id = stream_ids[0]
+
+        log.debug("got the parsed stream id: %s" % self.parsed_stream_id)
 
         #-------------------------------------------------------------------------------------
         # The configuration for the Event Alert Transform... set up the event types to listen to
         #-------------------------------------------------------------------------------------
         configuration = {
             'process':{
-                'stream_id':ctd_stream_def_id,
+                'exchange_point': 'science_data',
+                'stream_id':self.parsed_stream_id,
                 }
         }
 

--- a/ion/services/sa/test/test_ctd_transforms_no_sim.py
+++ b/ion/services/sa/test/test_ctd_transforms_no_sim.py
@@ -218,17 +218,17 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
 
         #todo simple_ctd_data_producer needs to be fixed
 
-#        #-------------------------------------------------------------------------------------
-#        # Create the process -  ctd simulator process
-#        #-------------------------------------------------------------------------------------
-#        producer_procdef_id = TestCTDTransformsNoSim.create_process(  name='Example Data Producer',
-#            module='ion.services.sa.test.simple_ctd_data_producer',
-#            class_name='SimpleCtdDataProducer',
-#            configuration= configuration)
-#
-#        log.debug("Created an example data producer process with the following id: %s" % producer_procdef_id)
-#
-#        self.assertIsNotNone(producer_procdef_id)
+        #-------------------------------------------------------------------------------------
+        # Create the process -  ctd simulator process
+        #-------------------------------------------------------------------------------------
+        producer_procdef_id = TestCTDTransformsNoSim.create_process(  name='Example Data Producer',
+            module='ion.services.sa.test.simple_ctd_data_producer',
+            class_name='SimpleCtdDataProducer',
+            configuration= configuration)
+
+        log.debug("Created an example data producer process with the following id: %s" % producer_procdef_id)
+
+        self.assertIsNotNone(producer_procdef_id)
 
         #-------------------------------
         # Create CTD Raw as the second data product

--- a/ion/services/sa/test/test_ctd_transforms_no_sim.py
+++ b/ion/services/sa/test/test_ctd_transforms_no_sim.py
@@ -107,18 +107,14 @@ class FakeProcess(LocalContextMixin):
 
 
 @attr('INT', group='sa')
-@unittest.skip("not ready")
+#@unittest.skip("not ready")
 class TestCTDTransformsNoSim(IonIntegrationTestCase):
 
     def setUp(self):
-        # Start container
-        #print 'instantiating container'
-        self._start_container()
-        #container = Container()
-        #print 'starting container'
-        #container.start()
-        #print 'started container'
 
+        super(TestCTDTransformsNoSim, self).setUp()
+
+        self._start_container()
         self.container.start_rel_from_url('res/deploy/r2deploy.yml')
 
         # Now create client to DataProductManagementService
@@ -153,18 +149,27 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
 
         return pid
 
-    @unittest.skip('test not working')
-    def test_createTransformsThenPublishGranules(self):
+    @staticmethod
+    def create_process(name= '', module = '', class_name = '', configuration = None):
+        '''
+        A helper method to create a process
+        '''
 
-        # ctd simulator process
-        producer_definition = ProcessDefinition(name='Example Data Producer')
+        producer_definition = ProcessDefinition(name=name)
         producer_definition.executable = {
-            'module':'ion.services.sa.test.simple_ctd_data_producer',
-            'class':'SimpleCtdDataProducer'
+            'module':module,
+            'class': class_name
         }
 
-        producer_procdef_id = self.processdispatchclient.create_process_definition(process_definition=producer_definition)
+        process_dispatcher = ProcessDispatcherServiceClient()
 
+        procdef_id = process_dispatcher.create_process_definition(process_definition=producer_definition)
+        pid = process_dispatcher.schedule_process(process_definition_id= procdef_id, configuration=configuration)
+
+        return procdef_id
+
+    #    @unittest.skip('test not working')
+    def test_createTransformsThenPublishGranules(self):
 
         #-------------------------------
         # Create CTD Parsed as the first data product
@@ -173,9 +178,8 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
         ctd_stream_def = SBE37_CDM_stream_definition()
         ctd_stream_def_id = self.pubsubclient.create_stream_definition(container=ctd_stream_def)
 
-        print 'test_createTransformsThenActivateInstrument: new Stream Definition id = ', ctd_stream_def_id
-
-        print 'Creating new CDM data product with a stream definition'
+        log.debug('test_createTransformsThenActivateInstrument: new Stream Definition id = %s' % ctd_stream_def_id)
+        log.debug('Creating new CDM data product with a stream definition')
 
         craft = CoverageCraft
         sdom, tdom = craft.create_domains()
@@ -192,21 +196,45 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
 
         ctd_parsed_data_product = self.dataproductclient.create_data_product(dp_obj, ctd_stream_def_id, parameter_dictionary)
 
-        print 'new ctd_parsed_data_product_id = ', ctd_parsed_data_product
+        log.debug('new ctd_parsed_data_product_id = %s' % ctd_parsed_data_product)
 
         #self.damsclient.assign_data_product(input_resource_id=instDevice_id, data_product_id=ctd_parsed_data_product)
 
         #self.dataproductclient.activate_data_product_persistence(data_product_id=ctd_parsed_data_product))
 
         # Retrieve the id of the OUTPUT stream from the out Data Product
-        stream_ids, _ = self.rrclient.find_objects(ctd_parsed_data_product, PRED.hasStream, None, True)
-        print 'test_createTransformsThenActivateInstrument: Data product streams1 = ', stream_ids
-        self.parsed_stream_id = stream_ids[0]
+        #        stream_ids, _ = self.rrclient.find_objects(ctd_parsed_data_product, PRED.hasStream, None, True)
+        #        log.debug('test_createTransformsThenActivateInstrument: Data product streams1 = %s' % stream_ids)
+        #        self.parsed_stream_id = stream_ids[0]
+
+        #-------------------------------------------------------------------------------------
+        # The configuration for the Event Alert Transform... set up the event types to listen to
+        #-------------------------------------------------------------------------------------
+        configuration = {
+            'process':{
+                'stream_id':ctd_stream_def_id,
+                }
+        }
+
+        #todo simple_ctd_data_producer needs to be fixed
+
+#        #-------------------------------------------------------------------------------------
+#        # Create the process -  ctd simulator process
+#        #-------------------------------------------------------------------------------------
+#        producer_procdef_id = TestCTDTransformsNoSim.create_process(  name='Example Data Producer',
+#            module='ion.services.sa.test.simple_ctd_data_producer',
+#            class_name='SimpleCtdDataProducer',
+#            configuration= configuration)
+#
+#        log.debug("Created an example data producer process with the following id: %s" % producer_procdef_id)
+#
+#        self.assertIsNotNone(producer_procdef_id)
 
         #-------------------------------
         # Create CTD Raw as the second data product
         #-------------------------------
-        print 'test_createTransformsThenActivateInstrument: Creating new RAW data product with a stream definition'
+        log.debug('test_createTransformsThenActivateInstrument: Creating new RAW data product with a stream definition')
+
         raw_stream_def = SBE37_RAW_stream_definition()
         raw_stream_def_id = self.pubsubclient.create_stream_definition(container=raw_stream_def)
 
@@ -235,15 +263,23 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
         #-------------------------------
         log.debug("TestIntDataProcessMgmtServiceMultiOut: create data process definition ctd_L0_all")
         dpd_obj = IonObject(RT.DataProcessDefinition,
-                            name='ctd_L0_all',
-                            description='transform ctd package into three separate L0 streams',
-                            module='ion.processes.data.transforms.ctd.ctd_L0_all',
-                            class_name='ctd_L0_all',
-                            process_source='some_source_reference')
+            name='ctd_L0_all',
+            description='transform ctd package into three separate L0 streams',
+            module='ion.processes.data.transforms.ctd.ctd_L0_all',
+            class_name='ctd_L0_all',
+            process_source='some_source_reference')
         try:
             ctd_L0_all_dprocdef_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
         except BadRequest as ex:
             self.fail("failed to create new ctd_L0_all data process definition: %s" %ex)
+
+
+        #        ctd_L0_all_dprocdef_id = TestCTDTransformsNoSim.create_process(  name='ctd_L0_all',
+        #            module='ion.processes.data.transforms.ctd.ctd_L0_all',
+        #            class_name='ctd_L0_all',
+        #            configuration= configuration)
+        #
+        #        self.assertIsNotNone(ctd_L0_all_dprocdef_id)
 
 
         #-------------------------------
@@ -251,46 +287,67 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
         #-------------------------------
         log.debug("TestIntDataProcessMgmtServiceMultiOut: create data process definition CTDL1ConductivityTransform")
         dpd_obj = IonObject(RT.DataProcessDefinition,
-                            name='ctd_L1_conductivity',
-                            description='create the L1 conductivity data product',
-                            module='ion.processes.data.transforms.ctd.ctd_L1_conductivity',
-                            class_name='CTDL1ConductivityTransform',
-                            process_source='CTDL1ConductivityTransform source code here...')
+            name='ctd_L1_conductivity',
+            description='create the L1 conductivity data product',
+            module='ion.processes.data.transforms.ctd.ctd_L1_conductivity',
+            class_name='CTDL1ConductivityTransform',
+            process_source='CTDL1ConductivityTransform source code here...')
         try:
             ctd_L1_conductivity_dprocdef_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
         except BadRequest as ex:
             self.fail("failed to create new CTDL1ConductivityTransform data process definition: %s" %ex)
+
+        #
+        #        ctd_L1_conductivity_dprocdef_id = TestCTDTransformsNoSim.create_process(  name='ctd_L1_conductivity',
+        #            module='ion.processes.data.transforms.ctd.ctd_L1_conductivity',
+        #            class_name='CTDL1ConductivityTransform',
+        #            configuration= configuration)
+        #
+        #        self.assertIsNotNone(ctd_L1_conductivity_dprocdef_id)
 
         #-------------------------------
         # L1 Pressure: Data Process Definition
         #-------------------------------
         log.debug("TestIntDataProcessMgmtServiceMultiOut: create data process definition CTDL1PressureTransform")
         dpd_obj = IonObject(RT.DataProcessDefinition,
-                            name='ctd_L1_pressure',
-                            description='create the L1 pressure data product',
-                            module='ion.processes.data.transforms.ctd.ctd_L1_pressure',
-                            class_name='CTDL1PressureTransform',
-                            process_source='CTDL1PressureTransform source code here...')
+            name='ctd_L1_pressure',
+            description='create the L1 pressure data product',
+            module='ion.processes.data.transforms.ctd.ctd_L1_pressure',
+            class_name='CTDL1PressureTransform',
+            process_source='CTDL1PressureTransform source code here...')
         try:
             ctd_L1_pressure_dprocdef_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
         except BadRequest as ex:
             self.fail("failed to create new CTDL1PressureTransform data process definition: %s" %ex)
 
+        #        ctd_L1_conductivity_dprocdef_id = TestCTDTransformsNoSim.create_process(  name='ctd_L1_conductivity',
+        #            module='ion.processes.data.transforms.ctd.ctd_L1_conductivity',
+        #            class_name='CTDL1ConductivityTransform',
+        #            configuration= configuration)
+        #
+        #        self.assertIsNotNone(ctd_L1_conductivity_dprocdef_id)
 
         #-------------------------------
         # L1 Temperature: Data Process Definition
         #-------------------------------
         log.debug("TestIntDataProcessMgmtServiceMultiOut: create data process definition CTDL1TemperatureTransform")
         dpd_obj = IonObject(RT.DataProcessDefinition,
-                            name='ctd_L1_temperature',
-                            description='create the L1 temperature data product',
-                            module='ion.processes.data.transforms.ctd.ctd_L1_temperature',
-                            class_name='CTDL1TemperatureTransform',
-                            process_source='CTDL1TemperatureTransform source code here...')
+            name='ctd_L1_temperature',
+            description='create the L1 temperature data product',
+            module='ion.processes.data.transforms.ctd.ctd_L1_temperature',
+            class_name='CTDL1TemperatureTransform',
+            process_source='CTDL1TemperatureTransform source code here...')
         try:
             ctd_L1_temperature_dprocdef_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
         except BadRequest as ex:
             self.fail("failed to create new CTDL1TemperatureTransform data process definition: %s" %ex)
+
+        #        ctd_L1_temperature_dprocdef_id = TestCTDTransformsNoSim.create_process(  name='ctd_L1_temperature',
+        #            module='ion.processes.data.transforms.ctd.ctd_L1_temperature',
+        #            class_name='CTDL1TemperatureTransform',
+        #            configuration= configuration)
+        #
+        #        self.assertIsNotNone(ctd_L1_temperature_dprocdef_id)
 
 
         #-------------------------------
@@ -298,33 +355,44 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
         #-------------------------------
         log.debug("TestIntDataProcessMgmtServiceMultiOut: create data process definition SalinityTransform")
         dpd_obj = IonObject(RT.DataProcessDefinition,
-                            name='ctd_L2_salinity',
-                            description='create the L1 temperature data product',
-                            module='ion.processes.data.transforms.ctd.ctd_L2_salinity',
-                            class_name='SalinityTransform',
-                            process_source='SalinityTransform source code here...')
+            name='ctd_L2_salinity',
+            description='create the L1 temperature data product',
+            module='ion.processes.data.transforms.ctd.ctd_L2_salinity',
+            class_name='SalinityTransform',
+            process_source='SalinityTransform source code here...')
         try:
             ctd_L2_salinity_dprocdef_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
         except BadRequest as ex:
             self.fail("failed to create new SalinityTransform data process definition: %s" %ex)
 
+        #        ctd_L2_salinity_dprocdef_id = TestCTDTransformsNoSim.create_process(  name='ctd_L2_salinity',
+        #            module='ion.processes.data.transforms.ctd.ctd_L2_salinity',
+        #            class_name='SalinityTransform',
+        #            configuration= configuration)
+        #
+        #        self.assertIsNotNone(ctd_L2_salinity_dprocdef_id)
 
         #-------------------------------
         # L2 Density: Data Process Definition
         #-------------------------------
         log.debug("TestIntDataProcessMgmtServiceMultiOut: create data process definition DensityTransform")
         dpd_obj = IonObject(RT.DataProcessDefinition,
-                            name='ctd_L2_density',
-                            description='create the L1 temperature data product',
-                            module='ion.processes.data.transforms.ctd.ctd_L2_density',
-                            class_name='DensityTransform',
-                            process_source='DensityTransform source code here...')
+            name='ctd_L2_density',
+            description='create the L1 temperature data product',
+            module='ion.processes.data.transforms.ctd.ctd_L2_density',
+            class_name='DensityTransform',
+            process_source='DensityTransform source code here...')
         try:
             ctd_L2_density_dprocdef_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
         except BadRequest as ex:
             self.fail("failed to create new DensityTransform data process definition: %s" %ex)
 
-
+        #        ctd_L2_density_dprocdef_id = TestCTDTransformsNoSim.create_process(  name='ctd_L2_density',
+        #            module='ion.processes.data.transforms.ctd.ctd_L2_density',
+        #            class_name='DensityTransform',
+        #            configuration= configuration)
+        #
+        #        self.assertIsNotNone(ctd_L2_density_dprocdef_id)
 
         self.loggerpids = []
 
@@ -356,8 +424,8 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
             spatial_domain = sdom)
 
         ctd_l0_conductivity_output_dp_id = self.dataproductclient.create_data_product(ctd_l0_conductivity_output_dp_obj,
-                                                                                outgoing_stream_l0_conductivity_id,
-                                                                                parameter_dictionary)
+            outgoing_stream_l0_conductivity_id,
+            parameter_dictionary)
         self.output_products['conductivity'] = ctd_l0_conductivity_output_dp_id
         self.dataproductclient.activate_data_product_persistence(data_product_id=ctd_l0_conductivity_output_dp_id)
 
@@ -422,10 +490,10 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
         log.debug("test_createTransformsThenActivateInstrument: create output data product L1 pressure")
 
         ctd_l1_pressure_output_dp_obj = IonObject(RT.DataProduct,
-                                                    name='L1_Pressure',
-                                                    description='transform output L1 pressure',
-                                                    temporal_domain = tdom,
-                                                    spatial_domain = sdom)
+            name='L1_Pressure',
+            description='transform output L1 pressure',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
 
         ctd_l1_pressure_output_dp_id = self.dataproductclient.create_data_product(ctd_l1_pressure_output_dp_obj, outgoing_stream_l1_pressure_id, parameter_dictionary)
         self.dataproductclient.activate_data_product_persistence(data_product_id=ctd_l1_pressure_output_dp_id)
@@ -486,8 +554,6 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
 
         ctd_l2_density_output_dp_id = self.dataproductclient.create_data_product(ctd_l2_density_output_dp_obj, outgoing_stream_l2_density_id, parameter_dictionary)
         self.dataproductclient.activate_data_product_persistence(data_product_id=ctd_l2_density_output_dp_id)
-
-
 
         # Set up subscribers/loggers to these streams
         stream_ids, _ = self.rrclient.find_objects(ctd_l2_salinity_output_dp_id, PRED.hasStream, None, True)
@@ -580,27 +646,15 @@ class TestCTDTransformsNoSim(IonIntegrationTestCase):
 
 
 
+#        producer_pid = self.processdispatchclient.schedule_process(process_definition_id= producer_procdef_id, configuration=configuration)
 
-        #-------------------------------
-        # Streaming
-        #-------------------------------
-
-        # Start the ctd simulator to produce some data
-        configuration = {
-            'process':{
-                'stream_id':self.parsed_stream_id,
-                }
-        }
-        producer_pid = self.processdispatchclient.schedule_process(process_definition_id= producer_procdef_id, configuration=configuration)
-
-        time.sleep(2.0)
-
-
-        # clean up the launched processes
-        self.processdispatchclient.cancel_process(producer_pid)
-        for pid in self.loggerpids:
-            self.processdispatchclient.cancel_process(pid)
-
+#        time.sleep(2.0)
+#
+#
+#        # clean up the launched processes
+#        self.processdispatchclient.cancel_process(producer_pid)
+#        for pid in self.loggerpids:
+#            self.processdispatchclient.cancel_process(pid)
 
 
 


### PR DESCRIPTION
Removed taxonomy and included the passing in of parameter dictionaries for the modules, ctd_stream_publisher.py, example_data_producer.py, simple_ctd_data_producer.py and raw_stream_publisher.py. Also fixed a test, test_ctd_transforms_no_sim.py, which test several of the ctd transforms.
