### PR TITLE
Fixes UNS for end to end demo using ION-UX

### DIFF
--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -6,6 +6,7 @@
 @author Swarbhanu Chatterjee
 '''
 from pyon.util.log import log
+from pyon.core.exception import NotFound
 from pyon.util.containers import DotDict, get_ion_ts
 from pyon.util.arg_check import validate_is_instance, validate_true
 from pyon.event.event import EventPublisher, EventSubscriber
@@ -303,7 +304,15 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
         valid_values = config.get_safe('valid_values', [-100,100])
         variable_name = config.get_safe('variable_name', 'input_voltage')
         preferred_time = config.get_safe('time_field_name', 'preferred_timestamp')
-        origin = config.get_safe('origin', input.data_producer_id)
+
+        # Get the source of the granules which will be used to set the origin of the DeviceStatusEvent and DeviceCommsEvent events
+        origin = config.get_safe('origin')
+        if not origin:
+            origin = input.data_producer_id
+
+        if not origin:
+            raise NotFound("The DemoStreamAlertTransform could not figure out the origin. It needs to be provided an origin through a config for the DeviceStatus and DeviceCommsEvent events it will publish."
+                           "If not, then the data_producer_id attribute should be filled for the granules that are sent to it so that it can figure out the origin to use.")
 
         if origin != input.data_producer_id:
             log.debug("Received an event of the correct type but the wrong source!")

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -269,7 +269,7 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
                 # Publish the event
                 self.publisher.publish_event(
                     event_type = 'DeviceCommsEvent',
-                    origin = self.origin,
+                    origin = self.origin or "Not yet computed",
                     origin_type='PlatformDevice',
                     sub_type = self.instrument_variable_name,
                     time_stamp =int(time.time() + 2208988800),  # granules use NTP not unix

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -232,6 +232,8 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
         #-------------------------------------------------------------------------------------
         bad_values, bad_value_times, self.origin = AlertTransformAlgorithm.execute(msg, config = config)
 
+        if not bad_values: return
+
         log.debug("DemoStreamAlertTransform got the origin of the event as: %s" % self.origin)
 
         #-------------------------------------------------------------------------------------
@@ -311,7 +313,7 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
 
         if origin != input.data_producer_id:
             log.debug("Received an event of the correct type but the wrong source!")
-            return
+            return None, None, None
 
         log.debug("The origin the demo transform is listening to is: %s" % origin)
 

--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -102,7 +102,8 @@ class NotificationWorker(TransformEventListener):
             user_ids = check_user_notification_interest(event = msg, reverse_user_info = self.reverse_user_info)
 
         log.debug("Type of event received by notification worker: %s" % msg.type_)
-        log.debug("Notification worker deduced the following users were interested in the event: %s" % user_ids )
+        log.debug("Event received by notification worker: %s" % msg)
+        log.debug("Notification worker deduced the following users were interested in the event: %s, event_type: %s, origin: %s" % (user_ids, msg.type_, msg.origin ))
 
         #------------------------------------------------------------------------------------
         # Send email to the users

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -334,7 +334,8 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
                 'variable_name': 'input_voltage',
                 'time_field_name': 'preferred_timestamp',
                 'valid_values': self.valid_values,
-                'timer_origin': 'Interval Timer'
+                'timer_origin': 'Interval Timer',
+                'event_origin': 'instrument_1'
             }
         }
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -909,12 +909,16 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         notification_request_correct = NotificationRequest(   name = "notification_1",
             origin="instrument_1",
             origin_type="type_1",
-            event_type='ResourceLifecycleEvent')
+            event_type='ResourceLifecycleEvent',
+            event_subtype=''
+        )
 
         notification_request_2 = NotificationRequest(   name = "notification_2",
             origin="instrument_2",
             origin_type="type_2",
-            event_type='DetectionEvent')
+            event_type='DetectionEvent',
+            event_subtype=''
+        )
 
 
         #--------------------------------------------------------------------------------------

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -175,11 +175,6 @@ def check_user_notification_interest(event, reverse_user_info):
     @retval user_ids list
     '''
 
-    user_list_1 = []
-    user_list_2 = []
-    user_list_3 = []
-    user_list_4 = []
-
     if not isinstance(event, Event):
         raise BadRequest("The input parameter should have been an Event.")
 
@@ -195,19 +190,36 @@ def check_user_notification_interest(event, reverse_user_info):
     if not event or not reverse_user_info:
         raise BadRequest("Missing input parameters for method, check_user_notification_interest().")
 
+    users = set()
+
     if reverse_user_info['event_origin'].has_key(event.origin):
-        user_list_1 = reverse_user_info['event_origin'][event.origin]
+        if event.origin: # for an incoming event that has origin specified (this should be true for almost all events)
+            user_list_1 = set(reverse_user_info['event_origin'][event.origin])
+            if reverse_user_info['event_origin'].has_key(''): # for users who subscribe to any event origins
+                user_list_1 += reverse_user_info['event_origin']['']
+            users = user_list_1
 
     if reverse_user_info['event_origin_type'].has_key(event.origin_type):
-        user_list_2 = reverse_user_info['event_origin_type'][event.origin_type]
+        if event.origin_type: # for an incoming event with origin type specified
+            user_list_2 = reverse_user_info['event_origin_type'][event.origin_type]
+            if reverse_user_info['event_origin_type'].has_key(''): # for users who subscribe to any event origin types
+                user_list_2 += reverse_user_info['event_origin_type']['']
+            users = set.intersection(users, user_list_2)
 
     if reverse_user_info['event_type'].has_key(event.type_):
         user_list_3 = reverse_user_info['event_type'][event.type_]
+        if reverse_user_info['event_type'].has_key(''): # for users who subscribe to any event types
+            user_list_3 += reverse_user_info['event_type']['']
+        users = set.intersection(users, user_list_3)
 
     if reverse_user_info['event_subtype'].has_key(event.sub_type):
-        user_list_4 = reverse_user_info['event_subtype'][event.sub_type]
+        if event.sub_type: # for an incoming event with the sub type specified
+            user_list_4 = reverse_user_info['event_subtype'][event.sub_type]
+            if reverse_user_info['event_subtype'].has_key(''): # for users who subscribe to any event subtypes
+                user_list_4 += reverse_user_info['event_subtype']['']
+            users = set.intersection(users, user_list_4)
 
-    users = list( set.intersection(set(user_list_1), set(user_list_2), set(user_list_3), set(user_list_4)))
+    users = list( users)
 
     return users
 

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -199,6 +199,8 @@ def check_user_notification_interest(event, reverse_user_info):
                 user_list_1 += reverse_user_info['event_origin']['']
             users = user_list_1
 
+            log.debug("for event origin %s got interested users here  %s" % (event.origin, users))
+
     if reverse_user_info['event_origin_type'].has_key(event.origin_type):
         if event.origin_type: # for an incoming event with origin type specified
             user_list_2 = reverse_user_info['event_origin_type'][event.origin_type]
@@ -206,11 +208,16 @@ def check_user_notification_interest(event, reverse_user_info):
                 user_list_2 += reverse_user_info['event_origin_type']['']
             users = set.intersection(users, user_list_2)
 
+            log.debug("for event_origin_type: %s got interested users here  %s" % (event.origin_type, users))
+
     if reverse_user_info['event_type'].has_key(event.type_):
         user_list_3 = reverse_user_info['event_type'][event.type_]
         if reverse_user_info['event_type'].has_key(''): # for users who subscribe to any event types
             user_list_3 += reverse_user_info['event_type']['']
         users = set.intersection(users, user_list_3)
+
+        log.debug("for event_type: %s got interested users here  %s" % (event.type_, users))
+
 
     if reverse_user_info['event_subtype'].has_key(event.sub_type):
         if event.sub_type: # for an incoming event with the sub type specified
@@ -218,6 +225,9 @@ def check_user_notification_interest(event, reverse_user_info):
             if reverse_user_info['event_subtype'].has_key(''): # for users who subscribe to any event subtypes
                 user_list_4 += reverse_user_info['event_subtype']['']
             users = set.intersection(users, user_list_4)
+
+            log.debug("for event_subtype: %s got interested users here  %s" % (event.sub_type, users))
+
 
     users = list( users)
 


### PR DESCRIPTION
Patches uns_utility_method.py so that it can calculate the subscribed users correctly when notification requests are made with event_subtype set as ''. Made the method more resilient against different kinds of inputs.

Added the option to pass an origin to the demo stream alert transform when it is launched by sending it a  CFG.process.event_origin field. But this is just an option and it does NOT have to be passed the origin. The existing preload code will work fine. Existing tests which do not pass the origin will work fine too. When the origin is not being passed (as in several successfully running tests), the transform extracts the origin from the granule using its data_producer_id attribute.

The code now has been verified to atleast send fake emails using a fake smtp client to the correct user email address using the correct sender's address and with the right contents.

What is left is to try it from inside the UCSD VPN to send a real email using mail.oceanobservatories.org.
