### PR TITLE
Fixes buildbot by fixing test_data_product_management_service_integration.py

### DIFF
--- a/ion/services/sa/product/test/test_data_product_management_service_integration.py
+++ b/ion/services/sa/product/test/test_data_product_management_service_integration.py
@@ -103,7 +103,10 @@ class TestDataProductManagementServiceIntegration(IonIntegrationTestCase):
 
     def cleaning_up(self):
         for pid in self.pids:
-            self.container.proc_manager.terminate_process(pid)
+            try:
+                self.container.proc_manager.terminate_process(pid)
+            except:
+                log.debug("could not terminate the process id: %s" % pid)
         IngestionManagementIntTest.clean_subscriptions()
 
         for xn in self.exchange_names:


### PR DESCRIPTION
Fixes the cleanup of the processes in the test for data product management service integration test.

It does this by doing a friendly cleanup of processes using addCleanUp(). If the terminate process fails while cleaning up it handles the exception in a friendly way.
