### PR TITLE
Parameter Dictionary refactor and google_dt fix

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -635,10 +635,13 @@ class IONLoader(ImmediateProcess):
         res_obj = self._create_object_from_row("StreamDefinition", row, "sdef/")
         sd_module = row["StreamContainer_module"]
         sd_method = row["StreamContainer_method"]
+        sd_pdict_name = row["StreamContainer_pdict_name"]
         creator_func = named_any("%s.%s" % (sd_module, sd_method))
         sd_container = creator_func()
+        dset_mgmt = self._get_service_client("dataset_management")
+        pdict_id = dset_mgmt.read_parameter_dictionary_by_name(sd_pdict_name, id_only=True)
         svc_client = self._get_service_client("pubsub_management")
-        res_id = svc_client.create_stream_definition( name=res_obj.name, description=res_obj.description)
+        res_id = svc_client.create_stream_definition( name=res_obj.name, parameter_dictionary_id=pdict_id, description=res_obj.description)
         self._register_id(row[self.COL_ID], res_id)
 
     def _load_PlatformDevice(self, row):

--- a/ion/processes/bootstrap/plugins/bootstrap_parameter_definitions.py
+++ b/ion/processes/bootstrap/plugins/bootstrap_parameter_definitions.py
@@ -26,11 +26,13 @@ class BootstrapParameterDefinitions(BootstrapPlugin):
 
 
     def load_contexts(self):
-
-        contexts = {i.name : i for i in build_contexts()} # Thanks to DAF for this pattern
-        for name, context in contexts.iteritems():
-            context_id = self.dataset_management.create_parameter_context(name=name, parameter_context=context.dump())
-            contexts[name] = context_id
+        try:
+            contexts = {i.name : i for i in build_contexts()} # Thanks to DAF for this pattern
+            for name, context in contexts.iteritems():
+                context_id = self.dataset_management.create_parameter_context(name=name, parameter_context=context.dump())
+                contexts[name] = context_id
+        except Exception as e:
+            print 'Exception %s: %s' %(type(e), e.message)
 
         print 'Loaded %s Parameter Contexts' % len(contexts)
         return contexts

--- a/ion/processes/data/example_data_producer.py
+++ b/ion/processes/data/example_data_producer.py
@@ -14,7 +14,6 @@ import gevent
 class BetterDataProducer(SimpleCtdPublisher):
     def on_start(self):
         self.pdict = None
-
         stream_id = self.CFG.get_safe('process.stream_id')
         pubsub_cli = PubsubManagementServiceProcessClient(process=self)
         try: 

--- a/ion/processes/data/transforms/viz/google_dt.py
+++ b/ion/processes/data/transforms/viz/google_dt.py
@@ -13,7 +13,6 @@ from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTo
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
 
 import numpy as np
-import simplejson as json
 
 from pyon.ion.transforma import TransformDataProcess
 
@@ -98,8 +97,7 @@ class VizTransformGoogleDT(TransformDataProcess):
                     "data_description" : data_description,
                     "data_content" : data_table_content}
 
-        json_dump = json.dumps(out_dict)
-        out_rdt["json"] = np.array([json_dump])
+        out_rdt["google_dt_components"] = np.array([out_dict])
         print out_dict
 
         log.debug('Google DT transform: Sending a granule')

--- a/ion/services/ans/test/test_helper.py
+++ b/ion/services/ans/test/test_helper.py
@@ -40,6 +40,10 @@ from pyon.util.containers import get_safe
 
 class VisualizationIntegrationTestHelper(IonIntegrationTestCase):
 
+    def on_start(self):
+        super(VisualizationIntegrationTestHelper, self).on_start()
+
+
     def create_ctd_input_stream_and_data_product(self, data_product_name='ctd_parsed'):
 
         cc = self.container
@@ -363,6 +367,7 @@ class VisualizationIntegrationTestHelper(IonIntegrationTestCase):
     def create_google_dt_data_process_definition(self):
 
         #First look to see if it exists and if not, then create it
+        self.dataset_management =  DatasetManagementServiceClient(node=self.container.node)
         dpd,_ = self.rrclient.find_resources(restype=RT.DataProcessDefinition, name='google_dt_transform')
         if len(dpd) > 0:
             return dpd[0]
@@ -380,9 +385,10 @@ class VisualizationIntegrationTestHelper(IonIntegrationTestCase):
         except Exception as ex:
             self.fail("failed to create new VizTransformGoogleDT data process definition: %s" %ex)
 
+        pdict_id = self.dataset_management.read_parameter_dictionary_by_name('google_dt', id_only=True)
 
         # create a stream definition for the data from the
-        stream_def_id = self.pubsubclient.create_stream_definition(name='VizTransformGoogleDT')
+        stream_def_id = self.pubsubclient.create_stream_definition(name='VizTransformGoogleDT', parameter_dictionary_id=pdict_id)
         self.dataprocessclient.assign_stream_definition_to_data_process_definition(stream_def_id, procdef_id )
 
         return procdef_id

--- a/ion/services/dm/inventory/test/test_dataset_management.py
+++ b/ion/services/dm/inventory/test/test_dataset_management.py
@@ -4,7 +4,6 @@
 @description Unit and Integration test implementations for the data set management service class.
 '''
 from pyon.core.exception import NotFound
-from pyon.datastore.datastore import DataStore
 from pyon.util.containers import DotDict
 from pyon.util.int_test import IonIntegrationTestCase
 from pyon.util.unit_test import PyonTestCase
@@ -20,10 +19,7 @@ from coverage_model.parameter import QuantityType, ParameterContext, ParameterDi
 from nose.plugins.attrib import attr
 from mock import Mock, patch
 
-
 import numpy as np
-import unittest
-
 
 
 @attr('UNIT',group='dm')
@@ -149,6 +145,7 @@ class DatasetManagementIntTest(IonIntegrationTestCase):
 
         self.resource_registry = ResourceRegistryServiceClient()
         self.dataset_management = DatasetManagementServiceClient()
+   
     
     def test_context_crud(self):
         context_ids = self.create_contexts()
@@ -175,15 +172,6 @@ class DatasetManagementIntTest(IonIntegrationTestCase):
         self.assertEquals(pdict.identifier, pdict_res_id)
 
         self.assertEquals(set(pdict_contexts), set(context_ids))
-
-        context_id = context_ids.pop()
-        self.dataset_management.remove_context(parameter_dictionary_id=pdict_res_id, parameter_context_ids=[context_id])
-
-        self.assertTrue(context_id not in self.dataset_management.read_parameter_contexts(parameter_dictionary_id=pdict_res_id, id_only=True))
-
-        self.dataset_management.add_context(parameter_dictionary_id=pdict_res_id, parameter_context_ids=[context_id])
-
-        self.assertTrue(context_id in self.dataset_management.read_parameter_contexts(parameter_dictionary_id=pdict_res_id, id_only=True))
 
         self.dataset_management.delete_parameter_dictionary(parameter_dictionary_id=pdict_res_id)
         with self.assertRaises(NotFound):
@@ -218,3 +206,4 @@ class DatasetManagementIntTest(IonIntegrationTestCase):
         context_ids.append(self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump()))
 
         return context_ids
+

--- a/ion/util/parameter_yaml_IO.py
+++ b/ion/util/parameter_yaml_IO.py
@@ -17,7 +17,7 @@ pdict_as_python_dictionary = pdict.dump()
 '''
 
 from coverage_model.parameter import ParameterDictionary, ParameterContext
-from coverage_model.parameter_types import QuantityType, ArrayType
+from coverage_model.parameter_types import QuantityType, ArrayType, RecordType
 from coverage_model.basic_types import AxisTypeEnum
 import yaml
 from pyon.util.log import log
@@ -146,8 +146,8 @@ def build_contexts():
     content_type_ctxt = ParameterContext(name='content_type', param_type=ArrayType())
     contexts.append(content_type_ctxt)
 
-    json_ctxt = ParameterContext(name='json', param_type=ArrayType())
-    contexts.append(json_ctxt)
+    gdt_ctxt = ParameterContext(name='google_dt_components', param_type=RecordType())
+    contexts.append(gdt_ctxt)
 
     return contexts
 

--- a/ion/util/parameter_yaml_IO.py
+++ b/ion/util/parameter_yaml_IO.py
@@ -146,6 +146,9 @@ def build_contexts():
     content_type_ctxt = ParameterContext(name='content_type', param_type=ArrayType())
     contexts.append(content_type_ctxt)
 
+    json_ctxt = ParameterContext(name='json', param_type=ArrayType())
+    contexts.append(json_ctxt)
+
     return contexts
 
 def dump_param_contexts_to_yml():


### PR DESCRIPTION
# Parameter Dictionaries and Dataset Management

Lots of changes to the flow of things.
- Parameter Dictionaries are stored in the resource registry.
- Parameter Dictionaries are bootstrapped by a [plugin](https://github.com/lukecampbell/coi-services/blob/google_dt/ion/processes/bootstrap/plugins/bootstrap_parameter_definitions.py).
- Stream Definitions can be defined with a [paramter_dictionary_id](https://github.com/lukecampbell/coi-services/blob/google_dt/ion/services/dm/test/test_dm_end_2_end.py#L257) flag. This is the preferred method for defining stream definitions from now on, it makes an association between the stream definition and the paramter dictionary instead of cramming large dictionaries inside every resource, this will save immense amounts of space.
- Paramter Dictionaries can be retrieved using their [name as a key](https://github.com/lukecampbell/coi-services/blob/google_dt/ion/services/dm/inventory/test/test_dataset_management.py#L169). 
# Interface Changes
- DatasetManagement
  - Added parameter_dictionary_id field to create_dataset

```
    def create_dataset(self, name='', datastore_name='', view_name='', stream_id='', parameter_dict=None, spatial_domain=None, temporal_domain=None, parameter_dictionary_id='', description=''):
```

```
- Added read_parameter_context_by_name to Data, this locates the context resouce based on the name.
```

```
    def read_parameter_context(self, parameter_context_id=''):
```

```
- Removed add_context and remove_context, parameter dictionaries must be immutable.

- read_parameter_dictionary_by_name, this gets the parameter dictionary **resource** using the name as a key.  *Note: this is only useful when getting the identifier, otherwise use get_parameter_dictionary_by_name* 

- Pubsub now accepts a parameter dictionary identifier in create_stream_definition

- New Association: StreamDefinition -> ParameterDictionaryResource

- New parameter dictionary for supporting google_dt transform: 'google_dt'
```
# Usage

To get an existing parameter dictionary, like ctd_parsed_param_dict
the following is a wrapper to a dataset management client which gets the resource and compiles the contexts into a ready-to-use parameter dictionary container (from coverage_model).

```
from ion.services.dm.inventory.dataset_management_service import DatasetManagementService

pdict = DatasetManagementService.get_parameter_dictionary_by_name('ctd_parsed_param_dict')
```

To get the identifier for a parameter dictionary and use it to make a stream definition

```
dataset_management = DatasetManagementServiceClient()
pubsub_management  = PubsubManagementServiceClient()

pdict_id = dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict',id_only=True)

stream_definition_id = pubsub_management.create_stream_definition('parsed_stream_def', parameter_dictionary_id=pdict_id)
```

To make a record dictionary tool with a ctd_parsed_param_dict

```
dataset_management = DatasetManagementServiceClient()
pubsub_management  = PubsubManagementServiceClient()

pdict_id = dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict',id_only=True)

stream_definition_id = pubsub_management.create_stream_definition('parsed_stream_def', parameter_dictionary_id=pdict_id)

rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
rdt['time'] = np.arange(20)
rdt['temp'] = ...

```
