### PR TITLE
Fixes buildbot

### DIFF
--- a/ion/services/coi/org_management_service.py
+++ b/ion/services/coi/org_management_service.py
@@ -1134,7 +1134,7 @@ class OrgManagementService(BaseOrgManagementService):
         status_rollups = outil.get_status_roll_ups(org_id, extended_org.resource._get_type())
 
         extended_org.computed.instrument_status = [status_rollups.get(idev._id,{}).get("agg",4) for idev in extended_org.instruments]
-        extended_org.computed.platform_status = [status_rollups(pdev._id,{}).get("agg",4) for pdev in extended_org.platforms]
+        extended_org.computed.platform_status = [status_rollups.get(pdev._id,{}).get("agg",4) for pdev in extended_org.platforms]
 
         #set counter attributes
         extended_org.number_of_data_products = len(extended_org.data_products)


### PR DESCRIPTION
Fixes the test, 

ERROR: test_observatory_org_extended (ion.services.sa.observatory.test.test_observatory_management_service_integration.TestObservatoryManagementServiceIntegration)

TypeError: 'dict object is not callable'
