### PR TITLE
Fixes the buildbot: test_observatory_structure in test_assembly.py

### DIFF
--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -1157,14 +1157,21 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
         log.trace("branching up to parents with acc = %s", str(low_branch))
         retval_ids = _branch_out(low_branch, in_list, parents)
 
-        log.debug("converting retrieved ids to objects")
+        log.debug("converting retrieved ids to objects = %s" % retval_ids)
         retval = {}
-        all_res = self.RR.read_mult([res_id for rt, resource_ids in retval_ids.iteritems() for res_id in resource_ids])
-        res_by_id = dict(zip([res._id for res in all_res], all_res))
-        for rt, resource_ids in retval_ids.iteritems():
-            retval[rt] = []
-            for resource_id in resource_ids:
-                retval[rt].append(res_by_id[resource_id])
+
+        res_ids = [res_id for resource_ids in retval_ids.itervalues() for res_id in resource_ids]
+        if res_ids:
+            all_res = self.RR.read_mult(res_ids)
+
+            res_by_id = dict(zip([res._id for res in all_res], all_res))
+            for rt, resource_ids in retval_ids.iteritems():
+                retval[rt] = []
+                for resource_id in resource_ids:
+                    retval[rt].append(res_by_id[resource_id])
+        else:
+            retval = retval_ids
+
         return retval
 
 


### PR DESCRIPTION
Got the test_observatory_structure test to work in test_assembly.py by fiixing the find_related_frames_of_reference() method in observatory management.

The find_related_frames_of_reference() method in observatory_management_service would crash if
no related associations were found. The error would get generated when the resource registry's
read_mult() method would get called on an empty list of object ids. 

Fixed this by calling the  read_mult() method only when a non empty list of values are found. 

All tests using the find_related_frames_of_reference() have been verified to be  work after this change. 

The tests were:
1. test_observatory_service_management_integration.py
2. test_assembly.py
