### PR TITLE
Event alert  and stream alert transforms

### DIFF
--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -34,7 +34,7 @@ class EventAlertTransform(TransformEventListener):
         self.instrument_event_queue = gevent.queue.Queue()
 
         def timer_event_received(message, headers):
-            log.debug("Got an instrument event here::: %s" % message)
+            log.debug("EventAlertTransform received an instrument event here::: %s" % message)
             self.instrument_event_queue.put(message)
 
         self.timer_event_subscriber = EventSubscriber(origin = self.instrument_origin,
@@ -57,11 +57,6 @@ class EventAlertTransform(TransformEventListener):
         The callback method.
         If the events satisfy the criteria, publish an alert event.
         '''
-
-        log.debug("got a timer event!! %s" % msg)
-
-#        if msg.event_origin != self.timer_origin:
-#            return
 
         if self.instrument_event_queue.empty():
             log.debug("no event received from the instrument. Publishing an alarm event!")
@@ -95,7 +90,7 @@ class StreamAlertTransform(TransformStreamListener):
         The callback method.
         If the events satisfy the criteria, publish an alert event.
         '''
-        log.info('Got incoming packet')
+        log.debug('StreamAlertTransform got an incoming packet!')
 
         value = self._extract_parameters_from_stream(msg, "VALUE")
 

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -7,7 +7,7 @@
 '''
 from pyon.util.log import log
 from pyon.event.event import EventPublisher, EventSubscriber
-from ion.core.process.transform import TransformEventListener, TransformStreamListener
+from ion.core.process.transform import TransformEventListener, TransformStreamListener, TransformEventPublisher
 import gevent
 from gevent import queue
 
@@ -75,15 +75,11 @@ class EventAlertTransform(TransformEventListener):
                                             origin="EventAlertTransform",
                                             description= "An alert event being published.")
 
-class StreamAlertTransform(TransformStreamListener):
+class StreamAlertTransform(TransformStreamListener, TransformEventPublisher):
 
     def on_start(self):
         super(StreamAlertTransform,self).on_start()
         self.value = self.CFG.get_safe('process.value', 0)
-
-
-        # Create the publisher that will publish the Alert message
-        self.event_publisher = EventPublisher()
 
     def recv_packet(self, msg, stream_route, stream_id):
         '''
@@ -101,9 +97,8 @@ class StreamAlertTransform(TransformStreamListener):
         '''
         Publish an alert event
         '''
-        self.event_publisher.publish_event( event_type= "DeviceEvent",
-                                            origin="StreamAlertTransform",
-                                            description= "An alert event being published.")
+        self.publisher.publish_event(origin="StreamAlertTransform",
+                                    description= "An alert event being published.")
 
     def _extract_parameters_from_stream(self, msg, field ):
 

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -28,7 +28,7 @@ class EventAlertTransform(TransformEventListener):
         self.event_times = []
 
         #-------------------------------------------------------------------------------------
-        # Set up a listener for scheduler events
+        # Set up a listener for instrument events
         #-------------------------------------------------------------------------------------
 
         self.instrument_event_queue = gevent.queue.Queue()

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -200,7 +200,8 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         config = {
             'process':{
                 'queue_name': 'a_queue',
-                'value': 10
+                'value': 10,
+                'event_type':'DeviceEvent'
             }
         }
 
@@ -229,7 +230,8 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         pub = StandaloneStreamPublisher('stream_id', stream_route)
 
         message = "A dummy example message containing the word PUBLISH, and with VALUE = 5 . This message" + \
-                    " will trigger an alert event from the StreamAlertTransform"
+                    " will trigger an alert event from the StreamAlertTransform because the value provided is " \
+                    "less than 10 that was passed in through the config."
 
         pub.publish(message)
 


### PR DESCRIPTION
Modifies the event alert transform and stream alert transform.

Integrates Scheduler with the event alert transform that does event-in/event-out processing

The event alert transform is an event-in/event-out transform that publishes an alarm event if no event has arrived from an instrument within two timer events... note that the scheduler can be set up to publish timer events at specified time interval continuously (akin to a heartbeat).

The stream alert transform is designed as a stream-in/event-out transform. The transform listens to a stream being published somewhere (like an instrument publishing data) and publishes an alarm event if something in the published data's content matches a condition (ex: VALUE = 5 is less than a value passed in through the config that is used to launch this transform).

This transforms are aligned with the latest transform architecture.

The tests for the two transforms are here:
ion/processes/data/transforms/test/test_transform_prototype.py
