### PR TITLE
Removed coverage craft from sa tests

### DIFF
--- a/ion/services/sa/acquisition/test/test_bulk_data_ingestion.py
+++ b/ion/services/sa/acquisition/test/test_bulk_data_ingestion.py
@@ -24,11 +24,12 @@ from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcher
 from interface.services.dm.idata_retriever_service import DataRetrieverServiceClient
 from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance, ExternalDataProvider, DataProduct, ExternalDatasetModel, DataSourceModel, ContactInformation, UpdateDescription, DatasetDescription, ExternalDataset, Institution, DataSource
 from interface.objects import AgentCommand, ExternalDatasetAgent, ExternalDatasetAgentInstance, ProcessDefinition
+from ion.util.parameter_yaml_IO import get_param_dict
 
 from coverage_model.parameter import ParameterDictionary, ParameterContext
 from coverage_model.parameter_types import QuantityType
-from coverage_model.basic_types import AxisTypeEnum
-from ion.services.dm.utility.granule_utils import CoverageCraft, RecordDictionaryTool
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
 
 from ion.agents.instrument.instrument_agent import InstrumentAgentState
 
@@ -333,13 +334,18 @@ class TestBulkIngest(IonIntegrationTestCase):
         # Generate the data product and associate it to the ExternalDataset
         streamdef_id = self.pubsub_client.create_stream_definition(name="temp", description="temp")
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-#        parameter_dictionary = craft.create_parameters()
-        #parameter_dictionary = parameter_dictionary.dump()
-        parameter_dictionary = self._create_param_dict()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
 
         dprod = IonObject(RT.DataProduct,
             name='slocum_parsed_product',
@@ -379,235 +385,3 @@ class TestBulkIngest(IonIntegrationTestCase):
         self.EDA_RESOURCE_ID = ds_id
         self.EDA_NAME = ds_name
 
-
-
-
-    def _create_param_dict(self):
-
-        pdict = ParameterDictionary()
-
-
-#        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.int64))
-#        t_ctxt.reference_frame = AxisTypeEnum.TIME
-#        t_ctxt.uom = 'seconds since 1970-01-01'
-#        t_ctxt.fill_value = 0x0
-#        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('c_wpt_y_lmc', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_water_cond', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_y_lmc', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('u_hd_fin_ap_inflection_holdoff', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_m_present_time', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.reference_frame = AxisTypeEnum.TIME
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_leakdetect_voltage_forward', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_bb3slo_b660_scaled', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('c_science_send_all', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_gps_status', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_water_vx', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_water_vy', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('c_heading', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_fl3slo_chlor_units', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('u_hd_fin_ap_gain', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_vacuum', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('u_min_water_depth', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_gps_lat', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_veh_temp', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('f_fin_offset', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('u_hd_fin_ap_hardover_holdoff', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('c_alt_time', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_present_time', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_heading', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_bb3slo_b532_scaled', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_fl3slo_cdom_units', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_fin', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('x_cycle_overrun_in_ms', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_water_pressure', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('u_hd_fin_ap_igain', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_fl3slo_phyco_units', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_battpos', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_bb3slo_b470_scaled', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_lat', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_gps_lon', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_ctd41cp_timestamp', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_pressure', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('c_wpt_x_lmc', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('c_ballast_pumped', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('x_lmc_xy_source', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_lon', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_avg_speed', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('sci_water_temp', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('u_pitch_ap_gain', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_roll', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_tot_num_inflections', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_x_lmc', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('u_pitch_ap_deadband', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_final_water_vy', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_final_water_vx', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_water_depth', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_leakdetect_voltage', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('u_pitch_max_delta_battpos', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_coulomb_amphr', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        t_ctxt = ParameterContext('m_pitch', param_type=QuantityType(value_encoding=numpy.dtype('float32')))
-        t_ctxt.uom = 'unknown'
-        pdict.add_context(t_ctxt)
-
-        return pdict

--- a/ion/services/sa/acquisition/test/test_external_dataset_agent_mgmt.py
+++ b/ion/services/sa/acquisition/test/test_external_dataset_agent_mgmt.py
@@ -35,13 +35,16 @@ from pyon.public import RT, LCS, PRED
 from mock import Mock, patch
 from pyon.util.unit_test import PyonTestCase
 from nose.plugins.attrib import attr
-from coverage_model.parameter import ParameterDictionary
 import unittest
 import time
-from ion.services.dm.utility.granule_utils import CoverageCraft
 from ion.services.sa.product.data_product_impl import DataProductImpl
 from ion.services.sa.resource_impl.resource_impl_metatest import ResourceImplMetatest
+from ion.util.parameter_yaml_IO import get_param_dict
 
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
 
 # Agent parameters.
 EDA_RESOURCE_ID = '123xyz'
@@ -126,11 +129,19 @@ class TestExternalDatasetAgentMgmt(IonIntegrationTestCase):
         log.debug("TestExternalDatasetAgentMgmt: Creating new data product with a stream definition")
         dp_obj = IonObject(RT.DataProduct,name='eoi dataset data',description=' stream test')
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
+
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,
@@ -316,5 +327,3 @@ class TestExternalDatasetAgentMgmt(IonIntegrationTestCase):
         #-------------------------------
         self.damsclient.stop_external_dataset_agent_instance(extDatasetAgentInstance_id)
 
-
-  

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -10,7 +10,6 @@ from interface.services.sa.iinstrument_management_service import InstrumentManag
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
-from ion.services.dm.utility.granule_utils import CoverageCraft
 
 from prototype.sci_data.stream_defs import SBE37_CDM_stream_definition
 
@@ -24,8 +23,12 @@ import unittest
 from pyon.util.log import log
 
 from ion.services.sa.test.helpers import any_old
+from ion.util.parameter_yaml_IO import get_param_dict
 
-
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
 
 class FakeProcess(LocalContextMixin):
     name = ''
@@ -126,11 +129,19 @@ class TestDeployment(IonIntegrationTestCase):
         ctd_stream_def = SBE37_CDM_stream_definition()
         ctd_stream_def_id = self.psmsclient.create_stream_definition(container=ctd_stream_def)
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
+
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,
@@ -181,3 +192,4 @@ class TestDeployment(IonIntegrationTestCase):
         log.debug("test_create_deployment: created deployment id: %s ", str(deployment_id) )
 
         self.omsclient.activate_deployment(deployment_id)
+

--- a/ion/services/sa/process/test/test_data_process_with_lookup_tables.py
+++ b/ion/services/sa/process/test/test_data_process_with_lookup_tables.py
@@ -35,7 +35,12 @@ from interface.objects import HdfStorage, CouchStorage
 from prototype.sci_data.stream_parser import PointSupplementStreamParser
 from pyon.agent.agent import ResourceAgentClient
 from interface.objects import AgentCommand
-from ion.services.dm.utility.granule_utils import CoverageCraft
+from ion.util.parameter_yaml_IO import get_param_dict
+
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
 
 import base64
 
@@ -136,11 +141,19 @@ class TestDataProcessWithLookupTable(IonIntegrationTestCase):
 
         print 'Creating new CDM data product with a stream definition'
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
+
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -35,9 +35,11 @@ from prototype.sci_data.stream_parser import PointSupplementStreamParser
 from pyon.agent.agent import ResourceAgentClient
 from interface.objects import AgentCommand
 from mock import patch
-from coverage_model.parameter import ParameterDictionary
-from ion.services.dm.utility.granule_utils import CoverageCraft
-
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
+from ion.util.parameter_yaml_IO import get_param_dict
 
 class FakeProcess(LocalContextMixin):
     """
@@ -113,11 +115,19 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
 
 
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
+
         parameter_dictionary = parameter_dictionary.dump()
 
         input_dp_obj = IonObject(   RT.DataProduct,
@@ -271,11 +281,19 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         print 'Creating new CDM data product with a stream definition'
 
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
+
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,

--- a/ion/services/sa/product/test/test_data_product_management_service.py
+++ b/ion/services/sa/product/test/test_data_product_management_service.py
@@ -21,7 +21,11 @@ import time
 
 from ion.services.sa.product.data_product_impl import DataProductImpl
 from ion.services.sa.resource_impl.resource_impl_metatest import ResourceImplMetatest
-from ion.services.dm.utility.granule_utils import CoverageCraft
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
+from ion.util.parameter_yaml_IO import get_param_dict
 
 
 class FakeProcess(LocalContextMixin):
@@ -55,11 +59,20 @@ class TestDataProductManagementServiceUnit(PyonTestCase):
         self.clients.data_acquisition_management.assign_data_product.return_value = None
         self.clients.pubsub_management.create_stream.return_value = "stream_id"
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
+
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,
@@ -117,4 +130,3 @@ class TestDataProductManagementServiceUnit(PyonTestCase):
 #unit
 rim = ResourceImplMetatest(TestDataProductManagementServiceUnit, DataProductManagementService, log)
 rim.add_resource_impl_unittests(DataProductImpl)
-

--- a/ion/services/sa/product/test/test_data_product_management_service_integration.py
+++ b/ion/services/sa/product/test/test_data_product_management_service_integration.py
@@ -28,7 +28,12 @@ import numpy as np
 from coverage_model.basic_types import AbstractIdentifiable, AbstractBase, AxisTypeEnum, MutabilityEnum
 from coverage_model.coverage import CRS, GridDomain, GridShape
 from ion.processes.data.last_update_cache import CACHE_DATASTORE_NAME
-from ion.services.dm.utility.granule_utils import CoverageCraft
+
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
+from ion.util.parameter_yaml_IO import get_param_dict
 
 class FakeProcess(LocalContextMixin):
     name = ''
@@ -86,11 +91,19 @@ class TestDataProductManagementServiceIntegration(IonIntegrationTestCase):
     def test_get_last_update(self):
 
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,
@@ -127,12 +140,20 @@ class TestDataProductManagementServiceIntegration(IonIntegrationTestCase):
         #------------------------------------------------------------------------------------------------
         log.debug('test_createDataProduct: Creating new data product w/o a stream definition (L4-CI-SA-RQ-308)')
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
+
 
         dp_obj = IonObject(RT.DataProduct,
             name='DP1',
@@ -235,12 +256,20 @@ class TestDataProductManagementServiceIntegration(IonIntegrationTestCase):
         #------------------------------------------------------------------------------------------------
         log.debug('test_createDataProduct: Creating new data product w/o a stream definition (L4-CI-SA-RQ-308)')
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
+
 
         dp_obj = IonObject(RT.DataProduct,
             name='DP1',
@@ -279,5 +308,4 @@ class TestDataProductManagementServiceIntegration(IonIntegrationTestCase):
 #            cls='SimpleProcess',
 #            config={})
 #        dummy_process = self.container.proc_manager.procs[pid]
-
 

--- a/ion/services/sa/product/test/test_data_product_provenance.py
+++ b/ion/services/sa/product/test/test_data_product_provenance.py
@@ -14,7 +14,6 @@ from interface.services.sa.iinstrument_management_service import InstrumentManag
 from prototype.sci_data.stream_defs import ctd_stream_definition, L0_pressure_stream_definition, L0_temperature_stream_definition, L0_conductivity_stream_definition
 from prototype.sci_data.stream_defs import L1_pressure_stream_definition, L1_temperature_stream_definition, L1_conductivity_stream_definition, L2_practical_salinity_stream_definition, L2_density_stream_definition
 from prototype.sci_data.stream_defs import SBE37_CDM_stream_definition, SBE37_RAW_stream_definition
-from ion.services.dm.utility.granule_utils import CoverageCraft
 
 from prototype.sci_data.stream_defs import ctd_stream_definition, SBE37_CDM_stream_definition
 from interface.objects import  ContactInformation
@@ -30,8 +29,13 @@ from interface.objects import ProcessDefinition
 import unittest
 import time
 
-from ion.services.dm.utility.granule.taxonomy import TaxyTool
 from ion.util.parameter_yaml_IO import get_param_dict
+
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
+
 
 class FakeProcess(LocalContextMixin):
     name = ''
@@ -120,12 +124,20 @@ class TestDataProductProvenance(IonIntegrationTestCase):
 
         log.debug( 'test_get_provenance:Creating new CDM data product with a stream definition')
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('sample_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
+
         parsed_param_dict = get_param_dict('ctd_parsed_param_dict')
 
         dp_obj = IonObject(RT.DataProduct,
@@ -564,3 +576,4 @@ class TestDataProductProvenance(IonIntegrationTestCase):
 
 
         results = self.dpmsclient.get_data_product_provenance_report(ctd_l2_density_output_dp_id)
+

--- a/ion/services/sa/product/test/test_data_product_versions.py
+++ b/ion/services/sa/product/test/test_data_product_versions.py
@@ -10,7 +10,6 @@ from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcher
 from prototype.sci_data.stream_defs import ctd_stream_definition, SBE37_CDM_stream_definition
 from interface.services.sa.iinstrument_management_service import InstrumentManagementServiceClient
 from coverage_model.parameter import ParameterDictionary
-from ion.services.dm.utility.granule_utils import CoverageCraft
 
 from pyon.util.context import LocalContextMixin
 from pyon.util.containers import DotDict
@@ -23,6 +22,11 @@ from interface.objects import ProcessDefinition
 import unittest
 import time
 
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
+from ion.util.parameter_yaml_IO import get_param_dict
 
 class FakeProcess(LocalContextMixin):
     name = ''
@@ -61,11 +65,18 @@ class TestDataProductVersions(IonIntegrationTestCase):
         # test creating a new data product which will also create the initial/default version
         log.debug('Creating new data product with a stream definition')
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,
@@ -144,11 +155,19 @@ class TestDataProductVersions(IonIntegrationTestCase):
 
         print 'Creating new CDM data product with a stream definition'
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,
@@ -240,4 +259,3 @@ class TestDataProductVersions(IonIntegrationTestCase):
 
         # clean up the launched processes
         self.processdispatchclient.cancel_process(producer_pid)
-

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -43,9 +43,14 @@ from pyon.agent.agent import ResourceAgentClient
 from pyon.agent.agent import ResourceAgentState
 from pyon.agent.agent import ResourceAgentEvent
 
-from ion.services.dm.utility.granule_utils import CoverageCraft
 from ion.util.parameter_yaml_IO import get_param_dict
 from pyon.core.exception import BadRequest, NotFound, Conflict
+
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
+from ion.util.parameter_yaml_IO import get_param_dict
 
 from nose.plugins.attrib import attr
 
@@ -178,12 +183,20 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         log.debug( 'Creating new CDM data product with a stream definition')
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('sample_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
+
         parsed_param_dict = get_param_dict('ctd_parsed_param_dict')
         raw_param_dict = get_param_dict('ctd_raw_param_dict')
 
@@ -490,11 +503,18 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         log.debug( 'Creating new CDM data product with a stream definition')
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,
@@ -643,3 +663,4 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         self.imsclient.stop_instrument_agent_instance(instrument_agent_instance_id=instAgentInstance_id)
         for pid in self.loggerpids:
             self.processdispatchclient.cancel_process(pid)
+

--- a/ion/services/sa/test/test_assembly.py
+++ b/ion/services/sa/test/test_assembly.py
@@ -11,7 +11,6 @@ from interface.services.sa.iinstrument_management_service import InstrumentManag
 from interface.services.sa.iobservatory_management_service import ObservatoryManagementServiceClient
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
-from ion.services.dm.utility.granule_utils import CoverageCraft
 
 from pyon.core.exception import BadRequest, NotFound, Inconsistent #, Conflict
 from pyon.public import RT, LCS, LCE
@@ -29,6 +28,12 @@ from ion.services.sa.instrument.sensor_device_impl import SensorDeviceImpl
 from ion.services.sa.instrument.flag import KeywordFlag
 
 from prototype.sci_data.stream_defs import SBE37_CDM_stream_definition, ctd_stream_definition
+
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
+from ion.util.parameter_yaml_IO import get_param_dict
 
 # some stuff for logging info to the console
 # import sys
@@ -441,11 +446,18 @@ class TestAssembly(IonIntegrationTestCase):
 
         log.debug('test_createDataProduct: Creating new data product w/o a stream definition: %s' % ctd_stream_def_id)
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
+
+        parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
         parameter_dictionary = parameter_dictionary.dump()
 
         dp_obj = IonObject(RT.DataProduct,
@@ -749,3 +761,4 @@ class TestAssembly(IonIntegrationTestCase):
         self.assertTrue(num_objs2 > num_objs)
 
         return generic_id
+

--- a/ion/services/sa/test/test_granule_publish.py
+++ b/ion/services/sa/test/test_granule_publish.py
@@ -17,7 +17,6 @@ from interface.services.sa.idata_process_management_service import DataProcessMa
 ### For new granule and stream interface
 from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from ion.services.dm.utility.granule.granule import build_granule
-from ion.services.dm.utility.granule_utils import CoverageCraft
 from pyon.public import log
 from coverage_model.parameter import ParameterContext, ParameterDictionary
 from coverage_model.parameter_types import QuantityType
@@ -25,7 +24,10 @@ from coverage_model.basic_types import AxisTypeEnum
 
 from interface.objects import StreamRoute
 from pyon.ion.stream import SimpleStreamRoutePublisher
-
+from coverage_model.parameter import ParameterDictionary, ParameterContext
+from coverage_model.parameter_types import QuantityType
+from coverage_model.coverage import GridDomain, GridShape, CRS
+from coverage_model.basic_types import MutabilityEnum, AxisTypeEnum
 
 from interface.objects import ProcessDefinition
 
@@ -93,8 +95,14 @@ class TestGranulePublish(IonIntegrationTestCase):
         #retrieve the param dict from the repository
         parameter_dictionary = get_param_dict('ctd_parsed_param_dict')
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        # Construct temporal and spatial Coordinate Reference System objects
+        tcrs = CRS([AxisTypeEnum.TIME])
+        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
+
+        # Construct temporal and spatial Domain objects
+        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
+        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
+
         sdom = sdom.dump()
         tdom = tdom.dump()
 


### PR DESCRIPTION
Using the get_param_dict() method to pull param dict from yml for now. Soon we will add the feature where it gets param dict from the couch.

This pull request only affects SA test code and so it should not break anyone's code.
