### PR TITLE
Fixed demo transform for origin_type and timestamp

### DIFF
--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -401,6 +401,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
 
         self.assertEquals(event.type_, "DeviceCommsEvent")
         self.assertEquals(event.origin, "instrument_1")
+        self.assertEquals(event.origin_type, "PlatformDevice")
         self.assertEquals(event.state, DeviceCommsType.DATA_DELIVERY_INTERRUPTION)
         self.assertEquals(event.sub_type, 'input_voltage')
 
@@ -426,6 +427,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
 
         self.assertEquals(event.type_, "DeviceCommsEvent")
         self.assertEquals(event.origin, "instrument_1")
+        self.assertEquals(event.origin_type, "PlatformDevice")
         self.assertEquals(event.state, DeviceCommsType.DATA_DELIVERY_INTERRUPTION)
         self.assertEquals(event.sub_type, 'input_voltage')
 
@@ -439,7 +441,12 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
 
         for i in xrange(number):
             rdt['input_voltage'] = values
-            rdt['preferred_timestamp'] = times
+            rdt['preferred_timestamp'] = ['time' for l in xrange(len(times))]
+            rdt['time'] = times
+
             g = rdt.to_granule()
             g.data_producer_id = 'instrument_1'
+
+            log.debug("granule published by instrument:: %s" % g)
+
             pub.publish(g)


### PR DESCRIPTION
Fixed transform so that the events published include origin_type set as "PlatformDevice'. 

Also fixed the transform so that the corresponding value for time is got for the timestamp attribute of DeviceStatusEvent and not just the name, which is set in the 'preferred_timestamp' array. Tests all working
