### PR TITLE
Multi ingestion

### DIFF
--- a/ion/processes/bootstrap/plugins/bootstrap_ingestion.py
+++ b/ion/processes/bootstrap/plugins/bootstrap_ingestion.py
@@ -27,8 +27,6 @@ class BootstrapIngestion(BootstrapPlugin):
         for i in xrange(len(queues)):
             item = queues[i]
             queues[i] = IngestionQueue(name=item['name'], type=item['type'], datastore_name=item['datastore_name'])
-            xn = self.container.ex_manager.create_xn_queue(item['name'])
-            xn.purge()
 
         ing_ms_client.create_ingestion_configuration(name='standard ingestion config',
             exchange_point_id=exchange_point,

--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -48,8 +48,6 @@ class ScienceGranuleIngestionWorker(TransformStreamListener):
                 log.exception('Problems closing the coverage')
 
 
-
-
     def _new_dataset(self, stream_id):
         '''
         Adds a new dataset to the internal cache of the ingestion worker

--- a/ion/services/dm/distribution/pubsub_management_service.py
+++ b/ion/services/dm/distribution/pubsub_management_service.py
@@ -308,6 +308,23 @@ class PubsubManagementService(BasePubsubManagementService):
         self.clients.resource_registry.delete(subscription_id)
         return True
 
+    def move_subscription(self, subscription_id='', exchange_name=''):
+
+        self.read_subscription(subscription_id)
+        self.container.ex_manager.create_xn_queue(exchange_name)
+
+        xn_ids, _ = self.clients.resource_registry.find_resources(restype=RT.ExchangeName, name=exchange_name, id_only=True)
+        if not xn_ids:
+            return
+
+        _, assocs = self.clients.resource_registry.find_subjects(object=subscription_id, predicate=PRED.hasSubscription, id_only=True)
+        for assoc in assocs:
+            self.clients.resource_registry.delete_association(assoc)
+
+        self._associate_subscription_with_xn(subscription_id, xn_ids[0])
+
+
+
     #--------------------------------------------------------------------------------
 
     def create_topic(self, name='', exchange_point='', parent_topic_id='', description=''):

--- a/ion/services/dm/distribution/pubsub_management_service.py
+++ b/ion/services/dm/distribution/pubsub_management_service.py
@@ -302,8 +302,19 @@ class PubsubManagementService(BasePubsubManagementService):
     def delete_subscription(self, subscription_id=''):
         if self.subscription_is_active(subscription_id):
             raise BadRequest('Clients can not delete an active subscription.')
+        print 'deleting'
 
+        xn_objs, assocs = self.clients.resource_registry.find_subjects(object=subscription_id, predicate=PRED.hasSubscription, id_only=False)
+        if len(xn_objs) > 1:
+            log.warning('Subscription %s was attached to multiple queues')
         self._deassociate_subscription(subscription_id)
+
+        for xn_obj in xn_objs:
+            subscriptions, assocs = self.clients.resource_registry.find_objects(subject=xn_obj, predicate=PRED.hasSubscription, id_only=True)
+            print subscriptions
+            if not subscriptions:
+                self.clients.exchange_management.undeclare_exchange_name(xn_obj._id)
+
 
         self.clients.resource_registry.delete(subscription_id)
         return True

--- a/ion/services/dm/distribution/pubsub_management_service.py
+++ b/ion/services/dm/distribution/pubsub_management_service.py
@@ -302,7 +302,6 @@ class PubsubManagementService(BasePubsubManagementService):
     def delete_subscription(self, subscription_id=''):
         if self.subscription_is_active(subscription_id):
             raise BadRequest('Clients can not delete an active subscription.')
-        print 'deleting'
 
         xn_objs, assocs = self.clients.resource_registry.find_subjects(object=subscription_id, predicate=PRED.hasSubscription, id_only=False)
         if len(xn_objs) > 1:
@@ -311,7 +310,6 @@ class PubsubManagementService(BasePubsubManagementService):
 
         for xn_obj in xn_objs:
             subscriptions, assocs = self.clients.resource_registry.find_objects(subject=xn_obj, predicate=PRED.hasSubscription, id_only=True)
-            print subscriptions
             if not subscriptions:
                 self.clients.exchange_management.undeclare_exchange_name(xn_obj._id)
 

--- a/ion/services/dm/distribution/test/test_pubsub.py
+++ b/ion/services/dm/distribution/test/test_pubsub.py
@@ -133,6 +133,32 @@ class PubsubManagementIntTest(IonIntegrationTestCase):
         self.pubsub_management.delete_stream(stream_id)
         self.pubsub_management.delete_stream_definition(stream_def_id)
 
+    def test_move_subscription(self):
+        stream_id, route = self.pubsub_management.create_stream(name='test_stream', exchange_point='test_xp')
+
+        #--------------------------------------------------------------------------------
+        # Test moving before activate
+        #--------------------------------------------------------------------------------
+
+        subscription_id = self.pubsub_management.create_subscription('first_queue', stream_ids=[stream_id])
+
+        xn_ids, _ = self.resource_registry.find_resources(restype=RT.ExchangeName, name='first_queue', id_only=True)
+        subjects, _ = self.resource_registry.find_subjects(object=subscription_id, predicate=PRED.hasSubscription, id_only=True)
+        self.assertEquals(xn_ids[0], subjects[0])
+
+        self.pubsub_management.move_subscription(subscription_id, exchange_name='second_queue')
+
+        xn_ids, _ = self.resource_registry.find_resources(restype=RT.ExchangeName, name='second_queue', id_only=True)
+        subjects, _ = self.resource_registry.find_subjects(object=subscription_id, predicate=PRED.hasSubscription, id_only=True)
+
+        self.assertEquals(len(subjects),1)
+        self.assertEquals(subjects[0], xn_ids[0])
+
+        self.pubsub_management.delete_subscription(subscription_id)
+        self.pubsub_management.delete_stream(stream_id)
+
+        
+
     def test_topic_crud(self):
 
         topic_id = self.pubsub_management.create_topic(name='test_topic', exchange_point='test_xp')

--- a/ion/services/dm/distribution/test/test_pubsub.py
+++ b/ion/services/dm/distribution/test/test_pubsub.py
@@ -22,6 +22,8 @@ from gevent.event import Event
 from gevent.queue import Queue, Empty
 from nose.plugins.attrib import attr
 
+import gevent
+
 @attr('UNIT',group='dm')
 class PubsubManagementUnitTest(PyonTestCase):
     pass
@@ -133,7 +135,7 @@ class PubsubManagementIntTest(IonIntegrationTestCase):
         self.pubsub_management.delete_stream(stream_id)
         self.pubsub_management.delete_stream_definition(stream_def_id)
 
-    def test_move_subscription(self):
+    def test_move_before_activate(self):
         stream_id, route = self.pubsub_management.create_stream(name='test_stream', exchange_point='test_xp')
 
         #--------------------------------------------------------------------------------
@@ -157,6 +159,46 @@ class PubsubManagementIntTest(IonIntegrationTestCase):
         self.pubsub_management.delete_subscription(subscription_id)
         self.pubsub_management.delete_stream(stream_id)
 
+    def test_move_activated_subscription(self):
+
+        stream_id, route = self.pubsub_management.create_stream(name='test_stream', exchange_point='test_xp')
+        #--------------------------------------------------------------------------------
+        # Test moving after activate
+        #--------------------------------------------------------------------------------
+
+        subscription_id = self.pubsub_management.create_subscription('first_queue', stream_ids=[stream_id])
+        self.pubsub_management.activate_subscription(subscription_id)
+
+        xn_ids, _ = self.resource_registry.find_resources(restype=RT.ExchangeName, name='first_queue', id_only=True)
+        subjects, _ = self.resource_registry.find_subjects(object=subscription_id, predicate=PRED.hasSubscription, id_only=True)
+        self.assertEquals(xn_ids[0], subjects[0])
+
+        self.verified = Event()
+
+        def verify(m,r,s):
+            self.assertEquals(m,'verified')
+            self.verified.set()
+
+        subscriber = StandaloneStreamSubscriber('second_queue', verify)
+        subscriber.start()
+
+        self.pubsub_management.move_subscription(subscription_id, exchange_name='second_queue')
+
+        xn_ids, _ = self.resource_registry.find_resources(restype=RT.ExchangeName, name='second_queue', id_only=True)
+        subjects, _ = self.resource_registry.find_subjects(object=subscription_id, predicate=PRED.hasSubscription, id_only=True)
+
+        self.assertEquals(len(subjects),1)
+        self.assertEquals(subjects[0], xn_ids[0])
+
+        publisher = StandaloneStreamPublisher(stream_id, route)
+        publisher.publish('verified')
+
+        self.assertTrue(self.verified.wait(2))
+
+        self.pubsub_management.deactivate_subscription(subscription_id)
+
+        self.pubsub_management.delete_subscription(subscription_id)
+        self.pubsub_management.delete_stream(stream_id)
         
 
     def test_topic_crud(self):

--- a/ion/services/dm/distribution/test/test_pubsub.py
+++ b/ion/services/dm/distribution/test/test_pubsub.py
@@ -199,6 +199,22 @@ class PubsubManagementIntTest(IonIntegrationTestCase):
 
         self.pubsub_management.delete_subscription(subscription_id)
         self.pubsub_management.delete_stream(stream_id)
+
+    def test_queue_cleanup(self):
+        stream_id, route = self.pubsub_management.create_stream('test_stream','xp1')
+        xn_objs, _ = self.resource_registry.find_resources(restype=RT.ExchangeName, name='queue1')
+        for xn_obj in xn_objs:
+            xn = self.container.ex_manager.create_xn_queue(xn_obj.name)
+            xn.delete()
+        subscription_id = self.pubsub_management.create_subscription('queue1',stream_ids=[stream_id])
+        xn_ids, _ = self.resource_registry.find_resources(restype=RT.ExchangeName, name='queue1')
+        self.assertEquals(len(xn_ids),1)
+
+        self.pubsub_management.delete_subscription(subscription_id)
+
+        xn_ids, _ = self.resource_registry.find_resources(restype=RT.ExchangeName, name='queue1')
+        self.assertEquals(len(xn_ids),0)
+
         
 
     def test_topic_crud(self):


### PR DESCRIPTION
Lots of changes:
- better queue and process cleanup
- the process can be killed correctly through ingestion
- subscription and queue associations

Part of [OOIION-542](https://jira.oceanobservatories.org/tasks/browse/OOIION-542)
