### PR TITLE
Update to driver_process module to add driver launching via an egg

### DIFF
--- a/ion/agents/instrument/driver_process.py
+++ b/ion/agents/instrument/driver_process.py
@@ -418,7 +418,7 @@ class ZMQPyClassDriverProcess(DriverProcess):
 #        return self._packet_factories
 
 
-class ZMQEggDriverLauncher(DriverProcess):
+class ZMQEggDriverProcess(DriverProcess):
     """
     Object to facilitate driver processes launch from an egg as an 'eggsecutable'
     """

--- a/ion/agents/instrument/driver_process.py
+++ b/ion/agents/instrument/driver_process.py
@@ -338,13 +338,6 @@ class ZMQPyClassDriverProcess(DriverProcess):
 
         @param stream_info
 
-    def get_packet_factories(self, stream_info):
-        """
-        Construct packet factories from PACKET_CONFIG member of the driver_config
-        and the given stream_info dict.
-
-        @param stream_info
-
         @retval a dict indexed by stream name of the packet factories defined.
         """
 

--- a/ion/agents/instrument/driver_process.py
+++ b/ion/agents/instrument/driver_process.py
@@ -35,11 +35,7 @@ class DriverProcessType(BaseEnum):
     Base states for driver launcher types.
     """
     PYTHON_MODULE = 'ZMQPyClassDriverLauncher'
-<<<<<<< HEAD
-    EGG = 'ZMQEggDriverLauncherG'
-=======
     EGG = 'ZMQEggDriverLauncher'
->>>>>>> 8742114278a502a40ebd28480e69b0bdae763a46
 
 
 class DriverProcess(object):
@@ -342,7 +338,6 @@ class ZMQPyClassDriverProcess(DriverProcess):
 
         @param stream_info
 
-<<<<<<< HEAD
     def get_packet_factories(self, stream_info):
         """
         Construct packet factories from PACKET_CONFIG member of the driver_config
@@ -350,8 +345,6 @@ class ZMQPyClassDriverProcess(DriverProcess):
 
         @param stream_info
 
-=======
->>>>>>> 8742114278a502a40ebd28480e69b0bdae763a46
         @retval a dict indexed by stream name of the packet factories defined.
         """
 
@@ -431,12 +424,8 @@ class ZMQPyClassDriverProcess(DriverProcess):
 #
 #        return self._packet_factories
 
-<<<<<<< HEAD
-class ZMQEggDriverLauncher(DriverProcess):
-=======
 
 class ZMQEggDriverProcess(DriverProcess):
->>>>>>> 8742114278a502a40ebd28480e69b0bdae763a46
     """
     Object to facilitate driver processes launch from an egg as an 'eggsecutable'
     """

--- a/ion/agents/instrument/instrument_agent.py
+++ b/ion/agents/instrument/instrument_agent.py
@@ -155,10 +155,6 @@ class InstrumentAgent(ResourceAgent):
         # stream_config agent config member during process on_init.
         self._data_publishers = {}
 
-        # Factories for stream packets. Constructed by driver
-        # configuration information on transition to inactive.
-        self._packet_factories = {}
-                
     def on_init(self):
         """
         Instrument agent pyon process initialization.
@@ -384,8 +380,6 @@ class InstrumentAgent(ResourceAgent):
         # Start the driver and switch to inactive.
         self._start_driver(self._dvr_config)
 
-        self._construct_packet_factories()
-        
         next_state = ResourceAgentState.INACTIVE
 
         return (next_state, result)
@@ -401,7 +395,6 @@ class InstrumentAgent(ResourceAgent):
         next_state = None
 
         result = self._stop_driver()
-        self._clear_packet_factories()
         next_state = ResourceAgentState.UNINITIALIZED
   
         return (next_state, result)
@@ -455,7 +448,6 @@ class InstrumentAgent(ResourceAgent):
         self._dvr_client.cmd_dvr('disconnect')
         self._dvr_client.cmd_dvr('initialize')        
         result = self._stop_driver()
-        self._clear_packet_factories()        
         next_state = ResourceAgentState.UNINITIALIZED
   
         return (next_state, result)
@@ -495,7 +487,6 @@ class InstrumentAgent(ResourceAgent):
         self._dvr_client.cmd_dvr('disconnect')
         self._dvr_client.cmd_dvr('initialize')        
         result = self._stop_driver()
-        self._clear_packet_factories()        
         next_state = ResourceAgentState.UNINITIALIZED
         
         return (next_state, result)        
@@ -543,7 +534,6 @@ class InstrumentAgent(ResourceAgent):
         self._dvr_client.cmd_dvr('disconnect')
         self._dvr_client.cmd_dvr('initialize')        
         result = self._stop_driver()
-        self._clear_packet_factories()        
         next_state = ResourceAgentState.UNINITIALIZED
         
         return (next_state, result)        
@@ -641,7 +631,6 @@ class InstrumentAgent(ResourceAgent):
         self._dvr_client.cmd_dvr('disconnect')
         self._dvr_client.cmd_dvr('initialize')        
         result = self._stop_driver()
-        self._clear_packet_factories()        
         next_state = ResourceAgentState.UNINITIALIZED
           
         return (next_state, result)        
@@ -1136,26 +1125,7 @@ class InstrumentAgent(ResourceAgent):
                                 publisher for stream %s.', self._proc_name,
                                 stream_name)
 
-    def _construct_packet_factories(self):
-        """
-        Construct packet factories from packet_config member of the
-        driver_config and self.CFG.stream_config.
-        @retval None
-        """
-        self._packet_factories = self._dvr_proc.get_packet_factories(
-            self.CFG.stream_config)
-        log.info('Insturment agent %s constructed its packet factories.',
-                 self._proc_name)
-        
-    def _clear_packet_factories(self):
-        """
-        Delete packet factories.
-        @retval None
-        """
-        self._packet_factories.clear()
-        log.info('Instrument agent %s deleted packet factories.',
-                 self._proc_name)
-        
+
     ###############################################################################
     # Event callback and handling for direct access.
     ###############################################################################

--- a/ion/agents/instrument/test/test_driver_process.py
+++ b/ion/agents/instrument/test/test_driver_process.py
@@ -84,15 +84,6 @@ class TestInstrumentDriverProcess(PyonTestCase):
         self.assertTrue(driver_client)
 
         driver_client.start_messaging(self.event_received)
-        #
-        # Do we need to verify events here?  Is it deterministic behavior?
-        #
-
-        stream_info = CFG.get('stream_config', None)
-
-        #@TODO re-enable this when stream_info is defined
-        #packet_factories = driver_process.get_packet_factories(stream_info)
-        #self.assertTrue(packet_factories)
 
         self.assertGreater(driver_process.memory_usage(), 0)
         log.info("Driver memory usage before stop: %d", driver_process.memory_usage())
@@ -104,7 +95,6 @@ class TestInstrumentDriverProcess(PyonTestCase):
         """
         Test the driver launching process for a class and module
         """
-
         self.assert_driver_process_launch_success(self._class_driver_config)
 
     def test_driver_process_by_egg(self):

--- a/ion/agents/instrument/test/test_driver_process.py
+++ b/ion/agents/instrument/test/test_driver_process.py
@@ -19,7 +19,7 @@ from pyon.util.unit_test import PyonTestCase
 
 from pyon.public import log
 
-from ion.agents.instrument.driver_process import DriverProcess, DriverProcessType, ZMQEggDriverLauncher
+from ion.agents.instrument.driver_process import DriverProcess, DriverProcessType, ZMQEggDriverProcess
 from ion.agents.instrument.exceptions import DriverLaunchException
 
 # Make tests verbose and provide stdout
@@ -42,7 +42,7 @@ class TestInstrumentDriverProcess(PyonTestCase):
             'dvr_mod': 'mi.instrument.seabird.sbe37smb.example.driver',
             'dvr_cls': 'InstrumentDriver',
 
-            'process_type': DriverProcessType.PYTHON_MODULE
+            'process_type': [DriverProcessType.PYTHON_MODULE]
         }
 
         self._egg_driver_config = {
@@ -52,7 +52,7 @@ class TestInstrumentDriverProcess(PyonTestCase):
 
             'dvr_egg': 'seabird_sbe37smb_ooicore-0.0.1-py2.7.egg',
 
-            'process_type': DriverProcessType.EGG
+            'process_type': [DriverProcessType.EGG]
         }
 
         self._events = []
@@ -90,8 +90,9 @@ class TestInstrumentDriverProcess(PyonTestCase):
 
         stream_info = CFG.get('stream_config', None)
 
-        packet_factories = driver_process.get_packet_factories(stream_info)
-        self.assertTrue(packet_factories)
+        #@TODO re-enable this when stream_info is defined
+        #packet_factories = driver_process.get_packet_factories(stream_info)
+        #self.assertTrue(packet_factories)
 
         self.assertGreater(driver_process.memory_usage(), 0)
         log.info("Driver memory usage before stop: %d", driver_process.memory_usage())
@@ -136,7 +137,7 @@ class TestInstrumentDriverProcess(PyonTestCase):
             # ignore this exception.
             """
 
-        launcher = ZMQEggDriverLauncher("DUMMY_VAL")
+        launcher = ZMQEggDriverProcess("DUMMY_VAL")
         self.assertEqual(launcher._check_cache_for_egg("NOT_FOUND_EGG"), None)
         self.assertEqual(launcher._check_cache_for_egg("seabird_sbe37smb_ooicore-0.0.1-py2.7.egg"), None)
 
@@ -147,7 +148,7 @@ class TestInstrumentDriverProcess(PyonTestCase):
         path for cached egg if not present locally, but in repo, or exception if not present locally or in repo.
         """
 
-        launcher = ZMQEggDriverLauncher("DUMMY_VAL")
+        launcher = ZMQEggDriverProcess("DUMMY_VAL")
         got_exception = False
         try:
             self.assertEqual(launcher._get_remote_egg("NOT_FOUND_EGG"), None)
@@ -165,7 +166,7 @@ class TestInstrumentDriverProcess(PyonTestCase):
         """
         # Cleanup on isle one!
 
-        launcher = ZMQEggDriverLauncher("DUMMY_VAL")
+        launcher = ZMQEggDriverProcess("DUMMY_VAL")
         self.assertEqual(launcher._check_cache_for_egg("NOT_FOUND_EGG"), None)
         self.assertEqual(launcher._check_cache_for_egg("seabird_sbe37smb_ooicore-0.0.1-py2.7.egg"), "/tmp/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
 
@@ -175,7 +176,7 @@ class TestInstrumentDriverProcess(PyonTestCase):
         eggs, and exception for non-existing in the repo.
         """
 
-        launcher = ZMQEggDriverLauncher("DUMMY_VAL")
+        launcher = ZMQEggDriverProcess("DUMMY_VAL")
 
         got_exception = False
         try:

--- a/ion/agents/instrument/test/test_driver_process.py
+++ b/ion/agents/instrument/test/test_driver_process.py
@@ -10,22 +10,23 @@
 __author__ = 'Bill French'
 __license__ = 'Apache 2.0'
 
+import os
 import time
 import unittest
-
+from pyon.public import CFG
 from nose.plugins.attrib import attr
 from pyon.util.unit_test import PyonTestCase
 
 from pyon.public import log
 
-from ion.agents.instrument.driver_process import DriverProcess, DriverProcessType
+from ion.agents.instrument.driver_process import DriverProcess, DriverProcessType, ZMQEggDriverLauncher
+from ion.agents.instrument.exceptions import DriverLaunchException
 
 # Make tests verbose and provide stdout
 # bin/nosetests -s -v ion/agents.instrument/test/test_driver_launcher.py
 
-@unittest.skip("more negitive testing needed")
 @attr('UNIT', group='mi')
-class TestPythonClassDriverProcess(PyonTestCase):
+class TestInstrumentDriverProcess(PyonTestCase):
     """
     Unit tests for Driver Process using python classes
     """
@@ -33,7 +34,8 @@ class TestPythonClassDriverProcess(PyonTestCase):
         """
         Setup test cases.
         """
-        self._driver_config = { 'host': 'localhost',
+        self._class_driver_config = {
+            'host': 'localhost',
             'cmd_port': 5556,
             'evt_port': 5557,
 
@@ -43,18 +45,32 @@ class TestPythonClassDriverProcess(PyonTestCase):
             'process_type': DriverProcessType.PYTHON_MODULE
         }
 
+        self._egg_driver_config = {
+            'host': 'localhost',
+            'cmd_port': 5556,
+            'evt_port': 5557,
+
+            'dvr_egg': 'seabird_sbe37smb_ooicore-0.0.1-py2.7.egg',
+
+            'process_type': DriverProcessType.EGG
+        }
+
+        self._events = []
+
 
         # Add cleanup handler functions.
         # self.addCleanup()
 
-    def event_received(self):
+    def event_received(self, event):
         log.debug("Event received")
+        self._events.append(event)
 
-    def test_driver_process(self):
+    def assert_driver_process_launch_success(self, driver_config):
         """
-        Test driver process launch
+        Verify that we can launch a driver using a driver config.
+        @param driver_config: driver configuration dictionary
         """
-        driver_process = DriverProcess.get_process(self._driver_config, True)
+        driver_process = DriverProcess.get_process(driver_config, True)
         self.assertTrue(driver_process)
 
         driver_process.launch()
@@ -67,9 +83,14 @@ class TestPythonClassDriverProcess(PyonTestCase):
         driver_client = driver_process.get_client()
         self.assertTrue(driver_client)
 
-        driver_client.start_messaging(self.event_received())
+        driver_client.start_messaging(self.event_received)
+        #
+        # Do we need to verify events here?  Is it deterministic behavior?
+        #
 
-        packet_factories = driver_process.get_packet_factories()
+        stream_info = CFG.get('stream_config', None)
+
+        packet_factories = driver_process.get_packet_factories(stream_info)
         self.assertTrue(packet_factories)
 
         self.assertGreater(driver_process.memory_usage(), 0)
@@ -78,19 +99,88 @@ class TestPythonClassDriverProcess(PyonTestCase):
         driver_process.stop()
         self.assertFalse(driver_process.getpid())
 
-
-
-
-
-@attr('UNIT', group='mi')
-class TestEggDriverProcess(PyonTestCase):
-    """
-    Unit tests for Driver Process using eggs
-    """
-    
-    def setUp(self):
+    def test_driver_process_by_class(self):
         """
-        Setup test cases.
+        Test the driver launching process for a class and module
         """
-        pass
 
+        self.assert_driver_process_launch_success(self._class_driver_config)
+
+    def test_driver_process_by_egg(self):
+        """
+        Test the driver launching process for a class and module
+        """
+        try:
+            os.unlink("/tmp/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
+        except:
+            """
+            # ignore this exception.
+            """
+
+        # remove egg from cache and run.  Verifies download
+        self.assert_driver_process_launch_success(self._egg_driver_config)
+
+        # Verify egg is in cache then run again
+        self.assert_driver_process_launch_success(self._egg_driver_config)
+
+    def test_01_check_cache_for_egg(self):
+        """
+        Test _check_cache_for_egg  checks the cache for the egg,
+        returns path if present locally, or None if not.
+        """
+        # Cleanup on isle one!
+        try:
+            os.unlink("/tmp/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
+        except:
+            """
+            # ignore this exception.
+            """
+
+        launcher = ZMQEggDriverLauncher("DUMMY_VAL")
+        self.assertEqual(launcher._check_cache_for_egg("NOT_FOUND_EGG"), None)
+        self.assertEqual(launcher._check_cache_for_egg("seabird_sbe37smb_ooicore-0.0.1-py2.7.egg"), None)
+
+
+    def test_02_get_remote_egg(self):
+        """
+        Test _get_remote_egg should return path for cached egg if present,
+        path for cached egg if not present locally, but in repo, or exception if not present locally or in repo.
+        """
+
+        launcher = ZMQEggDriverLauncher("DUMMY_VAL")
+        got_exception = False
+        try:
+            self.assertEqual(launcher._get_remote_egg("NOT_FOUND_EGG"), None)
+        except DriverLaunchException:
+            got_exception = True
+        self.assertTrue(got_exception)
+
+        self.assertEqual(launcher._get_remote_egg("seabird_sbe37smb_ooicore-0.0.1-py2.7.egg"), "/tmp/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
+
+
+    def test_03_check_cache_for_egg(self):
+        """
+        Test _check_cache_for_egg  checks the cache for the egg,
+        returns path if present locally, or None if not.
+        """
+        # Cleanup on isle one!
+
+        launcher = ZMQEggDriverLauncher("DUMMY_VAL")
+        self.assertEqual(launcher._check_cache_for_egg("NOT_FOUND_EGG"), None)
+        self.assertEqual(launcher._check_cache_for_egg("seabird_sbe37smb_ooicore-0.0.1-py2.7.egg"), "/tmp/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
+
+    def test_04_get_egg(self):
+        """
+        Test _get_egg should return a path to a local egg for existing
+        eggs, and exception for non-existing in the repo.
+        """
+
+        launcher = ZMQEggDriverLauncher("DUMMY_VAL")
+
+        got_exception = False
+        try:
+            self.assertEqual(launcher._get_egg("NOT_FOUND_EGG"), None)
+        except DriverLaunchException:
+            got_exception = True
+        self.assertTrue(got_exception)
+        self.assertEqual(launcher._get_egg("seabird_sbe37smb_ooicore-0.0.1-py2.7.egg"), "/tmp/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")


### PR DESCRIPTION
This update puts the changes in place to start launching drivers from eggs.  However, changes still need to be made to IMS or where ever the driver_config dictionary is created to start using this feature.

Also, it appears that the instrument agent no longer uses the packet factory class.  So I've removed that code from the instrument agent and driver process module.
