### PR TITLE
Resolves nostests error in test_workflow.py caused by previously different naming of parameter contexts for conductivity etc in different modules 

### DIFF
--- a/ion/processes/data/transforms/ctd/ctd_L0_all.py
+++ b/ion/processes/data/transforms/ctd/ctd_L0_all.py
@@ -27,6 +27,7 @@ from prototype.sci_data.stream_parser import PointSupplementStreamParser
 from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from ion.services.dm.utility.granule.granule import build_granule
+from ion.services.dm.utility.granule_utils import CoverageCraft
 
 #from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 #pmsc = PubsubManagementServiceClient(node=cc.node)
@@ -35,6 +36,11 @@ from ion.services.dm.utility.granule.granule import build_granule
 #p_stream_id = pmsc.create_stream(name='pressure')
 #cc.spawn_process('l0_transform', 'ion.processes.data.transforms.ctd_L0_all','ctd_L0_all', config={'processes':{'publish_streams':{'conductivity':c_stream_id, 'temperature':t_stream_id, 'pressure': p_stream_id } } })
 
+craft = CoverageCraft
+sdom, tdom = craft.create_domains()
+sdom = sdom.dump()
+tdom = tdom.dump()
+parameter_dictionary = craft.create_parameters()
 
 class ctd_L0_all(TransformDataProcess):
     """Model for a TransformDataProcess
@@ -53,107 +59,8 @@ class ctd_L0_all(TransformDataProcess):
         #outgoing_stream_temperature = L0_temperature_stream_definition()
         #outgoing_stream_conductivity = L0_conductivity_stream_definition()
 
-        ### Taxonomies are defined before hand out of band... somehow.
-    #    pres = TaxyTool()
-    #    pres.add_taxonomy_set('pres','long name for pres')
-    #    pres.add_taxonomy_set('lat','long name for latitude')
-    #    pres.add_taxonomy_set('lon','long name for longitude')
-    #    pres.add_taxonomy_set('height','long name for height')
-    #    pres.add_taxonomy_set('time','long name for time')
-    #    # This is an example of using groups it is not a normative statement about how to use groups
-    #    pres.add_taxonomy_set('coordinates','This group contains coordinates...')
-    #    pres.add_taxonomy_set('data','This group contains data...')
-    #
-    #    temp = TaxyTool()
-    #    temp.add_taxonomy_set('temp','long name for temp')
-    #    temp.add_taxonomy_set('lat','long name for latitude')
-    #    temp.add_taxonomy_set('lon','long name for longitude')
-    #    temp.add_taxonomy_set('height','long name for height')
-    #    temp.add_taxonomy_set('time','long name for time')
-    #    # This is an example of using groups it is not a normative statement about how to use groups
-    #    temp.add_taxonomy_set('coordinates','This group contains coordinates...')
-    #    temp.add_taxonomy_set('data','This group contains data...')
-    #
-    #    coord = TaxyTool()
-    #    coord.add_taxonomy_set('cond','long name for cond')
-    #    coord.add_taxonomy_set('lat','long name for latitude')
-    #    coord.add_taxonomy_set('lon','long name for longitude')
-    #    coord.add_taxonomy_set('height','long name for height')
-    #    coord.add_taxonomy_set('time','long name for time')
-    #    # This is an example of using groups it is not a normative statement about how to use groups
-    #    coord.add_taxonomy_set('coordinates','This group contains coordinates...')
-    #    coord.add_taxonomy_set('data','This group contains data...')
-
-        ### Parameter dictionaries
-        self.defining_parameter_dictionary()
-
         self.publisher = Publisher(to_name=NameTrio(get_sys_name(), str(uuid.uuid4())[0:6]))
 
-    def defining_parameter_dictionary(self):
-
-        # Define the parameter context objects
-
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.int64))
-        t_ctxt.reference_frame = AxisTypeEnum.TIME
-        t_ctxt.uom = 'seconds since 1970-01-01'
-        t_ctxt.fill_value = 0x0
-
-        lat_ctxt = ParameterContext('lat', param_type=QuantityType(value_encoding=np.float32))
-        lat_ctxt.reference_frame = AxisTypeEnum.LAT
-        lat_ctxt.uom = 'degree_north'
-        lat_ctxt.fill_value = 0e0
-
-        lon_ctxt = ParameterContext('lon', param_type=QuantityType(value_encoding=np.float32))
-        lon_ctxt.reference_frame = AxisTypeEnum.LON
-        lon_ctxt.uom = 'degree_east'
-        lon_ctxt.fill_value = 0e0
-
-        height_ctxt = ParameterContext('height', param_type=QuantityType(value_encoding=np.float32))
-        height_ctxt.reference_frame = AxisTypeEnum.HEIGHT
-        height_ctxt.uom = 'meters'
-        height_ctxt.fill_value = 0e0
-
-        pres_ctxt = ParameterContext('pres', param_type=QuantityType(value_encoding=np.float32))
-        pres_ctxt.uom = 'degree_Celsius'
-        pres_ctxt.fill_value = 0e0
-
-        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.float32))
-        temp_ctxt.uom = 'degree_Celsius'
-        temp_ctxt.fill_value = 0e0
-
-        cond_ctxt = ParameterContext('cond', param_type=QuantityType(value_encoding=np.float32))
-        cond_ctxt.uom = 'unknown'
-        cond_ctxt.fill_value = 0e0
-
-        data_ctxt = ParameterContext('data', param_type=QuantityType(value_encoding=np.int8))
-        data_ctxt.uom = 'byte'
-        data_ctxt.fill_value = 0x0
-
-        # Define the parameter dictionary objects
-
-        self.pres = ParameterDictionary()
-        self.pres.add_context(t_ctxt)
-        self.pres.add_context(lat_ctxt)
-        self.pres.add_context(lon_ctxt)
-        self.pres.add_context(height_ctxt)
-        self.pres.add_context(pres_ctxt)
-        self.pres.add_context(data_ctxt)
-
-        self.temp = ParameterDictionary()
-        self.temp.add_context(t_ctxt)
-        self.temp.add_context(lat_ctxt)
-        self.temp.add_context(lon_ctxt)
-        self.temp.add_context(height_ctxt)
-        self.temp.add_context(temp_ctxt)
-        self.temp.add_context(data_ctxt)
-
-        self.cond = ParameterDictionary()
-        self.cond.add_context(t_ctxt)
-        self.cond.add_context(lat_ctxt)
-        self.cond.add_context(lon_ctxt)
-        self.cond.add_context(height_ctxt)
-        self.cond.add_context(cond_ctxt)
-        self.cond.add_context(data_ctxt)
 
     def process(self, packet):
 
@@ -167,38 +74,38 @@ class ctd_L0_all(TransformDataProcess):
 #        rdt0 = rdt['coordinates']
 #        rdt1 = rdt['data']
 
-        conductivity = get_safe(rdt, 'cond') #psd.get_values('conductivity')
-        pressure = get_safe(rdt, 'pres') #psd.get_values('pressure')
+        conductivity = get_safe(rdt, 'conductivity') #psd.get_values('conductivity')
+        pressure = get_safe(rdt, 'pressure') #psd.get_values('pressure')
         temperature = get_safe(rdt, 'temp') #psd.get_values('temperature')
 
         longitude = get_safe(rdt, 'lon') # psd.get_values('longitude')
         latitude = get_safe(rdt, 'lat')  #psd.get_values('latitude')
         time = get_safe(rdt, 'time') # psd.get_values('time')
-        height = get_safe(rdt, 'height') # psd.get_values('time')
+        depth = get_safe(rdt, 'depth') # psd.get_values('time')
 
         log.warn('Got conductivity: %s' % str(conductivity))
         log.warn('Got pressure: %s' % str(pressure))
         log.warn('Got temperature: %s' % str(temperature))
 
-        g = self._build_granule_settings(self.cond, 'cond', conductivity, time, latitude, longitude, height)
+        g = self._build_granule_settings(self.cond, 'conductivity', conductivity, time, latitude, longitude, depth)
 
         # publish a granule
         self.cond_publisher = self.publisher
         self.cond_publisher.publish(g)
 
-        g = self._build_granule_settings(self.temp, 'temp', temperature, time, latitude, longitude, height)
+        g = self._build_granule_settings(self.temp, 'temp', temperature, time, latitude, longitude, depth)
 
         # publish a granule
         self.temp_publisher = self.publisher
         self.temp_publisher.publish(g)
 
-        g = self._build_granule_settings(self.pres, 'pres', pressure, time, latitude, longitude, height)
+        g = self._build_granule_settings(self.pres, 'pressure', pressure, time, latitude, longitude, depth)
 
         # publish a granule
         self.pres_publisher = self.publisher
         self.pres_publisher.publish(g)
 
-    def _build_granule_settings(self, param_dictionary=None, field_name='', value=None, time=None, latitude=None, longitude=None, height=None):
+    def _build_granule_settings(self, param_dictionary=None, field_name='', value=None, time=None, latitude=None, longitude=None, depth=None):
 
         root_rdt = RecordDictionaryTool(param_dictionary=param_dictionary)
 
@@ -211,7 +118,7 @@ class ctd_L0_all(TransformDataProcess):
         root_rdt['time'] = time
         root_rdt['lat'] = latitude
         root_rdt['lon'] = longitude
-        root_rdt['height'] = height
+        root_rdt['depth'] = depth
 
         #todo: use only flat dicts for now, may change later...
 #        root_rdt['coordinates'] = coor_rdt

--- a/ion/processes/data/transforms/ctd/ctd_L1_conductivity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_conductivity.py
@@ -23,6 +23,14 @@ from pyon.util.containers import get_safe
 from coverage_model.parameter import ParameterDictionary, ParameterContext
 from coverage_model.parameter_types import QuantityType
 from coverage_model.basic_types import AxisTypeEnum
+from ion.services.dm.utility.granule_utils import CoverageCraft
+
+craft = CoverageCraft
+sdom, tdom = craft.create_domains()
+sdom = sdom.dump()
+tdom = tdom.dump()
+parameter_dictionary = craft.create_parameters()
+
 
 class CTDL1ConductivityTransform(TransformFunction):
     ''' A basic transform that receives input through a subscription,
@@ -39,52 +47,6 @@ class CTDL1ConductivityTransform(TransformFunction):
     def __init__(self):
         super(CTDL1ConductivityTransform, self).__init__()
 
-        ### Parameter dictionaries
-        self.defining_parameter_dictionary()
-
-
-    def defining_parameter_dictionary(self):
-
-        # Define the parameter context objects
-
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.int64))
-        t_ctxt.reference_frame = AxisTypeEnum.TIME
-        t_ctxt.uom = 'seconds since 1970-01-01'
-        t_ctxt.fill_value = 0x0
-
-        lat_ctxt = ParameterContext('lat', param_type=QuantityType(value_encoding=np.float32))
-        lat_ctxt.reference_frame = AxisTypeEnum.LAT
-        lat_ctxt.uom = 'degree_north'
-        lat_ctxt.fill_value = 0e0
-
-        lon_ctxt = ParameterContext('lon', param_type=QuantityType(value_encoding=np.float32))
-        lon_ctxt.reference_frame = AxisTypeEnum.LON
-        lon_ctxt.uom = 'degree_east'
-        lon_ctxt.fill_value = 0e0
-
-        height_ctxt = ParameterContext('height', param_type=QuantityType(value_encoding=np.float32))
-        height_ctxt.reference_frame = AxisTypeEnum.HEIGHT
-        height_ctxt.uom = 'meters'
-        height_ctxt.fill_value = 0e0
-
-        cond_ctxt = ParameterContext('cond', param_type=QuantityType(value_encoding=np.float32))
-        cond_ctxt.uom = 'unknown'
-        cond_ctxt.fill_value = 0e0
-
-        data_ctxt = ParameterContext('data', param_type=QuantityType(value_encoding=np.int8))
-        data_ctxt.uom = 'byte'
-        data_ctxt.fill_value = 0x0
-
-        # Define the parameter dictionary objects
-
-        self.cond = ParameterDictionary()
-        self.cond.add_context(t_ctxt)
-        self.cond.add_context(lat_ctxt)
-        self.cond.add_context(lon_ctxt)
-        self.cond.add_context(height_ctxt)
-        self.cond.add_context(cond_ctxt)
-        self.cond.add_context(data_ctxt)
-
     def execute(self, granule):
         """Processes incoming data!!!!
         """
@@ -93,16 +55,16 @@ class CTDL1ConductivityTransform(TransformFunction):
 #        rdt0 = rdt['coordinates']
 #        rdt1 = rdt['data']
 
-        conductivity = get_safe(rdt, 'cond') #psd.get_values('conductivity')
+        conductivity = get_safe(rdt, 'conductivity') #psd.get_values('conductivity')
 
         longitude = get_safe(rdt, 'lon') # psd.get_values('longitude')
         latitude = get_safe(rdt, 'lat')  #psd.get_values('latitude')
         time = get_safe(rdt, 'time') # psd.get_values('time')
-        height = get_safe(rdt, 'height') # psd.get_values('time')
+        depth = get_safe(rdt, 'depth') # psd.get_values('time')
 
         log.warn('CTDL1ConductivityTransform: Got conductivity: %s' % str(conductivity))
 
-        root_rdt = RecordDictionaryTool(param_dictionary=self.cond)
+        root_rdt = RecordDictionaryTool(param_dictionary=parameter_dictionary)
 
         #todo: use only flat dicts for now, may change later...
 #        data_rdt = RecordDictionaryTool(taxonomy=self.tx)
@@ -113,16 +75,16 @@ class CTDL1ConductivityTransform(TransformFunction):
         for i in xrange(len(conductivity)):
             scaled_conductivity[i] = (conductivity[i] / 100000.0) - 0.5
 
-        root_rdt['cond'] = scaled_conductivity
+        root_rdt['conductivity'] = scaled_conductivity
         root_rdt['time'] = time
         root_rdt['lat'] = latitude
         root_rdt['lon'] = longitude
-        root_rdt['height'] = height
+        root_rdt['depth'] = depth
 
 #        root_rdt['coordinates'] = coord_rdt
 #        root_rdt['data'] = data_rdt
 
-        return build_granule(data_producer_id='ctd_L1_conductivity', param_dictionary=self.cond, record_dictionary=root_rdt)
+        return build_granule(data_producer_id='ctd_L1_conductivity', param_dictionary=parameter_dictionary, record_dictionary=root_rdt)
 
 #        # The L1 conductivity data product algorithm takes the L0 conductivity data product and converts it
 #        # into Siemens per meter (S/m)
@@ -137,7 +99,7 @@ class CTDL1ConductivityTransform(TransformFunction):
 #
 #        for i in xrange(len(conductivity)):
 #            scaled_conductivity =  ( conductivity[i] / 100000.0 ) - 0.5
-#            point_id = psc.add_point(time=time[i],location=(longitude[i],latitude[i],height[i]))
+#            point_id = psc.add_point(time=time[i],location=(longitude[i],latitude[i],depth[i]))
 #            psc.add_scalar_point_coverage(point_id=point_id, coverage_id='conductivity', value=scaled_conductivity)
 #
 #        return psc.close_stream_granule()

--- a/ion/processes/data/transforms/ctd/ctd_L1_pressure.py
+++ b/ion/processes/data/transforms/ctd/ctd_L1_pressure.py
@@ -17,12 +17,18 @@ from prototype.sci_data.constructor_apis import PointSupplementConstructor
 
 ### For new granule and stream interface
 from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
-from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from ion.services.dm.utility.granule.granule import build_granule
 from pyon.util.containers import get_safe
 from coverage_model.parameter import ParameterDictionary, ParameterContext
 from coverage_model.parameter_types import QuantityType
 from coverage_model.basic_types import AxisTypeEnum
+from ion.services.dm.utility.granule_utils import CoverageCraft
+
+craft = CoverageCraft
+sdom, tdom = craft.create_domains()
+sdom = sdom.dump()
+tdom = tdom.dump()
+parameter_dictionary = craft.create_parameters()
 
 class CTDL1PressureTransform(TransformFunction):
     ''' A basic transform that receives input through a subscription,
@@ -39,51 +45,6 @@ class CTDL1PressureTransform(TransformFunction):
     def __init__(self):
         super(CTDL1PressureTransform, self).__init__()
 
-        ### Parameter dictionaries
-        self.defining_parameter_dictionary()
-
-    def defining_parameter_dictionary(self):
-
-        # Define the parameter context objects
-
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.int64))
-        t_ctxt.reference_frame = AxisTypeEnum.TIME
-        t_ctxt.uom = 'seconds since 1970-01-01'
-        t_ctxt.fill_value = 0x0
-
-        lat_ctxt = ParameterContext('lat', param_type=QuantityType(value_encoding=np.float32))
-        lat_ctxt.reference_frame = AxisTypeEnum.LAT
-        lat_ctxt.uom = 'degree_north'
-        lat_ctxt.fill_value = 0e0
-
-        lon_ctxt = ParameterContext('lon', param_type=QuantityType(value_encoding=np.float32))
-        lon_ctxt.reference_frame = AxisTypeEnum.LON
-        lon_ctxt.uom = 'degree_east'
-        lon_ctxt.fill_value = 0e0
-
-        height_ctxt = ParameterContext('height', param_type=QuantityType(value_encoding=np.float32))
-        height_ctxt.reference_frame = AxisTypeEnum.HEIGHT
-        height_ctxt.uom = 'meters'
-        height_ctxt.fill_value = 0e0
-
-        pres_ctxt = ParameterContext('pres', param_type=QuantityType(value_encoding=np.float32))
-        pres_ctxt.uom = 'degree_Celsius'
-        pres_ctxt.fill_value = 0e0
-
-        data_ctxt = ParameterContext('data', param_type=QuantityType(value_encoding=np.int8))
-        data_ctxt.uom = 'byte'
-        data_ctxt.fill_value = 0x0
-
-        # Define the parameter dictionary objects
-
-        self.pres = ParameterDictionary()
-        self.pres.add_context(t_ctxt)
-        self.pres.add_context(lat_ctxt)
-        self.pres.add_context(lon_ctxt)
-        self.pres.add_context(height_ctxt)
-        self.pres.add_context(pres_ctxt)
-        self.pres.add_context(data_ctxt)
-
 
     def execute(self, granule):
         """Processes incoming data!!!!
@@ -94,12 +55,12 @@ class CTDL1PressureTransform(TransformFunction):
 #        rdt0 = rdt['coordinates']
 #        rdt1 = rdt['data']
 
-        pressure = get_safe(rdt, 'pres') #psd.get_values('conductivity')
+        pressure = get_safe(rdt, 'pressure') #psd.get_values('conductivity')
 
         longitude = get_safe(rdt, 'lon') # psd.get_values('longitude')
         latitude = get_safe(rdt, 'lat')  #psd.get_values('latitude')
         time = get_safe(rdt, 'time') # psd.get_values('time')
-        height = get_safe(rdt, 'height') # psd.get_values('time')
+        depth = get_safe(rdt, 'depth') # psd.get_values('time')
 
         log.warn('Got pressure: %s' % str(pressure))
 
@@ -126,22 +87,18 @@ class CTDL1PressureTransform(TransformFunction):
             #todo: get pressure range from metadata (if present) and include in calc
             scaled_pressure[i] = ( pressure[i])
 
-        root_rdt = RecordDictionaryTool(taxonomy=self.tx)
+        root_rdt = RecordDictionaryTool(param_dictionary=parameter_dictionary)
 
-        #todo: use only flat dicts for now, may change later...
-#        data_rdt = RecordDictionaryTool(taxonomy=self.tx)
-#        coord_rdt = RecordDictionaryTool(taxonomy=self.tx)
-
-        root_rdt['pres'] = scaled_pressure
+        root_rdt['pressure'] = scaled_pressure
         root_rdt['time'] = time
         root_rdt['lat'] = latitude
         root_rdt['lon'] = longitude
-        root_rdt['height'] = height
+        root_rdt['depth'] = depth
 
 #        root_rdt['coordinates'] = coord_rdt
 #        root_rdt['data'] = data_rdt
 
-        return build_granule(data_producer_id='ctd_L1_pressure', taxonomy=self.tx, record_dictionary=root_rdt)
+        return build_granule(data_producer_id='ctd_L1_pressure', param_dictionary=parameter_dictionary, record_dictionary=root_rdt)
 
         return psc.close_stream_granule()
 

--- a/ion/processes/data/transforms/ctd/ctd_L2_density.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_density.py
@@ -21,13 +21,19 @@ from seawater.gibbs import cte
 
 ### For new granule and stream interface
 from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
-from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from ion.services.dm.utility.granule.granule import build_granule
 from pyon.util.containers import get_safe
 from coverage_model.parameter import ParameterDictionary, ParameterContext
 from coverage_model.parameter_types import QuantityType
 from coverage_model.basic_types import AxisTypeEnum
+from ion.services.dm.utility.granule_utils import CoverageCraft
 import numpy as np
+
+craft = CoverageCraft
+sdom, tdom = craft.create_domains()
+sdom = sdom.dump()
+tdom = tdom.dump()
+parameter_dictionary = craft.create_parameters()
 
 class DensityTransform(TransformFunction):
     ''' A basic transform that receives input through a subscription,
@@ -44,63 +50,6 @@ class DensityTransform(TransformFunction):
     def __init__(self):
         super(DensityTransform, self).__init__()
 
-#        ### Taxonomies are defined before hand out of band... somehow.
-#        tx = TaxyTool()
-#        tx.add_taxonomy_set('density','long name for density')
-#        tx.add_taxonomy_set('lat','long name for latitude')
-#        tx.add_taxonomy_set('lon','long name for longitude')
-#        tx.add_taxonomy_set('height','long name for height')
-#        tx.add_taxonomy_set('time','long name for time')
-#        # This is an example of using groups it is not a normative statement about how to use groups
-#        tx.add_taxonomy_set('coordinates','This group contains coordinates...')
-#        tx.add_taxonomy_set('data','This group contains data...')
-
-        ### Parameter dictionaries
-        self.defining_parameter_dictionary()
-
-    def defining_parameter_dictionary(self):
-
-        # Define the parameter context objects
-
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.int64))
-        t_ctxt.reference_frame = AxisTypeEnum.TIME
-        t_ctxt.uom = 'seconds since 1970-01-01'
-        t_ctxt.fill_value = 0x0
-
-        lat_ctxt = ParameterContext('lat', param_type=QuantityType(value_encoding=np.float32))
-        lat_ctxt.reference_frame = AxisTypeEnum.LAT
-        lat_ctxt.uom = 'degree_north'
-        lat_ctxt.fill_value = 0e0
-
-        lon_ctxt = ParameterContext('lon', param_type=QuantityType(value_encoding=np.float32))
-        lon_ctxt.reference_frame = AxisTypeEnum.LON
-        lon_ctxt.uom = 'degree_east'
-        lon_ctxt.fill_value = 0e0
-
-        height_ctxt = ParameterContext('height', param_type=QuantityType(value_encoding=np.float32))
-        height_ctxt.reference_frame = AxisTypeEnum.HEIGHT
-        height_ctxt.uom = 'meters'
-        height_ctxt.fill_value = 0e0
-
-        dens_ctxt = ParameterContext('dens', param_type=QuantityType(value_encoding=np.float32))
-        dens_ctxt.uom = 'degree_Celsius'
-        dens_ctxt.fill_value = 0e0
-
-        data_ctxt = ParameterContext('data', param_type=QuantityType(value_encoding=np.int8))
-        data_ctxt.uom = 'byte'
-        data_ctxt.fill_value = 0x0
-
-        # Define the parameter dictionary objects
-
-        self.dens = ParameterDictionary()
-        self.dens.add_context(t_ctxt)
-        self.dens.add_context(lat_ctxt)
-        self.dens.add_context(lon_ctxt)
-        self.dens.add_context(height_ctxt)
-        self.dens.add_context(dens_ctxt)
-        self.dens.add_context(data_ctxt)
-
-
     def execute(self, granule):
         """Processes incoming data!!!!
         """
@@ -111,13 +60,13 @@ class DensityTransform(TransformFunction):
 #        rdt1 = rdt['data']
 
         temperature = get_safe(rdt, 'temp')
-        conductivity = get_safe(rdt, 'cond')
-        density = get_safe(rdt, 'dens')
+        conductivity = get_safe(rdt, 'conductivity')
+        density = get_safe(rdt, 'density')
 
         longitude = get_safe(rdt, 'lon')
         latitude = get_safe(rdt, 'lat')
         time = get_safe(rdt, 'time')
-        height = get_safe(rdt, 'height')
+        depth = get_safe(rdt, 'depth')
 
 
         log.warn('Got conductivity: %s' % str(conductivity))
@@ -139,7 +88,7 @@ class DensityTransform(TransformFunction):
         ### the stream id is part of the metadata which much go in each stream granule - this is awkward to do at the
         ### application level like this!
 
-        root_rdt = RecordDictionaryTool(param_dictionary=self.dens)
+        root_rdt = RecordDictionaryTool(param_dictionary=parameter_dictionary)
         #todo: use only flat dicts for now, may change later...
 #        data_rdt = RecordDictionaryTool(taxonomy=self.tx)
 #        coord_rdt = RecordDictionaryTool(taxonomy=self.tx)
@@ -148,12 +97,12 @@ class DensityTransform(TransformFunction):
         root_rdt['time'] = time
         root_rdt['lat'] = latitude
         root_rdt['lon'] = longitude
-        root_rdt['height'] = height
+        root_rdt['depth'] = depth
 
 #        root_rdt['coordinates'] = coord_rdt
 #        root_rdt['data'] = data_rdt
 
-        return build_granule(data_producer_id='ctd_L2_density', param_dictionary=self.dens, record_dictionary=root_rdt)
+        return build_granule(data_producer_id='ctd_L2_density', param_dictionary=parameter_dictionary, record_dictionary=root_rdt)
 
 
   

--- a/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
@@ -30,7 +30,7 @@ import numpy as np
 class SalinityTransform(TransformFunction):
     '''
     L2 Transform for CTD Data.
-    Input is conductivity temperature and salsure delivered as a single packet.
+    Input is conductivity temperature and pres delivered as a single packet.
     Output is Practical Salinity as calculated by the Gibbs Seawater package
     '''
 
@@ -86,6 +86,16 @@ class SalinityTransform(TransformFunction):
         data_ctxt.uom = 'byte'
         data_ctxt.fill_value = 0x0
 
+        pres_ctxt = ParameterContext('pres', param_type=QuantityType(value_encoding=np.float32))
+        pres_ctxt.uom = 'degree_Celsius'
+        pres_ctxt.fill_value = 0e0
+
+        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.float32))
+        temp_ctxt.uom = 'degree_Celsius'
+        temp_ctxt.fill_value = 0e0
+
+
+
         # Define the parameter dictionary objects
 
         self.sal = ParameterDictionary()
@@ -95,6 +105,8 @@ class SalinityTransform(TransformFunction):
         self.sal.add_context(height_ctxt)
         self.sal.add_context(sal_ctxt)
         self.sal.add_context(data_ctxt)
+        self.sal.add_context(temp_ctxt)
+        self.sal.add_context(pres_ctxt)
 
     def execute(self, granule):
         """Processes incoming data!!!!
@@ -105,9 +117,9 @@ class SalinityTransform(TransformFunction):
 #        rdt0 = rdt['coordinates']
 #        rdt1 = rdt['data']
 
-        temperature = get_safe(rdt, 'sal')
+        temperature = get_safe(rdt, 'temp')
         conductivity = get_safe(rdt, 'cond')
-        salsure = get_safe(rdt, 'temp')
+        pres = get_safe(rdt, 'pres')
 
         longitude = get_safe(rdt, 'lon')
         latitude = get_safe(rdt, 'lat')
@@ -115,10 +127,10 @@ class SalinityTransform(TransformFunction):
         height = get_safe(rdt, 'height')
 
         log.warn('Got conductivity: %s' % str(conductivity))
-        log.warn('Got salsure: %s' % str(salsure))
+        log.warn('Got pres: %s' % str(pres))
         log.warn('Got temperature: %s' % str(temperature))
 
-        salinity = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=salsure)
+        salinity = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=pres)
 
         log.warn('Got salinity: %s' % str(salinity))
 

--- a/ion/services/ans/test/test_helper.py
+++ b/ion/services/ans/test/test_helper.py
@@ -335,8 +335,22 @@ class VisualizationIntegrationTestHelper(IonIntegrationTestCase):
         data_process_name = data_process_definition.name
 
         # Create the output data product of the transform
-        transform_dp_obj = IonObject(RT.DataProduct, name=data_process_name,description=data_process_definition.description)
-        transform_dp_id = self.dataproductclient.create_data_product(transform_dp_obj, process_output_stream_def_id)
+
+        craft = CoverageCraft
+        sdom, tdom = craft.create_domains()
+        sdom = sdom.dump()
+        tdom = tdom.dump()
+        parameter_dictionary = craft.create_parameters()
+        parameter_dictionary = parameter_dictionary.dump()
+
+        transform_dp_obj = IonObject(RT.DataProduct,
+            name=data_process_name,
+            description=data_process_definition.description,
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        transform_dp_id = self.dataproductclient.create_data_product(transform_dp_obj, process_output_stream_def_id, parameter_dictionary)
+
         self.dataproductclient.activate_data_product_persistence(data_product_id=transform_dp_id)
 
         #last one out of the for loop is the output product id

--- a/ion/services/ans/test/test_workflow.py
+++ b/ion/services/ans/test/test_workflow.py
@@ -120,9 +120,7 @@ class TestWorkflowManagementIntegration(VisualizationIntegrationTestHelper):
 
     @attr('LOCOINT')
     @attr('SMOKE')
-    @unittest.skip("not working")
     @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False),'Not integrated for CEI')
-    @unittest.skip("in progress")
     def test_transform_workflow(self):
 
         assertions = self.assertTrue

--- a/ion/services/dm/utility/granule_utils.py
+++ b/ion/services/dm/utility/granule_utils.py
@@ -179,6 +179,17 @@ class CoverageCraft(object):
         pres_ctxt.fill_value = 0x0
         pdict.add_context(pres_ctxt)
 
+        sal_ctxt = ParameterContext('salinity', param_type=QuantityType(value_encoding=np.float32))
+        sal_ctxt.uom = 'PSU'
+        sal_ctxt.fill_value = 0x0
+        pdict.add_context(sal_ctxt)
+
+        sal_ctxt = ParameterContext('density', param_type=QuantityType(value_encoding=np.float32))
+        sal_ctxt.uom = 'PSU'
+        sal_ctxt.fill_value = 0x0
+        pdict.add_context(sal_ctxt)
+
+
         return pdict
         
     @classmethod


### PR DESCRIPTION
Uses a common way of creating a parameter_dictionary through CoverageCraft in all the ctd transform modules. This ensures that the different modules do not use different names when creating or reading parameters leading to no errors due to that. Also, some other bugs were fixed.
