### PR TITLE
Luke: NoneType problem with ProcessStateGate

### DIFF
--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -65,9 +65,7 @@ class ProcessStateGate(EventSubscriber):
     def in_desired_state(self):
         # check whether the process we are monitoring is in the desired state as of this moment
         process_obj = self.read_process_fn(self.process_id)
-        if not process_obj:
-            return False
-        return self.desired_state == process_obj.process_state
+        return process_obj and self.desired_state == process_obj.process_state
 
     def await(self, timeout=0):
         #set up the event gate so that we don't miss any events

--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -65,6 +65,8 @@ class ProcessStateGate(EventSubscriber):
     def in_desired_state(self):
         # check whether the process we are monitoring is in the desired state as of this moment
         process_obj = self.read_process_fn(self.process_id)
+        if not process_obj:
+            return False
         return self.desired_state == process_obj.process_state
 
     def await(self, timeout=0):


### PR DESCRIPTION
If in_desired_state is called before a process is scheduled, the
read_process will return None.  When the method is called it will raise
a AttributeError, Nonetype has no attribute process_state.

This catches this case and simply returns False
