### PR TITLE
Get subscriptions using UNS

### DIFF
--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -97,19 +97,19 @@ class NotificationWorker(TransformEventListener):
         # From the reverse user info dict find out which users have subscribed to that event
         #------------------------------------------------------------------------------------
 
-        users = []
+        user_ids = []
         if self.reverse_user_info:
-            users = check_user_notification_interest(event = msg, reverse_user_info = self.reverse_user_info)
+            user_ids = check_user_notification_interest(event = msg, reverse_user_info = self.reverse_user_info)
 
         log.debug("Type of event received by notification worker: %s" % msg.type_)
-        log.debug("Notification worker deduced the following users were interested in the event: %s" % users )
+        log.debug("Notification worker deduced the following users were interested in the event: %s" % user_ids )
 
         #------------------------------------------------------------------------------------
         # Send email to the users
         #------------------------------------------------------------------------------------
 
-        for user_name in users:
-            msg_recipient = self.user_info[user_name]['user_contact'].email
+        for user_id in user_ids:
+            msg_recipient = self.user_info[user_id]['user_contact'].email
             send_email(message = msg, msg_recipient = msg_recipient, smtp_client = self.smtp_client )
 
     def on_stop(self):
@@ -144,6 +144,6 @@ class NotificationWorker(TransformEventListener):
                 if variable['name'] == 'notifications':
                     notifications = variable['value']
 
-            user_info[user.name] = { 'user_contact' : user.contact, 'notifications' : notifications}
+            user_info[user._id] = { 'user_contact' : user.contact, 'notifications' : notifications}
 
         return user_info

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1508,3 +1508,13 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         success = self.event_poll(poller, 10)
         self.assertTrue(success)
+
+    def test_get_subscriptions(self):
+        '''
+        Test that the get
+        '''
+
+        #--------------------------------------------------------------------------------------
+        # create user with email address in RR
+        #--------------------------------------------------------------------------------------
+

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -483,23 +483,23 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         notification_request_2 = self.rrc.read(notification_id_2)
 
         # check user_info dictionary
-        self.assertEquals(proc1.event_processor.user_info['user_1']['user_contact'].email, 'user_1@gmail.com' )
-        self.assertEquals(proc1.event_processor.user_info['user_1']['notifications'], [notification_request_correct])
+        self.assertEquals(proc1.event_processor.user_info[user_id_1]['user_contact'].email, 'user_1@gmail.com' )
+        self.assertEquals(proc1.event_processor.user_info[user_id_1]['notifications'], [notification_request_correct])
 
-        self.assertEquals(proc1.event_processor.user_info['user_2']['user_contact'].email, 'user_2@gmail.com' )
-        self.assertEquals(proc1.event_processor.user_info['user_2']['notifications'], [notification_request_2])
+        self.assertEquals(proc1.event_processor.user_info[user_id_2]['user_contact'].email, 'user_2@gmail.com' )
+        self.assertEquals(proc1.event_processor.user_info[user_id_2]['notifications'], [notification_request_2])
 
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin']['instrument_1'], ['user_1'])
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin']['instrument_2'], ['user_2'])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin']['instrument_1'], [user_id_1])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin']['instrument_2'], [user_id_2])
 
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_type']['ResourceLifecycleEvent'], ['user_1'])
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_type']['DetectionEvent'], ['user_2'])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_type']['ResourceLifecycleEvent'], [user_id_1])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_type']['DetectionEvent'], [user_id_2])
 
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_subtype']['subtype_1'], ['user_1'])
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_subtype']['subtype_2'], ['user_2'])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_subtype']['subtype_1'], [user_id_1])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_subtype']['subtype_2'], [user_id_2])
 
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin_type']['type_1'], ['user_1'])
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin_type']['type_2'], ['user_2'])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin_type']['type_1'], [user_id_1])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin_type']['type_2'], [user_id_2])
 
         log.debug("The event processor received the notification topics after a create_notification() for two users")
         log.debug("Verified that the event processor correctly updated its user info dictionaries")
@@ -510,21 +510,21 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         self.unsc.create_notification(notification=notification_request_2, user_id=user_id_1)
 
         # Check in UNS ------------>
-        self.assertEquals(proc1.event_processor.user_info['user_1']['user_contact'].email, 'user_1@gmail.com' )
+        self.assertEquals(proc1.event_processor.user_info[user_id_1]['user_contact'].email, 'user_1@gmail.com' )
 
-        self.assertEquals(proc1.event_processor.user_info['user_1']['notifications'], [notification_request_correct, notification_request_2])
+        self.assertEquals(proc1.event_processor.user_info[user_id_1]['notifications'], [notification_request_correct, notification_request_2])
 
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin']['instrument_1'], ['user_1'])
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin']['instrument_2'], ['user_2', 'user_1'])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin']['instrument_1'], [user_id_1])
+        self.assertEquals(set(proc1.event_processor.reverse_user_info['event_origin']['instrument_2']), set([user_id_2, user_id_1]))
 
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_type']['ResourceLifecycleEvent'], ['user_1'])
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_type']['DetectionEvent'], ['user_2', 'user_1'])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_type']['ResourceLifecycleEvent'], [user_id_1])
+        self.assertEquals(set(proc1.event_processor.reverse_user_info['event_type']['DetectionEvent']), set([user_id_2, user_id_1]))
 
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_subtype']['subtype_1'], ['user_1'])
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_subtype']['subtype_2'], ['user_2', 'user_1'])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_subtype']['subtype_1'], [user_id_1])
+        self.assertEquals(set(proc1.event_processor.reverse_user_info['event_subtype']['subtype_2']), set([user_id_2, user_id_1]))
 
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin_type']['type_1'], ['user_1'])
-        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin_type']['type_2'], ['user_2', 'user_1'])
+        self.assertEquals(proc1.event_processor.reverse_user_info['event_origin_type']['type_1'], [user_id_1])
+        self.assertEquals(set(proc1.event_processor.reverse_user_info['event_origin_type']['type_2']), set([user_id_2, user_id_1]))
 
         log.debug("The event processor received the notification topics after another create_notification() for the first user")
         log.debug("Verified that the event processor correctly updated its user info dictionaries")
@@ -543,11 +543,11 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         notification_request_correct = self.rrc.read(notification_id_1)
 
         # check that the updated notification is in the user info dictionary
-        self.assertTrue(notification_request_correct in proc1.event_processor.user_info['user_1']['notifications'] )
+        self.assertTrue(notification_request_correct in proc1.event_processor.user_info[user_id_1]['notifications'] )
 
         # check that the notifications in the user info dictionary got updated
         update_worked = False
-        for notification in proc1.event_processor.user_info['user_1']['notifications']:
+        for notification in proc1.event_processor.user_info[user_id_1]['notifications']:
             if notification.origin == "newly_changed_instrument":
                 update_worked = True
                 break
@@ -555,7 +555,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         self.assertTrue(update_worked)
 
         # reverse_user_info
-        self.assertTrue('user_1' in proc1.event_processor.reverse_user_info['event_origin']["newly_changed_instrument"])
+        self.assertTrue(user_id_1 in proc1.event_processor.reverse_user_info['event_origin']["newly_changed_instrument"])
 
         log.debug("Verified that the event processor correctly updated its user info dictionaries after an update_notification()")
 
@@ -565,18 +565,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         self.unsc.delete_notification(notification_id_2)
 
-        # Check for UNS ------->
-
-    #        # check that the notification is not there anymore in the resource registry
-    #        with self.assertRaises(NotFound):
-    #            notification = self.rrc.read(notification_id_2)
-
-    #        # check that the user_info dictionary for the user is not holding the notification anymore
-    #        self.assertFalse(notification_request_2 in proc1.event_processor.user_info['user_1']['notifications'])
-    #
-    #        log.debug("Verified that the event processor correctly updated its user info dictionaries after an delete_notification()")
-    #
-    #        log.debug("REQ: L4-CI-DM-RQ-56 was satisfied here for UNS")
 
     @attr('LOCOINT')
     @unittest.skipIf(not use_es, 'No ElasticSearch')
@@ -655,13 +643,13 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # read back the registered notification request objects
         notification_request_correct = self.rrc.read(notification_id_1)
 
-        self.assertEquals(reloaded_user_info['new_user']['notifications'], [notification_request_correct] )
-        self.assertEquals(reloaded_user_info['new_user']['user_contact'].email, 'new_user@gmail.com')
+        self.assertEquals(reloaded_user_info[user_id]['notifications'], [notification_request_correct] )
+        self.assertEquals(reloaded_user_info[user_id]['user_contact'].email, 'new_user@gmail.com')
 
-        self.assertEquals(reloaded_reverse_user_info['event_origin']['instrument_1'], ['new_user'] )
-        self.assertEquals(reloaded_reverse_user_info['event_subtype']['subtype_1'], ['new_user'] )
-        self.assertEquals(reloaded_reverse_user_info['event_type']['ResourceLifecycleEvent'], ['new_user'] )
-        self.assertEquals(reloaded_reverse_user_info['event_origin_type']['type_1'], ['new_user'] )
+        self.assertEquals(reloaded_reverse_user_info['event_origin']['instrument_1'], [user_id] )
+        self.assertEquals(reloaded_reverse_user_info['event_subtype']['subtype_1'], [user_id] )
+        self.assertEquals(reloaded_reverse_user_info['event_type']['ResourceLifecycleEvent'], [user_id] )
+        self.assertEquals(reloaded_reverse_user_info['event_origin_type']['type_1'], [user_id] )
 
         log.debug("Verified that the notification worker correctly updated its user info dictionaries after a create_notification()")
 
@@ -680,19 +668,19 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         notification_request_2 = self.rrc.read(notification_id_2)
 
 
-        self.assertEquals(reloaded_user_info['new_user']['notifications'], [notification_request_correct, notification_request_2] )
+        self.assertEquals(reloaded_user_info[user_id]['notifications'], [notification_request_correct, notification_request_2] )
 
-        self.assertEquals(reloaded_reverse_user_info['event_origin']['instrument_1'], ['new_user'] )
-        self.assertEquals(reloaded_reverse_user_info['event_origin']['instrument_2'], ['new_user'] )
+        self.assertEquals(reloaded_reverse_user_info['event_origin']['instrument_1'], [user_id] )
+        self.assertEquals(reloaded_reverse_user_info['event_origin']['instrument_2'], [user_id] )
 
-        self.assertEquals(reloaded_reverse_user_info['event_subtype']['subtype_1'], ['new_user'] )
-        self.assertEquals(reloaded_reverse_user_info['event_subtype']['subtype_2'], ['new_user'] )
+        self.assertEquals(reloaded_reverse_user_info['event_subtype']['subtype_1'], [user_id] )
+        self.assertEquals(reloaded_reverse_user_info['event_subtype']['subtype_2'], [user_id] )
 
-        self.assertEquals(reloaded_reverse_user_info['event_type']['ResourceLifecycleEvent'], ['new_user'] )
-        self.assertEquals(reloaded_reverse_user_info['event_type']['DetectionEvent'], ['new_user'] )
+        self.assertEquals(reloaded_reverse_user_info['event_type']['ResourceLifecycleEvent'], [user_id] )
+        self.assertEquals(reloaded_reverse_user_info['event_type']['DetectionEvent'], [user_id] )
 
-        self.assertEquals(reloaded_reverse_user_info['event_origin_type']['type_1'], ['new_user'] )
-        self.assertEquals(reloaded_reverse_user_info['event_origin_type']['type_2'], ['new_user'] )
+        self.assertEquals(reloaded_reverse_user_info['event_origin_type']['type_1'], [user_id] )
+        self.assertEquals(reloaded_reverse_user_info['event_origin_type']['type_2'], [user_id] )
 
         log.debug("Verified that the notification worker correctly updated its user info dictionaries after another create_notification()")
 
@@ -1612,7 +1600,11 @@ class UserNotificationIntTest(IonIntegrationTestCase):
             self.assertEquals(notific.origin, data_product_id)
             self.assertNotEquals(notific.temporal_bounds.end_datetime, '')
 
-        #--------------------------------------------------------------------------------------
+        log.debug("Verified that the event processor correctly updated its user info dictionaries after an delete_notification()")
+        log.debug("REQ: L4-CI-DM-RQ-56 was satisfied here for UNS")
+
+
+    #--------------------------------------------------------------------------------------
         # Use UNS to get the all subscriptions --- including retired
         #--------------------------------------------------------------------------------------
         result_notifications, _ = self.unsc.get_subscriptions(resource_id=data_product_id, include_retired=True)

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -83,8 +83,6 @@ class UserNotificationTest(PyonTestCase):
         self.user_notification.event_publisher = EventPublisher()
         self.user_notification.event_processor = EmailEventProcessor('an_smtp_client')
 
-
-    #    @unittest.skip('Bad test - figure out how to patch out the greenlet start...')
     def test_create_notification(self):
         '''
         Test creating a notification

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -178,6 +178,11 @@ class UserNotificationTest(PyonTestCase):
         self.user_notification.update_user_info_dictionary = mocksignature(self.user_notification.update_user_info_dictionary)
         self.user_notification.update_user_info_dictionary.return_value = ''
 
+        self.user_notification.notifications = []
+
+        self.user_notification._update_notification_in_notifications_dict = mocksignature(self.user_notification._update_notification_in_notifications_dict)
+        self.user_notification.update_user_info_dictionary.return_value = ''
+
         self.user_notification.event_publisher.publish_event = mocksignature(self.user_notification.event_publisher.publish_event)
 
         #-------------------------------------------------------------------------------------------------------------------
@@ -1603,14 +1608,14 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------------
         # Use UNS to get the subscriptions
         #--------------------------------------------------------------------------------------
-        result_notifications= self.unsc.get_subscriptions(resource_id=data_product_id, include_nonactive=False)
+        res_notifs= self.unsc.get_subscriptions(resource_id=data_product_id, include_nonactive=False)
 
-        log.debug("result_notifications::: %s" % result_notifications)
-        log.debug("number of result_notifications::: %s" % len(result_notifications))
+        log.debug("res_notifs::: %s" % res_notifs)
+        log.debug("number of res_notifs::: %s" % len(res_notifs))
 
-        self.assertEquals(len(result_notifications), 2)
+        self.assertEquals(len(res_notifs), 1)
 
-        for notific in result_notifications:
+        for notific in res_notifs:
             self.assertEquals(notific.origin, data_product_id)
             self.assertEquals(notific.temporal_bounds.end_datetime, '')
 
@@ -1621,11 +1626,11 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------------
         # Use UNS to get the all subscriptions --- including retired
         #--------------------------------------------------------------------------------------
-        result_notifications = self.unsc.get_subscriptions(resource_id=data_product_id, include_nonactive=True)
+        res_notifs = self.unsc.get_subscriptions(resource_id=data_product_id, include_nonactive=True)
 
-        for notific in result_notifications:
+        for notific in res_notifs:
             self.assertEquals(notific.origin, data_product_id)
 
-        self.assertEquals(len(result_notifications), 2)
+        self.assertEquals(len(res_notifs), 2)
 
-        log.debug("All subscriptions, number::: %s" % len(result_notifications))
+        log.debug("All subscriptions, number::: %s" % len(res_notifs))

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1511,10 +1511,12 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
     def test_get_subscriptions(self):
         '''
-        Test that the get
+        Test that the get_subscriptions, get_active_subscriptions and get_past_active_subscriptions
+        methods are working correctly
         '''
 
         #--------------------------------------------------------------------------------------
         # create user with email address in RR
         #--------------------------------------------------------------------------------------
 
+        pass

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -96,9 +96,16 @@ class UserNotificationTest(PyonTestCase):
         self.mock_rr_client.read = mocksignature(self.mock_rr_client.read)
         self.mock_rr_client.read.return_value = 'notification'
 
+        self.user_notification.notifications = {}
+
         self.user_notification.event_processor.add_notification_for_user = mocksignature(self.user_notification.event_processor.add_notification_for_user)
 
         self.user_notification.event_publisher.publish_event = mocksignature(self.user_notification.event_publisher.publish_event)
+
+        self.user_notification._notification_in_notifications = mocksignature(self.user_notification._notification_in_notifications)
+        self.user_notification._notification_in_notifications.return_value = None
+
+        self.mock_rr_client.create_association = mocksignature(self.mock_rr_client.create_association)
 
         #-------------------------------------------------------------------------------------------------------------------
         # Create a notification object

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1352,17 +1352,17 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         ar_1 = gevent.event.AsyncResult()
         ar_2 = gevent.event.AsyncResult()
 
-        def send_email(events_for_message, user_name):
+        def send_email(events_for_message, user_id):
             log.warning("(in asyncresult) events_for_message: %s" % events_for_message)
             ar_1.set(events_for_message)
-            ar_2.set(user_name)
+            ar_2.set(user_id)
 
         proc.format_and_send_email = send_email
 
         events_for_message = ar_1.get(timeout=20)
-        user_name = ar_2.get(timeout=20)
+        user_id = ar_2.get(timeout=20)
 
-        log.warning("user_name: %s" % user_name)
+        log.warning("user_id: %s" % user_id)
 
         origins_of_events = Set()
         times = Set()

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -197,7 +197,7 @@ class UserNotificationTest(PyonTestCase):
 
         self.mock_rr_client.update.assert_called_once_with(notification_request)
         self.user_notification.update_user_info_object.assert_called_once_with(user_id, notification, notification)
-        self.user_notification.update_user_info_dictionary.assert_called_once_with('user', notification, notification)
+        self.user_notification.update_user_info_dictionary.assert_called_once_with('user_id_1', notification, notification)
 
 
     def test_delete_user_notification(self):

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1575,14 +1575,24 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Make notification request objects -- Remember to put names
         #--------------------------------------------------------------------------------------
 
-        notification_active = NotificationRequest(   name = "notification_1",
+        notification_active_1 = NotificationRequest(   name = "notification_1",
             origin=data_product_id,
             origin_type="type_1",
             event_type='ResourceLifecycleEvent')
 
-        notification_past = NotificationRequest(   name = "notification_2",
+        notification_active_2 = NotificationRequest(   name = "notification_2",
             origin=data_product_id,
             origin_type="type_2",
+            event_type='ResourceLifecycleEvent')
+
+        notification_past_1 = NotificationRequest(   name = "notification_3_to_be_retired",
+            origin=data_product_id,
+            origin_type="type_3",
+            event_type='DetectionEvent')
+
+        notification_past_2 = NotificationRequest(   name = "notification_4_to_be_retired",
+            origin=data_product_id,
+            origin_type="type_4",
             event_type='DetectionEvent')
 
         #--------------------------------------------------------------------------------------
@@ -1592,11 +1602,19 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         past_notification_ids = set()
 
         for user_id in user_ids:
-            notification_id_active =  self.unsc.create_notification(notification=notification_active, user_id=user_id)
-            active_notification_ids.add(notification_id_active)
+            notification_id_active_1 =  self.unsc.create_notification(notification=notification_active_1, user_id=user_id)
+            notification_id_active_2 =  self.unsc.create_notification(notification=notification_active_2, user_id=user_id)
 
-            notification_id_past =  self.unsc.create_notification(notification=notification_past, user_id=user_id)
-            past_notification_ids.add(notification_id_past)
+            # Store the ids for the active notifications in a set
+            active_notification_ids.add(notification_id_active_1)
+            active_notification_ids.add(notification_id_active_2)
+
+            notification_id_past_1 =  self.unsc.create_notification(notification=notification_past_1, user_id=user_id)
+            notification_id_past_2 =  self.unsc.create_notification(notification=notification_past_2, user_id=user_id)
+
+            # Store the ids for the retired-to-be notifications in a set
+            past_notification_ids.add(notification_id_past_1)
+            past_notification_ids.add(notification_id_past_2)
 
         log.debug("len(active_notification_ids)::: %s" % len(active_notification_ids))
         log.debug("len(past_notification_ids)::: %s" % len(past_notification_ids))
@@ -1613,7 +1631,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         log.debug("res_notifs::: %s" % res_notifs)
         log.debug("number of res_notifs::: %s" % len(res_notifs))
 
-        self.assertEquals(len(res_notifs), 1)
+        self.assertEquals(len(res_notifs), 2)
 
         for notific in res_notifs:
             self.assertEquals(notific.origin, data_product_id)
@@ -1631,6 +1649,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         for notific in res_notifs:
             self.assertEquals(notific.origin, data_product_id)
 
-        self.assertEquals(len(res_notifs), 2)
+        self.assertEquals(len(res_notifs), 4)
 
         log.debug("All subscriptions, number::: %s" % len(res_notifs))

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -557,11 +557,15 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         log.debug("Verified that the event processor correctly updated its user info dictionaries after an update_notification()")
 
-        #--------------------------------------------------------------------------------------
-        # Delete notification and check that the user_info and reverse_user_info in UNS got reloaded
-        #--------------------------------------------------------------------------------------
+        #--------------------------------------------------------------------------------------------------------------------------------------
+        # Delete notification and check. Whether the user_info and reverse_user_info in UNS got reloaded is done in test_get_subscriptions()
+        #--------------------------------------------------------------------------------------------------------------------------------------
 
         self.unsc.delete_notification(notification_id_2)
+
+        notific = self.rrc.read(notification_id_2)
+        # This checks that the notification has been retired.
+        self.assertNotEquals(notific.temporal_bounds.end_datetime, '')
 
 
     @attr('LOCOINT')
@@ -1058,11 +1062,11 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         self.unsc.delete_notification(notification_id1)
         self.unsc.delete_notification(notification_id2)
 
-    #        # check that the notifications are not there
-    #        with self.assertRaises(NotFound):
-    #            notific1 = self.unsc.read_notification(notification_id1)
-    #        with self.assertRaises(NotFound):
-    #            notific2 = self.unsc.read_notification(notification_id2)
+        notific_1 = self.rrc.read(notification_id1)
+        notific_2 = self.rrc.read(notification_id2)
+        # This checks that the notifications have been retired.
+        self.assertNotEquals(notific_1.temporal_bounds.end_datetime, '')
+        self.assertNotEquals(notific_2.temporal_bounds.end_datetime, '')
 
     @attr('LOCOINT')
     @unittest.skipIf(not use_es, 'No ElasticSearch')

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -579,6 +579,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # This checks that the notification has been retired.
         self.assertNotEquals(notific.temporal_bounds.end_datetime, '')
 
+        log.debug("REQ: L4-CI-DM-RQ-56 was satisfied here for UNS")
 
     @attr('LOCOINT')
     @unittest.skipIf(not use_es, 'No ElasticSearch')
@@ -1616,10 +1617,10 @@ class UserNotificationIntTest(IonIntegrationTestCase):
             past_notification_ids.add(notification_id_past_1)
             past_notification_ids.add(notification_id_past_2)
 
-        log.debug("len(active_notification_ids)::: %s" % len(active_notification_ids))
-        log.debug("len(past_notification_ids)::: %s" % len(past_notification_ids))
+        log.debug("Number of active notification ids: %s" % len(active_notification_ids))
+        log.debug("Number of past notification ids: %s" % len(past_notification_ids))
 
-        # Retire some notifications
+        # Retire the retired-to-be notifications
         for notific_id in past_notification_ids:
             self.unsc.delete_notification(notification_id=notific_id)
 
@@ -1628,17 +1629,14 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------------
         res_notifs= self.unsc.get_subscriptions(resource_id=data_product_id, include_nonactive=False)
 
-        log.debug("res_notifs::: %s" % res_notifs)
-        log.debug("number of res_notifs::: %s" % len(res_notifs))
+        log.debug("Result for subscriptions: %s" % res_notifs)
+        log.debug("Number of subscriptions returned: %s" % len(res_notifs))
 
         self.assertEquals(len(res_notifs), 2)
 
         for notific in res_notifs:
             self.assertEquals(notific.origin, data_product_id)
             self.assertEquals(notific.temporal_bounds.end_datetime, '')
-
-        log.debug("Verified that the event processor correctly updated its user info dictionaries after an delete_notification()")
-        log.debug("REQ: L4-CI-DM-RQ-56 was satisfied here for UNS")
 
 
         #--------------------------------------------------------------------------------------
@@ -1651,4 +1649,4 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         self.assertEquals(len(res_notifs), 4)
 
-        log.debug("All subscriptions, number::: %s" % len(res_notifs))
+        log.debug("Number of subscriptions including retired notifications: %s" % len(res_notifs))

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1560,15 +1560,18 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------------
         # Create notifications using UNS.
         #--------------------------------------------------------------------------------------
-        active_notification_ids = []
-        past_notification_ids = []
+        active_notification_ids = set()
+        past_notification_ids = set()
 
         for user_id in user_ids:
             notification_id_active =  self.unsc.create_notification(notification=notification_active, user_id=user_id)
-            active_notification_ids.append(notification_id_active)
+            active_notification_ids.add(notification_id_active)
 
             notification_id_past =  self.unsc.create_notification(notification=notification_past, user_id=user_id)
-            past_notification_ids.append(notification_id_past)
+            past_notification_ids.add(notification_id_past)
+
+        log.debug("len(active_notification_ids)::: %s" % len(active_notification_ids))
+        log.debug("len(past_notification_ids)::: %s" % len(past_notification_ids))
 
         # Retire some notifications
         for notific_id in past_notification_ids:

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1533,6 +1533,9 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         success = self.event_poll(poller, 10)
         self.assertTrue(success)
 
+    @attr('LOCOINT')
+    @unittest.skipIf(not use_es, 'No ElasticSearch')
+    @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Skip test while in CEI LAUNCH mode')
     def test_get_subscriptions(self):
         '''
         Test that the get_subscriptions works correctly

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1574,42 +1574,32 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         for notific_id in past_notification_ids:
             self.unsc.delete_notification(notification_id=notific_id)
 
-        all_notification_ids = active_notification_ids + past_notification_ids
-
         #--------------------------------------------------------------------------------------
         # Use UNS to get the subscriptions
         #--------------------------------------------------------------------------------------
-        result_notifications, _ = self.unsc.get_subscriptions(resource_id=data_product_id, include_retired=False)
-        result_active_notifications, _ = self.unsc.get_active_subscriptions(resource_id=data_product_id)
-        result_past_notifications, _ = self.unsc.get_past_subscriptions(resource_id=data_product_id)
+        result_notifications= self.unsc.get_subscriptions(resource_id=data_product_id, include_nonactive=False)
 
         log.debug("result_notifications::: %s" % result_notifications)
-        log.debug("result_active_notifications::: %s" % result_active_notifications)
-        log.debug("result_past_notifications::: %s" % result_past_notifications)
+        log.debug("number of result_notifications::: %s" % len(result_notifications))
 
-#        self.assertEquals(len(result_notifications), 5)
-#        self.assertEquals(len(result_active_notifications), 5)
-#        self.assertEquals(len(result_past_notifications), 5)
+#        self.assertEquals(len(result_notifications), 2)
 
         for notific in result_notifications:
             self.assertEquals(notific.origin, data_product_id)
-
-        for notific in result_active_notifications:
-            self.assertEquals(notific.origin, data_product_id)
             self.assertEquals(notific.temporal_bounds.end_datetime, '')
-
-        for notific in result_past_notifications:
-            self.assertEquals(notific.origin, data_product_id)
-            self.assertNotEquals(notific.temporal_bounds.end_datetime, '')
 
         log.debug("Verified that the event processor correctly updated its user info dictionaries after an delete_notification()")
         log.debug("REQ: L4-CI-DM-RQ-56 was satisfied here for UNS")
 
 
-    #--------------------------------------------------------------------------------------
+        #--------------------------------------------------------------------------------------
         # Use UNS to get the all subscriptions --- including retired
         #--------------------------------------------------------------------------------------
-        result_notifications, _ = self.unsc.get_subscriptions(resource_id=data_product_id, include_retired=True)
+        result_notifications = self.unsc.get_subscriptions(resource_id=data_product_id, include_nonactive=True)
 
         for notific in result_notifications:
             self.assertEquals(notific.origin, data_product_id)
+
+#        self.assertEquals(len(result_notifications), 4)
+
+        log.debug("All subscriptions, number::: %s" % len(result_notifications))

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -896,8 +896,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
                 procs.append(proc)
 
-        log.debug("Got the list of processes: %s" % procs)
-
         #--------------------------------------------------------------------------------------
         # Make notification request objects -- Remember to put names
         #--------------------------------------------------------------------------------------
@@ -1028,6 +1026,25 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         self.assertEquals(n1.event_type, notification_request_1.event_type)
         self.assertEquals(n1.origin, notification_request_1.origin)
         self.assertEquals(n1.origin_type, notification_request_1.origin_type)
+
+        #--------------------------------------------------------------------------------------
+        # Create the same notification request again using UNS. Check that no duplicate notification request is made
+        #--------------------------------------------------------------------------------------
+
+        notification_again_id =  self.unsc.create_notification(notification=notification_request_1, user_id=user_id)
+        notification_again = self.rrc.read(notification_again_id)
+
+        self.assertEquals(notification_again.event_type, notification_request_1.event_type)
+        self.assertEquals(notification_again.origin, notification_request_1.origin)
+        self.assertEquals(notification_again.origin_type, notification_request_1.origin_type)
+
+        # assert that the old id is unchanged
+        self.assertEquals(notification_again_id, notification_id1)
+
+        proc = self.container.proc_manager.procs_by_name['user_notification']
+
+        self.assertEquals(len(proc.notifications.values()), 2)
+
 
     @attr('LOCOINT')
     @unittest.skipIf(not use_es, 'No ElasticSearch')

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -21,10 +21,7 @@ from interface.objects import ComputedValueAvailability
 
 import string
 import time
-import gevent
-from gevent.timeout import Timeout
 from email.mime.text import MIMEText
-from gevent import Greenlet
 import elasticpy as ep
 from datetime import datetime
 
@@ -306,11 +303,7 @@ class UserNotificationService(BaseUserNotificationService):
         # load event originators, types, and table
         #---------------------------------------------------------------------------------------------------
 
-        self.event_types = CFG.event.types
-        self.event_table = {}
         self.notifications = {}
-
-        self.notifs = set()
 
         #---------------------------------------------------------------------------------------------------
         # Get the clients
@@ -394,9 +387,6 @@ class UserNotificationService(BaseUserNotificationService):
 
         if not user_id:
             raise BadRequest("User id not provided.")
-
-        log.debug("user_id::: %s" % user_id)
-        log.debug("self.event_processor.user_info:: %s" % self.event_processor.user_info)
 
         #---------------------------------------------------------------------------------------------------
         # Persist Notification object as a resource if it has already not been persisted
@@ -542,9 +532,6 @@ class UserNotificationService(BaseUserNotificationService):
         #-------------------------------------------------------------------------------------------------------------------
 
         notification_request.temporal_bounds.end_datetime = self.makeEpochTime(self.__now())
-
-        log.debug("notification request::: %s" % notification_request)
-        log.debug("notification request.temporal_bounds.end_datetime::: %s" % notification_request.temporal_bounds.end_datetime)
 
         self.clients.resource_registry.update(notification_request)
 
@@ -1044,28 +1031,9 @@ class UserNotificationService(BaseUserNotificationService):
 
         """
 
-
-#        if include_nonactive:
-#            notifications_all = []
-#            for notif in self.notifications.values():
-#                if notif.origin==resource_id:
-#                    notifications_all.append(notif)
-#            return notifications_all
-#        else:
-#            notifications_active = []
-#
-#            for notif in self.notifications.values():
-#                if notif.temporal_bounds.end_datetime == '' and notif.origin==resource_id:
-#                    # Add the active notification
-#                    notifications_active.append(notif)
-#
-#            return notifications_active
-
-
-
         search_origin = 'search "origin" is "%s" from "resources_index"' % resource_id
         ret_vals = self.discovery.parse(search_origin)
-        log.debug("ret_vals::: %s" % ret_vals)
+        log.debug("Returned results: %s" % ret_vals)
 
         notifications_all = set()
         notifications_active = set()
@@ -1084,10 +1052,8 @@ class UserNotificationService(BaseUserNotificationService):
                     notifications_active.add(notif)
 
         if include_nonactive:
-            log.debug("found all notifications: num: %s " % len(notifications_all))
             return list(notifications_all)
         else:
-            log.debug("found ACTIVE notifications: num: %s " % len(notifications_active))
             return list(notifications_active)
 
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-'''
+"""
 @author Bill Bollenbacher
 @author Swarbhanu Chatterjee
 @author David Stuebe
 @file ion/services/dm/presentation/user_notification_service.py
 @description Implementation of the UserNotificationService
-'''
+"""
 
 from pyon.core.exception import BadRequest, IonException
 from pyon.public import RT, PRED, get_sys_name, Container, CFG, OT, IonObject
@@ -128,24 +128,24 @@ class EventProcessor(object):
 
 
 class EmailEventProcessor(EventProcessor):
-    '''
+    """
     Contains email related info.
-    '''
+    """
 
     def __init__(self, smtp_client):
-        '''
+        """
         Contain information about the smtp_client being used for that user
-        '''
+        """
         super(EmailEventProcessor, self).__init__()
         self.smtp_client = smtp_client
         self.notification_subscriptions = []
 
     def add_notification_for_user(self, notification_request, user_id):
-        '''
+        """
         Add a notification to the user's list of subscribed notifications
         @param notification_request NotificationRequest
         @param user_id str
-        '''
+        """
 
         #---------------------------------------------------------------------------------------------------
         # Make a callback function that is right for the user
@@ -188,14 +188,14 @@ class EmailEventProcessor(EventProcessor):
         return user
 
     def put_notification_in_user_object(self, user, notification_request):
-        '''
+        """
         Add the notification into the user info object.
 
         @param user UserInfo
         @param notification_request NotificationRequest
 
         @retval user UserInfo
-        '''
+        """
 
         user_variables_has_notifications = False
 
@@ -213,11 +213,11 @@ class EmailEventProcessor(EventProcessor):
 
 
     def update_user_info_dictionary(self, user, notification_subscription):
-        '''
+        """
         Update the user info and reverse user info dictionaries.
         @param user UserInfo object
         @param notification_subscription NotificationSubscription object
-        '''
+        """
 
         if self.user_info.has_key(user.name):
             # the user is already known by the EventProcessor
@@ -261,10 +261,10 @@ class EmailEventProcessor(EventProcessor):
             notif_sub.deactivate()
 
     def stop_notification_subscriber(self, notification_request):
-        '''
+        """
         Stops the listener of the notification subscriber object
         @param notification_request NotificationRequest
-        '''
+        """
 
         super(EmailEventProcessor, self).stop_notification_subscriber(notification_request)
 
@@ -340,19 +340,19 @@ class UserNotificationService(BaseUserNotificationService):
         super(UserNotificationService, self).on_quit()
 
     def __now(self):
-        '''
+        """
         This method defines what the UNS uses as its "current" time
-        '''
+        """
         return datetime.utcnow()
 
     def set_process_batch_key(self, process_batch_key = ''):
-        '''
+        """
         This method allows an operator to set the process_batch_key, a string.
         Once this method is used by the operator, the UNS will start listening for timer events
         published by the scheduler with origin = process_batch_key.
 
         @param process_batch_key str
-        '''
+        """
 
         def process(event_msg, headers):
             assert event_msg.origin == process_batch_key
@@ -364,9 +364,9 @@ class UserNotificationService(BaseUserNotificationService):
             self.start_time = self.end_time
 
         # the subscriber for the batch processing
-        '''
+        """
         To trigger the batch notification, have the scheduler create a timer with event_origin = process_batch_key
-        '''
+        """
         self.batch_processing_subscriber = EventSubscriber(
             event_type="ResourceEvent",
             origin=process_batch_key,
@@ -547,11 +547,11 @@ class UserNotificationService(BaseUserNotificationService):
             notification_id = notification_id)
 
     def delete_notification_from_user_info(self, notification_id):
-        '''
+        """
         Helper method to delete the notification from the user_info dictionary
 
         @param notification_id str
-        '''
+        """
 
         user_ids, assocs = self.clients.resource_registry.find_subjects(object=notification_id, predicate=PRED.hasNotification, id_only=True)
 
@@ -687,11 +687,11 @@ class UserNotificationService(BaseUserNotificationService):
         return events
 
     def publish_event(self, event=None):
-        '''
+        """
         Publish a general event at a certain time using the UNS
 
         @param event Event
-        '''
+        """
 
         self.event_publisher._publish_event( event_msg = event,
             origin=event.origin,
@@ -699,14 +699,14 @@ class UserNotificationService(BaseUserNotificationService):
         log.info("The publish_event() method of UNS was used to publish an event.")
 
     def get_recent_events(self, resource_id='', limit = 100):
-        '''
+        """
         Get recent events
 
         @param resource_id str
         @param limit int
 
         @retval events list of Event objects
-        '''
+        """
 
         now = self.makeEpochTime(datetime.utcnow())
         events = self.find_events(origin=resource_id,limit=limit, max_datetime=now, descending=False)
@@ -721,13 +721,13 @@ class UserNotificationService(BaseUserNotificationService):
         return ret
 
     def get_user_notifications(self, user_id=''):
-        '''
+        """
         Get the notification request objects that are subscribed to by the user
 
         @param user_id str
 
         @retval notifications list of NotificationRequest objects
-        '''
+        """
 
         user = self.clients.resource_registry.read(user_id)
 
@@ -752,13 +752,13 @@ class UserNotificationService(BaseUserNotificationService):
             return None
 
     def create_worker(self, number_of_workers=1):
-        '''
+        """
         Creates notification workers
 
         @param number_of_workers int
         @retval pids list
 
-        '''
+        """
 
         pids = []
 
@@ -812,7 +812,7 @@ class UserNotificationService(BaseUserNotificationService):
 
 
     def process_batch(self, start_time = 0, end_time = 0):
-        '''
+        """
         This method is launched when an process_batch event is received. The user info dictionary maintained
         by the User Notification Service is used to query the event repository for all events for a particular
         user that have occurred in a provided time interval, and then an email is sent to the user containing
@@ -820,7 +820,7 @@ class UserNotificationService(BaseUserNotificationService):
 
         @param start_time int
         @param end_time int
-        '''
+        """
 
         if end_time <= start_time:
             return
@@ -871,12 +871,12 @@ class UserNotificationService(BaseUserNotificationService):
                 self.format_and_send_email(events_for_message, user_name)
 
     def format_and_send_email(self, events_for_message, user_name):
-        '''
+        """
         Format the message for a particular user containing information about the events he is to be notified about
 
         @param events_for_message list
         @param user_name str
-        '''
+        """
 
         message = str(events_for_message)
         log.debug("The user, %s, will get the following events in his batch notification email: %s" % (user_name, message))
@@ -916,14 +916,14 @@ class UserNotificationService(BaseUserNotificationService):
             smtp_client=self.smtp_client )
 
     def send_batch_email(self, msg_body, msg_subject, msg_recipient, smtp_client):
-        '''
+        """
         Send the email
 
         @param msg_body str
         @param msg_subject str
         @param msg_recipient str
         @param smtp_client object
-        '''
+        """
 
         msg = MIMEText(msg_body)
         msg['Subject'] = msg_subject
@@ -937,13 +937,13 @@ class UserNotificationService(BaseUserNotificationService):
         smtp_client.sendmail(smtp_sender, msg_recipient, msg.as_string())
 
     def update_user_info_object(self, user_id, new_notification, old_notification):
-        '''
+        """
         Update the UserInfo object. If the passed in parameter, od_notification, is None, it does not need to remove the old notification
 
         @param user_id str
         @param new_notification NotificationRequest
         @param old_notification NotificationRequest
-        '''
+        """
 
         #------------------------------------------------------------------------------------
         # read the user
@@ -1018,3 +1018,95 @@ class UserNotificationService(BaseUserNotificationService):
 
         self.event_processor.reverse_user_info = calculate_reverse_user_info(self.event_processor.user_info)
 
+    def get_subscriptions_for_data_product(self, data_product_id='', include_retired=False):
+        """
+        This method is used to get the subscriptions to a data product. The method will return a list of NotificationRequest
+        objects for whom the origin is set to this data product. This way all the users who were interested in listening to
+        events with origin equal to this data product, will be known and all their subscriptions will be known.
+
+        @param data_product_id
+        @param include_retired
+        @return notification_requests []
+        """
+
+        notification_requests = []
+
+        #------------------------------------------------------------------------------------
+        # Get the users who have created notifications with the data product id as origin
+        #------------------------------------------------------------------------------------
+        dict =  self.event_processor.reverse_user_info['event_origin'][data_product_id]
+        user_names = set(dict.itervalues())
+
+        #------------------------------------------------------------------------------------
+        # Find the notification request objects with origin as data_product_id
+        #------------------------------------------------------------------------------------
+        if include_retired: # include both past and active notifications
+            for user_name in user_names:
+                notific = self.event_processor.user_info[user_name]['notifications']
+                notification_requests.append()
+        else: # include only the active notifications
+            for user_name in user_names:
+                for notific in self.event_processor.user_info[user_name]['notifications']:
+                    if not notific.temporal_bounds.end_datetime:
+                        notification_requests.append(notific)
+
+        number_of_subscriptions = len(notification_requests)
+
+        return number_of_subscriptions, notification_requests
+
+    def get_active_subscriptions_for_data_product(self, data_product_id=''):
+        """
+        This method is used to get the active subscriptions to a data product. The method will return a list of NotificationRequest
+        objects for whom the origin is set to this data product.
+
+        @param data_product_id str
+        @return number_of_subscriptions, active_notifications int, []
+        """
+        active_notifications = []
+
+        #------------------------------------------------------------------------------------
+        # Get the users who have created notifications with the data product id as origin
+        #------------------------------------------------------------------------------------
+        dict =  self.event_processor.reverse_user_info['event_origin'][data_product_id]
+        user_names = set(dict.itervalues())
+
+        #------------------------------------------------------------------------------------
+        # Get the notifications we want
+        #------------------------------------------------------------------------------------
+        for user_name in user_names:
+            for notific in self.event_processor.user_info[user_name]['notifications']:
+                if not notific.temporal_bounds.end_datetime: # this means that the notification is not retired
+                    active_notifications.append(notific)
+
+        number_of_subscriptions = len(active_notifications)
+
+        return number_of_subscriptions, active_notifications
+
+    def get_past_subscriptions_for_data_product(self, data_product_id=''):
+        """
+        This method is used to get the past subscriptions to a data product. The method will return a list of retired
+        NotificationRequest objects for whom the origin is set to this data product.
+
+        @param data_product_id
+        @return number_of_subscriptions, past_notifications int, []
+        """
+
+        past_notifications = []
+
+        #------------------------------------------------------------------------------------
+        # Get the users who have created notifications with the data product id as origin
+        #------------------------------------------------------------------------------------
+        dict =  self.event_processor.reverse_user_info['event_origin'][data_product_id]
+        user_names = set(dict.itervalues())
+
+        #------------------------------------------------------------------------------------
+        # Get the notifications we want
+        #------------------------------------------------------------------------------------
+        for user_name in user_names:
+            for notific in self.event_processor.user_info[user_name]['notifications']:
+                if notific.temporal_bounds.end_datetime:
+                    past_notifications.append(notific)
+
+        number_of_subscriptions = len(past_notifications)
+
+        return number_of_subscriptions, past_notifications

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -524,12 +524,6 @@ class UserNotificationService(BaseUserNotificationService):
 
         self.event_processor.stop_notification_subscriber(notification_request=notification_request)
 
-        #        #-------------------------------------------------------------------------------------------------------------------
-        #        # delete the notification from the user_info and reverse_user_info dictionaries
-        #        #-------------------------------------------------------------------------------------------------------------------
-        #
-        #        self.delete_notification_from_user_info(notification_id)
-
         #-------------------------------------------------------------------------------------------------------------------
         # Update the resource registry
         #-------------------------------------------------------------------------------------------------------------------
@@ -545,8 +539,8 @@ class UserNotificationService(BaseUserNotificationService):
         # Update the user info dictionaries
         #-------------------------------------------------------------------------------------------------------------------
 
-#        for user_id in self.event_processor.user_info.iterkeys():
-#            self.update_user_info_dictionary(user_id, notification_request, old_notification)
+        for user_id in self.event_processor.user_info.iterkeys():
+            self.update_user_info_dictionary(user_id, notification_request, old_notification)
 
         #-------------------------------------------------------------------------------------------------------------------
         # Generate an event that can be picked by a notification worker so that it can update its user_info dictionary

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -1018,13 +1018,13 @@ class UserNotificationService(BaseUserNotificationService):
 
         self.event_processor.reverse_user_info = calculate_reverse_user_info(self.event_processor.user_info)
 
-    def get_subscriptions_for_data_product(self, data_product_id='', include_retired=False):
+    def get_subscriptions(self, resource_id='', include_retired=False):
         """
         This method is used to get the subscriptions to a data product. The method will return a list of NotificationRequest
         objects for whom the origin is set to this data product. This way all the users who were interested in listening to
         events with origin equal to this data product, will be known and all their subscriptions will be known.
 
-        @param data_product_id
+        @param resource_id
         @param include_retired
         @return notification_requests []
         """
@@ -1034,11 +1034,11 @@ class UserNotificationService(BaseUserNotificationService):
         #------------------------------------------------------------------------------------
         # Get the users who have created notifications with the data product id as origin
         #------------------------------------------------------------------------------------
-        dict =  self.event_processor.reverse_user_info['event_origin'][data_product_id]
+        dict =  self.event_processor.reverse_user_info['event_origin'][resource_id]
         user_names = set(dict.itervalues())
 
         #------------------------------------------------------------------------------------
-        # Find the notification request objects with origin as data_product_id
+        # Find the notification request objects with origin as resource_id
         #------------------------------------------------------------------------------------
         if include_retired: # include both past and active notifications
             for user_name in user_names:
@@ -1054,12 +1054,12 @@ class UserNotificationService(BaseUserNotificationService):
 
         return number_of_subscriptions, notification_requests
 
-    def get_active_subscriptions_for_data_product(self, data_product_id=''):
+    def get_active_subscriptions(self, resource_id=''):
         """
         This method is used to get the active subscriptions to a data product. The method will return a list of NotificationRequest
         objects for whom the origin is set to this data product.
 
-        @param data_product_id str
+        @param resource_id str
         @return number_of_subscriptions, active_notifications int, []
         """
         active_notifications = []
@@ -1067,7 +1067,7 @@ class UserNotificationService(BaseUserNotificationService):
         #------------------------------------------------------------------------------------
         # Get the users who have created notifications with the data product id as origin
         #------------------------------------------------------------------------------------
-        dict =  self.event_processor.reverse_user_info['event_origin'][data_product_id]
+        dict =  self.event_processor.reverse_user_info['event_origin'][resource_id]
         user_names = set(dict.itervalues())
 
         #------------------------------------------------------------------------------------
@@ -1082,12 +1082,12 @@ class UserNotificationService(BaseUserNotificationService):
 
         return number_of_subscriptions, active_notifications
 
-    def get_past_subscriptions_for_data_product(self, data_product_id=''):
+    def get_past_subscriptions(self, resource_id=''):
         """
         This method is used to get the past subscriptions to a data product. The method will return a list of retired
         NotificationRequest objects for whom the origin is set to this data product.
 
-        @param data_product_id
+        @param resource_id
         @return number_of_subscriptions, past_notifications int, []
         """
 
@@ -1096,7 +1096,7 @@ class UserNotificationService(BaseUserNotificationService):
         #------------------------------------------------------------------------------------
         # Get the users who have created notifications with the data product id as origin
         #------------------------------------------------------------------------------------
-        dict =  self.event_processor.reverse_user_info['event_origin'][data_product_id]
+        dict =  self.event_processor.reverse_user_info['event_origin'][resource_id]
         user_names = set(dict.itervalues())
 
         #------------------------------------------------------------------------------------

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -170,7 +170,7 @@ def check_user_notification_interest(event, reverse_user_info):
     @param event                Event
     @param reverse_user_info    dict
 
-    @retval user_names list
+    @retval user_ids list
     '''
 
     user_list_1 = []
@@ -241,7 +241,7 @@ def calculate_reverse_user_info(user_info=None):
     dict_3 = {}
     dict_4 = {}
 
-    for user_name, value in user_info.iteritems():
+    for user_id, value in user_info.iteritems():
 
         notifications = value['notifications']
 
@@ -258,32 +258,32 @@ def calculate_reverse_user_info(user_info=None):
                     continue
 
                 if dict_1.has_key(notification.event_type) and notification.event_type:
-                    dict_1[notification.event_type].append(user_name)
+                    dict_1[notification.event_type].append(user_id)
                     # to remove duplicate user names
                     dict_1[notification.event_type] = list(set(dict_1[notification.event_type]))
                 else:
-                    dict_1[notification.event_type] = [user_name]
+                    dict_1[notification.event_type] = [user_id]
 
                 if dict_2.has_key(notification.event_subtype) and notification.event_subtype:
-                    dict_2[notification.event_subtype].append(user_name)
+                    dict_2[notification.event_subtype].append(user_id)
                     # to remove duplicate user names
                     dict_2[notification.event_subtype] = list(set(dict_2[notification.event_subtype]))
                 else:
-                    dict_2[notification.event_subtype] = [user_name]
+                    dict_2[notification.event_subtype] = [user_id]
 
                 if dict_3.has_key(notification.origin) and notification.origin:
-                    dict_3[notification.origin].append(user_name)
+                    dict_3[notification.origin].append(user_id)
                     # to remove duplicate user names
                     dict_3[notification.origin] = list(set(dict_3[notification.origin]))
                 else:
-                    dict_3[notification.origin] = [user_name]
+                    dict_3[notification.origin] = [user_id]
 
                 if dict_4.has_key(notification.origin_type) and notification.origin_type:
-                    dict_4[notification.origin_type].append(user_name)
+                    dict_4[notification.origin_type].append(user_id)
                     # to remove duplicate user names
                     dict_4[notification.origin_type] = list(set(dict_4[notification.origin_type]))
                 else:
-                    dict_4[notification.origin_type] = [user_name]
+                    dict_4[notification.origin_type] = [user_id]
 
                 reverse_user_info['event_type'] = dict_1
                 reverse_user_info['event_subtype'] = dict_2


### PR DESCRIPTION
The get_subscriptions() method has been implemented in UNS. An integration test has been implemented to test the same.

The way to use the method is the following:

```
notification_requests = user_notification_service.get_subscriptions(resource_id=data_product_id, include_nonactive=False)
```

The above returns a list of notification_requests including both active and past notifications. Past (or retired) notifications are those that have been retired using the delete_notification() method of UNS.

If you want the method to return only the active notifications, use True for the flag, include_nonactive.

```
notification_requests = user_notification_service.get_subscriptions(resource_id=data_product_id, include_nonactive=True)
```
