### PR TITLE
Demo transform publishes one BAD data event per granule instead of per bad value in granule

### DIFF
--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -237,20 +237,35 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
         #-------------------------------------------------------------------------------------
         if bad_values:
             # Create the event object
-            event = DeviceStatusEvent(  origin = self.origin,
+#            event = DeviceStatusEvent(  origin = self.origin,
+#                origin_type='PlatformDevice',
+#                sub_type = self.instrument_variable_name,
+#                values = bad_value,
+#                ts_created=get_ion_ts(),
+#                time_stamps = time_stamp,
+#                valid_values = self.valid_values,
+#                state = DeviceStatusType.OUT_OF_RANGE,
+#                description = "Event to deliver the status of instrument.")
+#
+#            # Publish the event
+#            self.publisher._publish_event(  event_msg = event,
+#                origin=event.origin,
+#                event_type = event.type_)
+
+            #---------------------------------------------------------------------------------
+            # Publish the event
+            #---------------------------------------------------------------------------------
+            self.publisher.publish_event(
+                event_type = 'DeviceStatusEvent',
+                origin = self.origin,
                 origin_type='PlatformDevice',
                 sub_type = self.instrument_variable_name,
-                values = bad_value,
-                ts_created=get_ion_ts(),
-                time_stamps = time_stamp,
+                values = bad_values,
+                time_stamps = bad_value_times,
                 valid_values = self.valid_values,
                 state = DeviceStatusType.OUT_OF_RANGE,
-                description = "Event to deliver the status of instrument.")
-
-            # Publish the event
-            self.publisher._publish_event(  event_msg = event,
-                origin=event.origin,
-                event_type = event.type_)
+                description = "Event to deliver the status of instrument."
+            )
 
             log.debug("DemoStreamAlertTransform published event:::: %s" % event)
 

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -267,7 +267,7 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
                 description = "Event to deliver the status of instrument."
             )
 
-            log.debug("DemoStreamAlertTransform published event:::: %s" % event)
+            log.debug("DemoStreamAlertTransform published event")
 
     def process_event(self, msg, headers):
         """
@@ -294,7 +294,7 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
                     origin=event.origin,
                     event_type = event.type_)
 
-                log.debug("DemoStreamAlertTransform published a NO DATA event: %s" % event)
+                log.debug("DemoStreamAlertTransform published a NO DATA event")
 
             else:
                 self.granules.queue.clear()
@@ -345,7 +345,7 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
                 arr = rdt[time_names[index]]
                 bad_value_times.append(arr[index])
 
-        log.debug("Returning a bad_values: %s, bad_value_times: %s and the origin: %s" % (bad_values, bad_value_times, origin))
+        log.debug("Returning bad_values: %s, bad_value_times: %s and the origin: %s" % (bad_values, bad_value_times, origin))
 
         # return the list of bad values and their timestamps
         return bad_values, bad_value_times, origin

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -236,25 +236,7 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
         # If there are any bad values, publish an alert event for the granule
         #-------------------------------------------------------------------------------------
         if bad_values:
-            # Create the event object
-#            event = DeviceStatusEvent(  origin = self.origin,
-#                origin_type='PlatformDevice',
-#                sub_type = self.instrument_variable_name,
-#                values = bad_value,
-#                ts_created=get_ion_ts(),
-#                time_stamps = time_stamp,
-#                valid_values = self.valid_values,
-#                state = DeviceStatusType.OUT_OF_RANGE,
-#                description = "Event to deliver the status of instrument.")
-#
-#            # Publish the event
-#            self.publisher._publish_event(  event_msg = event,
-#                origin=event.origin,
-#                event_type = event.type_)
-
-            #---------------------------------------------------------------------------------
             # Publish the event
-            #---------------------------------------------------------------------------------
             self.publisher.publish_event(
                 event_type = 'DeviceStatusEvent',
                 origin = self.origin,
@@ -280,20 +262,6 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
         if msg.origin == self.timer_origin:
 
             if self.granules.qsize() == 0:
-                # Create the event object
-#                event = DeviceCommsEvent( origin = self.origin,
-#                    origin_type='PlatformDevice',
-#                    sub_type = self.instrument_variable_name,
-#                    ts_created=get_ion_ts(),
-#                    time_stamp =int(time.time() + 2208988800),  # granules use NTP not unix
-#                    state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION,
-#                    lapse_interval_seconds=self.timer_interval,
-#                    description = "Event to deliver the communications status of the instrument.")
-#                # Publish the event
-#                self.publisher._publish_event(  event_msg = event,
-#                    origin=event.origin,
-#                    event_type = event.type_)
-
                 # Publish the event
                 self.publisher.publish_event(
                     event_type = 'DeviceCommsEvent',

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -267,7 +267,7 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
                 description = "Event to deliver the status of instrument."
             )
 
-            log.debug("DemoStreamAlertTransform published event")
+            log.debug("DemoStreamAlertTransform published a BAD DATA event")
 
     def process_event(self, msg, headers):
         """
@@ -281,18 +281,30 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
 
             if self.granules.qsize() == 0:
                 # Create the event object
-                event = DeviceCommsEvent( origin = self.origin,
+#                event = DeviceCommsEvent( origin = self.origin,
+#                    origin_type='PlatformDevice',
+#                    sub_type = self.instrument_variable_name,
+#                    ts_created=get_ion_ts(),
+#                    time_stamp =int(time.time() + 2208988800),  # granules use NTP not unix
+#                    state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION,
+#                    lapse_interval_seconds=self.timer_interval,
+#                    description = "Event to deliver the communications status of the instrument.")
+#                # Publish the event
+#                self.publisher._publish_event(  event_msg = event,
+#                    origin=event.origin,
+#                    event_type = event.type_)
+
+                # Publish the event
+                self.publisher.publish_event(
+                    event_type = 'DeviceCommsEvent',
+                    origin = self.origin,
                     origin_type='PlatformDevice',
                     sub_type = self.instrument_variable_name,
-                    ts_created=get_ion_ts(),
                     time_stamp =int(time.time() + 2208988800),  # granules use NTP not unix
                     state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION,
                     lapse_interval_seconds=self.timer_interval,
-                    description = "Event to deliver the communications status of the instrument.")
-                # Publish the event
-                self.publisher._publish_event(  event_msg = event,
-                    origin=event.origin,
-                    event_type = event.type_)
+                    description = "Event to deliver the communications status of the instrument."
+                )
 
                 log.debug("DemoStreamAlertTransform published a NO DATA event")
 

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -233,27 +233,26 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
         log.debug("DemoStreamAlertTransform got the origin of the event as: %s" % self.origin)
 
         #-------------------------------------------------------------------------------------
-        # If there are any bad values, publish an alert event for each of them, with information about their time stamp
+        # If there are any bad values, publish an alert event for the granule
         #-------------------------------------------------------------------------------------
         if bad_values:
-            for bad_value, time_stamp in zip(bad_values, bad_value_times):
-                # Create the event object
-                event = DeviceStatusEvent(  origin = self.origin,
-                    origin_type='PlatformDevice',
-                    sub_type = self.instrument_variable_name,
-                    value = bad_value,
-                    ts_created=get_ion_ts(),
-                    time_stamp = time_stamp,
-                    valid_values = self.valid_values,
-                    state = DeviceStatusType.OUT_OF_RANGE,
-                    description = "Event to deliver the status of instrument.")
+            # Create the event object
+            event = DeviceStatusEvent(  origin = self.origin,
+                origin_type='PlatformDevice',
+                sub_type = self.instrument_variable_name,
+                values = bad_value,
+                ts_created=get_ion_ts(),
+                time_stamps = time_stamp,
+                valid_values = self.valid_values,
+                state = DeviceStatusType.OUT_OF_RANGE,
+                description = "Event to deliver the status of instrument.")
 
-                # Publish the event
-                self.publisher._publish_event(  event_msg = event,
-                    origin=event.origin,
-                    event_type = event.type_)
+            # Publish the event
+            self.publisher._publish_event(  event_msg = event,
+                origin=event.origin,
+                event_type = event.type_)
 
-                log.debug("DemoStreamAlertTransform published event:::: %s" % event)
+            log.debug("DemoStreamAlertTransform published event:::: %s" % event)
 
     def process_event(self, msg, headers):
         """

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -301,7 +301,6 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
             log.debug("Got a BAD data event: %s" % message)
             if message.type_ == "DeviceStatusEvent":
                 queue_bad_data.put(message)
-                log.debug("the size of queue:: %s" % queue_bad_data.qsize())
 
         def no_data(message, headers):
             log.debug("Got a NO data event: %s" % message)
@@ -381,16 +380,18 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         val = numpy.array([(110 + l)  for l in xrange(self.length)])
         self._publish_granules(stream_id= stream_id, stream_route= stream_route, number= self.number, values=val)
 
-        for i in xrange(self.number):
-            log.debug("came here! size of queue: %s" % queue_bad_data.qsize())
+        for number in xrange(self.number):
             event = queue_bad_data.get(timeout=40)
             self.assertEquals(event.type_, "DeviceStatusEvent")
             self.assertEquals(event.origin, "instrument_1")
             self.assertEquals(event.state, DeviceStatusType.OUT_OF_RANGE)
             self.assertEquals(event.valid_values, self.valid_values)
             self.assertEquals(event.sub_type, 'input_voltage')
-#            self.assertTrue(event.values in val)
-#            self.assertTrue(event.time_stamps in numpy.array([l  for l in xrange(self.length)]))
+            self.assertTrue(set(event.values) ==  set(val))
+
+            s = set(event.time_stamps)
+            cond = s in [set(numpy.array([1  for l in xrange(self.length)]).tolist()), set(numpy.array([2  for l in xrange(self.length)]).tolist())]
+            self.assertTrue(cond)
 
         # To ensure that only the bad values generated the alert events. Queue should be empty now
         self.assertEquals(queue_bad_data.qsize(), 0)

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -376,7 +376,7 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         t = get_ion_ts()
         self.event_publisher.publish_event(  ts_created= t,  event_type = 'DeviceStatusEvent',
-                origin = instDevice_id, state=DeviceStatusType.OUT_OF_RANGE, value = 200 )
+                origin = instDevice_id, state=DeviceStatusType.OUT_OF_RANGE, values = [200] )
         self.event_publisher.publish_event( ts_created= t,   event_type = 'DeviceCommsEvent',
                 origin = instDevice_id, state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION, lapse_interval_seconds = 20 )
 


### PR DESCRIPTION
Both the tests that use this transform, test_transform_prototype.py and test_oms_launch2.py, are working fine after the mods.

The test, test_transform_prototype.py, needed to be fixed. It verifies the transform works correctly as advertised.
