### PR TITLE
Separates PyDAP from registration configuration

### DIFF
--- a/ion/processes/data/externalization/lightweight_pydap.py
+++ b/ion/processes/data/externalization/lightweight_pydap.py
@@ -5,22 +5,28 @@ from pyon.util.file_sys import FileSystem
 from logging import getLogger
 from pydap.wsgi.file import make_app
 from gevent.wsgi import WSGIServer
+from pyon.util.log import log
 
 class LightweightPyDAP(SimpleProcess):
     def on_start(self):
-        SimpleProcess.on_start(self)
-        self.pydap_host = self.CFG.get_safe('server.pydap.host', 'localhost')
-        self.pydap_port = self.CFG.get_safe('server.pydap.port', '8001')
+        try:
+            SimpleProcess.on_start(self)
+            self.pydap_host = self.CFG.get_safe('container.pydap_gateway.web_server.host', 'localhost')
+            self.pydap_port = self.CFG.get_safe('container.pydap_gateway.web_server.port', '8001')
 
-        self.pydap_data_path = self.CFG.get_safe('server.pydap.data_path', 'RESOURCE:ext/pydap')
+            self.pydap_data_path = self.CFG.get_safe('server.pydap.data_path', 'RESOURCE:ext/pydap')
 
-        self.pydap_data_path = FileSystem.get_extended_url(self.pydap_data_path)
+            self.pydap_data_path = FileSystem.get_extended_url(self.pydap_data_path)
 
-        self.app = make_app(None, self.pydap_data_path, 'ion/core/static/templates/')
-        self.log = getLogger('pydap')
-        self.log.write = self.log.info
-        self.server = WSGIServer((self.pydap_host, int(self.pydap_port)), self.app, log=self.log)
-        self.server.start()
+            self.app = make_app(None, self.pydap_data_path, 'ion/core/static/templates/')
+            self.log = getLogger('pydap')
+            self.log.write = self.log.info
+            self.server = WSGIServer((self.pydap_host, int(self.pydap_port)), self.app, log=self.log)
+            self.server.start()
+        except: 
+            log.exception('Unable to start PyDAP server')
+            raise
+
 
     def on_quit(self):
         self.server.stop()


### PR DESCRIPTION
This should make load balancing easier to configure.

Adds separate config for pydap gateway

The registration process will use the entry under server for pointing external clients to the the URL
where the datasets can be accessed via DAP.  The lightweight dap server (gateway) will use the container
configuration: `container.pydap_gateway.web_server` for the host and port to launch on.

This should make load balancing easier to configure.

Example:
The registration process will have the following config:

``` yaml
server:
  pydap:
    host: pydap.oceanobservatories.org
    port: 5000
```

One pydap gateway will have:

``` yaml
container:
  pydap_gateway:
    web_server:
      host: pydap-slave1.oceanobservatories.org
      port: 9001
```

Another will be

``` yaml
container:
  pydap_gateway:
    web_server:
      host: pydap-slave2.oceanobservatories.org
      port: 9002
```

Part of [OOIION-544](https://jira.oceanobservatories.org/tasks/browse/OOIION-544)
