### PR TITLE
Luke: removes the stream to subscription association in delete_stream

### DIFF
--- a/ion/services/dm/distribution/pubsub_management_service.py
+++ b/ion/services/dm/distribution/pubsub_management_service.py
@@ -429,6 +429,9 @@ class PubsubManagementService(BasePubsubManagementService):
         xps, assocs = self.clients.resource_registry.find_subjects(object=stream_id, predicate=PRED.hasStream,subject_type=RT.ExchangePoint, id_only=True)
         for assoc in assocs:
             self.clients.resource_registry.delete_association(assoc)
+        subs, assocs = self.clients.resource_registry.find_subjects(object=stream_id, predicate=PRED.hasStream, subject_type=RT.Subscription, id_only=True)
+        for assoc in assocs:
+            self.clients.resource_registry.delete_association(assoc)
         objects, assocs = self.clients.resource_registry.find_objects(subject=stream_id, id_only=True)
         for assoc in assocs:
             self.clients.resource_registry.delete_association(assoc)


### PR DESCRIPTION
This will aid in a very annoying race condition in the workflow framework where data process mgmt will delete a stream but the association lingers at the same time while the subscription framework tries to delete the associations as well and received a NotFound exception because the association exists but the stream objects do not.

There is no JIRA task for this, it fixes tests.
