### PR TITLE
Incorporate the use of the temporal bounds attribute of NotificationRequests in UNS

### DIFF
--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1252,8 +1252,8 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Set up a time for the scheduler to trigger timer events
         #--------------------------------------------------------------------------------
         # Trigger the timer event 10 seconds later from now
-        now = datetime.utcnow() + timedelta(seconds=15)
-        times_of_day =[{'hour': str(now.hour),'minute' : str(now.minute), 'second':str(now.second) }]
+        time_now = datetime.utcnow() + timedelta(seconds=15)
+        times_of_day =[{'hour': str(time_now.hour),'minute' : str(time_now.minute), 'second':str(time_now.second) }]
 
         #--------------------------------------------------------------------------------
         # Publish the events that the user will later be notified about

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -523,11 +523,11 @@ class UserNotificationService(BaseUserNotificationService):
 
         self.event_processor.stop_notification_subscriber(notification_request=notification_request)
 
-        #-------------------------------------------------------------------------------------------------------------------
-        # delete the notification from the user_info and reverse_user_info dictionaries
-        #-------------------------------------------------------------------------------------------------------------------
-
-        self.delete_notification_from_user_info(notification_id)
+#        #-------------------------------------------------------------------------------------------------------------------
+#        # delete the notification from the user_info and reverse_user_info dictionaries
+#        #-------------------------------------------------------------------------------------------------------------------
+#
+#        self.delete_notification_from_user_info(notification_id)
 
         #-------------------------------------------------------------------------------------------------------------------
         # update the resource registry

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -33,9 +33,9 @@ class FakeScheduler(object):
         # Calculate the time to wait
         #------------------------------------------------------------------------------------
         wait_time = datetime.timedelta( days = task_time.day - current_time.day,
-                                        hours = task_time.hour - current_time.hour,
-                                        minutes = task_time.minute - current_time.minute,
-                                        seconds = task_time.second - current_time.second)
+            hours = task_time.hour - current_time.hour,
+            minutes = task_time.minute - current_time.minute,
+            seconds = task_time.second - current_time.second)
 
         log.info("Fake scheduler calculated wait_time = %s" % wait_time)
 
@@ -181,8 +181,8 @@ def check_user_notification_interest(event, reverse_user_info):
     if not isinstance(event, Event):
         raise BadRequest("The input parameter should have been an Event.")
 
-    if reverse_user_info.has_key('event_origin') and \
-       reverse_user_info.has_key('event_origin_type') and \
+    if reverse_user_info.has_key('event_origin') and\
+       reverse_user_info.has_key('event_origin_type') and\
        reverse_user_info.has_key('event_type') and\
        reverse_user_info.has_key('event_subtype'):
         pass
@@ -249,8 +249,13 @@ def calculate_reverse_user_info(user_info=None):
 
             for notification in notifications:
 
+                # If the notification has expired, do not keep it in the reverse user info that the notification
+                # workers use
+                if notification.temporal_bounds.end_datetime:
+                    continue
+
                 if not isinstance(notification, NotificationRequest):
-                    break
+                    continue
 
                 if dict_1.has_key(notification.event_type) and notification.event_type:
                     dict_1[notification.event_type].append(user_name)


### PR DESCRIPTION
### Who are affected?

No one should be affected.

These changes should not be affecting anyone right now. Right now temporal bounds are not used outside UNS.
### What's the result

Temporal bounds have start_datetime and end_datetime attributes. When the operator creates a notification using create_notification(), the start_datetime value is filled to the current time value (in seconds, for now).

When a delete_notification() method is used, the end_datetime field of the notification request is filled in. The notification request can then be considered to have been retired.

Users do not receive notification pertaining to the retired notification.
