### PR TITLE
Removed an offending log warning from UNS get_user_notifications()

### DIFF
--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -734,9 +734,6 @@ class UserNotificationService(BaseUserNotificationService):
         if not user:
             return None
 
-        if not isinstance(user, UserInfo):
-            log.warning("UserNotificationService.get_user_notifications() got resource id not of the type UserInfo!")
-
         if not user.name:
             raise BadRequest("Please assign a name to the resource. Example: resource.name = \'Irene\' for UNS to "
                              "be able to fetch the related notifications")


### PR DESCRIPTION
This log was not necessary. It was generating a warning. But it was not really an error. Removing it here.
