### PR TITLE
Notification workers created in bootstrap similar to ingestion workers

### DIFF
--- a/ion/processes/bootstrap/plugins/bootstrap_process_dispatcher.py
+++ b/ion/processes/bootstrap/plugins/bootstrap_process_dispatcher.py
@@ -15,14 +15,24 @@ class BootstrapProcessDispatcher(BootstrapPlugin):
     def on_initial_bootstrap(self, process, config, **kwargs):
         pds_client = ProcessDispatcherServiceProcessClient(process=process)
 
+        # ingestion
         ingestion_module    = config.get_safe('bootstrap.processes.ingestion.module','ion.processes.data.ingestion.science_granule_ingestion_worker')
         ingestion_class     = config.get_safe('bootstrap.processes.ingestion.class' ,'ScienceGranuleIngestionWorker')
         ingestion_datastore = config.get_safe('bootstrap.processes.ingestion.datastore_name', 'datasets')
         ingestion_queue     = config.get_safe('bootstrap.processes.ingestion.queue' , 'science_granule_ingestion')
         ingestion_workers   = config.get_safe('bootstrap.processes.ingestion.workers', 2)
 
+        # user notifications
+        notification_module    = config.get_safe('bootstrap.processes.user_notification.module','ion.processes.data.transforms.notification_worker')
+        notification_class     = config.get_safe('bootstrap.processes.user_notification.class' ,'NotificationWorker')
+        notification_workers = config.get_safe('bootstrap.processes.user_notification.workers', 2)
+
         replay_module       = config.get_safe('bootstrap.processes.replay.module', 'ion.processes.data.replay.replay_process')
         replay_class        = config.get_safe('bootstrap.processes.replay.class' , 'ReplayProcess')
+
+        #--------------------------------------------------------------------------------
+        # Create ingestion workers
+        #--------------------------------------------------------------------------------
 
         process_definition = ProcessDefinition(
             name='ingestion_worker_process',
@@ -41,7 +51,28 @@ class BootstrapProcessDispatcher(BootstrapPlugin):
         for i in xrange(ingestion_workers):
             pds_client.schedule_process(process_definition_id=ingestion_procdef_id, configuration=config)
 
+        #--------------------------------------------------------------------------------
+        # Create notification workers
+        #--------------------------------------------------------------------------------
 
+        # set up the process definition
+        process_definition_uns = ProcessDefinition(
+            name='notification_worker_process',
+            description='Worker transform process for user notifications')
+        process_definition_uns.executable['module']= notification_module
+        process_definition_uns.executable['class'] = notification_class
+        uns_procdef_id = pds_client.create_process_definition(process_definition=process_definition_uns)
+
+        config = DotDict()
+        config.process.type = 'simple'
+
+        for i in xrange(notification_workers):
+            config.process.name = 'notification_worker_%s' % i
+            pds_client.schedule_process(process_definition_id=uns_procdef_id, configuration=config)
+
+        #--------------------------------------------------------------------------------
+        # Create replay process definition
+        #--------------------------------------------------------------------------------
 
         process_definition = ProcessDefinition(name='data_replay_process', description='Process for the replay of datasets')
         process_definition.executable['module']= replay_module


### PR DESCRIPTION
The default value is 2 workers. We can check by running bin/pycc with r2deploy.yml that right now two notification worker processes are created.
