### PR TITLE
Observatory management's create_site_data_product() method updated

### DIFF
--- a/ion/processes/data/transforms/logical_transform.py
+++ b/ion/processes/data/transforms/logical_transform.py
@@ -1,21 +1,28 @@
-import commands
-import time
 from gevent.greenlet import Greenlet
-from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
 from pyon.ion.streamproc import StreamProcess
 from ion.core.process.transform import TransformDataProcess
 from pyon.service.service import BaseService
 from pyon.core.exception import BadRequest
 from pyon.public import IonObject, RT, log
 
-
-
 class logical_transform(TransformDataProcess):
 
 
-    # send the packet out the same way it came in
+    def on_start(self):
+        super(logical_transform, self).on_start()
+
+        if not self.CFG.process.publish_streams.has_key('logical'):
+            raise BadRequest("For the logical transform, please send the stream_id using a special keyword (ex: logical)")
+
+        self.logical_stream = self.CFG.process.publish_streams.logical
+
     def recv_packet(self, msg, *args, **kwargs):
-        self.publish(msg)
+        '''
+        Send the packet out the same way it came in
+        '''
+        # Uses a publisher that is dynamically created in order to publish the message
+        self.logical.publish(msg)
 
 
 

--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -100,12 +100,12 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
 
         self.instrument_device   = InstrumentDeviceImpl(new_clients)
         self.platform_device     = PlatformDeviceImpl(new_clients)
-        self.dataproductclient = DataProductManagementServiceClient(node=self.container.node)
-        self.dataprocessclient = DataProcessManagementServiceClient(node=self.container.node)
+        self.dataproductclient = DataProductManagementServiceClient()
+        self.dataprocessclient = DataProcessManagementServiceClient()
 
 
 
-##########################################################################
+    ##########################################################################
     #
     # CRUD OPS
     #

--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -28,6 +28,8 @@ from ion.services.sa.instrument.platform_device_impl import PlatformDeviceImpl
 
 from interface.services.sa.iobservatory_management_service import BaseObservatoryManagementService
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
+from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
+from interface.services.sa.idata_process_management_service import DataProcessManagementServiceClient
 from interface.objects import OrgTypeEnum
 from interface.objects import ProcessDefinition
 
@@ -98,11 +100,12 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
 
         self.instrument_device   = InstrumentDeviceImpl(new_clients)
         self.platform_device     = PlatformDeviceImpl(new_clients)
+        self.dataproductclient = DataProductManagementServiceClient(node=self.container.node)
+        self.dataprocessclient = DataProcessManagementServiceClient(node=self.container.node)
 
 
 
-    
-    ##########################################################################
+##########################################################################
     #
     # CRUD OPS
     #
@@ -568,74 +571,76 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
         # validation
         prods, _ = self.RR.find_objects(site_id, PRED.hasOutputProduct, RT.DataProduct)
         if 0 < len(prods):
-            raise BadRequest("%s '%s' already has an ouptut data product" % (sitetype, site_id))
+            raise BadRequest("%s '%s' already has an output data product" % (sitetype, site_id))
 
         sites, _ = self.RR.find_subjects(sitetype, PRED.hasOutputProduct, data_product_id)
         if 0 < len(sites):
             raise BadRequest("DataProduct '%s' is already an output product of a %s" % (data_product_id, sitetype))
 
         #todo: re-use existing defintion?  how?
-#        log.info("Creating data process definition")
-#        dpd_obj = IonObject(RT.DataProcessDefinition,
-#                            name='SiteDataProduct', #as per Maurice.  todo: constant?
-#                            description=site_id,    #as per Maurice.
-#                            module='ion.processes.data.transforms.logical_transform',
-#                            class_name='logical_transform',
-#                            process_source="For %s '%s'" % (sitetype, site_id))
-
-        ##############
-        #todo: create the process directly through CEI
 
         #-------------------------------
         # Process Definition
         #-------------------------------
-        process_definition = ProcessDefinition()
-        process_definition.name = 'SiteDataProduct'
-        process_definition.description = site_id
-
-        process_definition.executable = {'module':'ion.processes.data.transforms.logical_transform', 'class':'logical_transform'}
-
-        process_dispatcher = ProcessDispatcherServiceClient()
-        process_definition_id = process_dispatcher.create_process_definition(process_definition=process_definition)
+#        process_definition = ProcessDefinition()
+#        process_definition.name = 'SiteDataProduct'
+#        process_definition.description = site_id
+#
+#        process_definition.executable = {'module':'ion.processes.data.transforms.logical_transform', 'class':'logical_transform'}
+#
+#        process_dispatcher = ProcessDispatcherServiceClient()
+#        process_definition_id = process_dispatcher.create_process_definition(process_definition=process_definition)
 
 #        subscription = self.clients.pubsub_management.read_subscription(subscription_id = in_subscription_id)
 #        queue_name = subscription.exchange_name
+#
+#
+#        configuration = DotDict()
+#
+#        configuration['process'] = dict({
+#            'output_streams' : [stream_ids[0]],
+#            'publish_streams': {data_product_id: }
+#        })
+#
+#        # ------------------------------------------------------------------------------------
+#        # Process Spawning
+#        # ------------------------------------------------------------------------------------
+#        # Spawn the process
+#        process_dispatcher.schedule_process(
+#            process_definition_id=process_definition_id,
+#            configuration=configuration
+#        )
+#
+#        ###########
+
+        #----------------------------------------------------------------------------------------------------
+        # Create a data process definition
+        #----------------------------------------------------------------------------------------------------
+
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+            name='SiteDataProduct', #as per Maurice.  todo: constant?
+            description=site_id,    #as per Maurice.
+            module='ion.processes.data.transforms.logical_transform',
+            class_name='logical_transform',
+            process_source="For %s '%s'" % (sitetype, site_id))
+
 
         stream_ids, _ = self.clients.resource_registry.find_objects(data_product_id, PRED.hasStream, RT.Stream, True)
 
-        configuration = DotDict()
+        data_process_def_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
 
-        configuration['process'] = dict({
-            'output_streams' : [stream_ids[0]],
-            'publish_streams': {data_product_id: stream_ids[0]}
-        })
+        #----------------------------------------------------------------------------------------------------
+        # Create a data process
+        #----------------------------------------------------------------------------------------------------
+        data_process_id = self.dataprocessclient.create_data_process(data_process_def_id, None,{"logical":data_product_id})
 
-        # ------------------------------------------------------------------------------------
-        # Process Spawning
-        # ------------------------------------------------------------------------------------
-        # Spawn the process
-        process_dispatcher.schedule_process(
-            process_definition_id=process_definition_id,
-            configuration=configuration
-        )
+        self.dataprocessclient.activate_data_process(data_process_id)
 
-        ###########
-
-#        logical_transform_dprocdef_id = self.PRMS.create_data_process_definition(dpd_obj)
-#
-#
-#        log.info("Creating data process")
-#        dproc_id = self.PRMS.create_data_process(logical_transform_dprocdef_id,  {"output":data_product_id})
-#        log.info("Created data process")
-
-        log.info("associating site hasOutputProduct")
         #make it all happen
         if RT.InstrumentSite == sitetype:
             self.instrument_site.link_output_product(site_id, data_product_id)
         elif RT.PlatformSite == sitetype:
             self.platform_site.link_output_product(site_id, data_product_id)
-
-
 
 
     def streamdef_of_site(self, site_id):

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -57,7 +57,6 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
 
 
 
-#    @unittest.skip('not working')
     def test_createDataProcess(self):
 
         #-------------------------------
@@ -100,10 +99,7 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         #-------------------------------
         log.debug("TestIntDataProcessMgmtServiceMultiOut: create input data product")
 
-
-
         tdom, sdom = time_series_domain()
-
         sdom = sdom.dump()
         tdom = tdom.dump()
 
@@ -193,7 +189,6 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
 
 
 
-#    @unittest.skip('not working..')
     @patch.dict(CFG, {'endpoint':{'receive':{'timeout': 60}}})
     def test_createDataProcessUsingSim(self):
         #-------------------------------


### PR DESCRIPTION
The create_site_data_product() method of observatory management service has been updated so that it creates a data process and launches it instead of using cei to create a process definition and launch it through a process_dispatcher.schedule_process().

No one should be affected by the code change as it only affects the above method of observatory management in the described way.

However, to make things work, the create_data_process() method in data_process_management was made stable for the case where one uses it but does not pass in any input data product ids (which is the usual situation in observatory related stuff). The method was made stable so that it will work correctly even if no input data product ids are provided.

Also, the logical transform was converted to the new transform design.
