### PR TITLE
Fix for OOIION-581

### DIFF
--- a/ion/agents/cei/execution_engine_agent.py
+++ b/ion/agents/cei/execution_engine_agent.py
@@ -60,7 +60,7 @@ class ExecutionEngineAgent(SimpleResourceAgent):
 
         interval = self.CFG.eeagent.get('heartbeat', DEFAULT_HEARTBEAT)
         if interval > 0:
-            self.heartbeater = HeartBeater(self.CFG, self._factory, self.id, log=log)
+            self.heartbeater = HeartBeater(self.CFG, self._factory, self.resource_id, log=log)
             self.heartbeater.poll()
             self.heartbeat_thread = looping_call(0.1, self.heartbeater.poll)
         else:

--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -19,13 +19,13 @@ from gevent import event as gevent_event
 
 try:
     from epu.processdispatcher.core import ProcessDispatcherCore
-    from epu.processdispatcher.store import ProcessDispatcherStore
+    from epu.processdispatcher.store import get_processdispatcher_store
     from epu.processdispatcher.engines import EngineRegistry
     from epu.processdispatcher.matchmaker import PDMatchmaker
     from epu.dashiproc.epumanagement import EPUManagementClient
 except ImportError:
     ProcessDispatcherCore = None
-    ProcessDispatcherStore = None
+    get_processdispatcher_store = None
     EngineRegistry = None
     PDMatchmaker = None
     EPUManagementClient = None
@@ -789,7 +789,9 @@ class PDNativeBackend(object):
         default_engine = conf.get('default_engine')
         if default_engine is None and len(engine_conf.keys()) == 1:
             default_engine = engine_conf.keys()[0]
-        self.store = ProcessDispatcherStore()
+        self.CFG = service.CFG
+        self.store = get_processdispatcher_store(self.CFG, use_gevent=True)
+        self.store.initialize()
         self.registry = EngineRegistry.from_config(engine_conf, default=default_engine)
 
         # The Process Dispatcher communicates with EE Agents over ION messaging

--- a/ion/services/cei/test/test_process_dispatcher.py
+++ b/ion/services/cei/test/test_process_dispatcher.py
@@ -275,10 +275,10 @@ class ProcessDispatcherServiceNativeTest(PyonTestCase):
 
         with patch.multiple('ion.services.cei.process_dispatcher_service',
                 get_dashi=DEFAULT, ProcessDispatcherCore=DEFAULT,
-                ProcessDispatcherStore=DEFAULT, EngineRegistry=DEFAULT,
+                get_processdispatcher_store=DEFAULT, EngineRegistry=DEFAULT,
                 PDMatchmaker=DEFAULT) as mocks:
             mocks['get_dashi'].return_value = self.mock_dashi
-            mocks['ProcessDispatcherStore'].return_value = self.mock_store = Mock()
+            mocks['get_processdispatcher_store'].return_value = self.mock_store = Mock()
             mocks['ProcessDispatcherCore'].return_value = self.mock_core = Mock()
             mocks['PDMatchmaker'].return_value = self.mock_matchmaker = Mock()
             mocks['EngineRegistry'].return_value = self.mock_engineregistry = Mock()


### PR DESCRIPTION
Fixes PD->EEAgent messaging after the EEAgent container has failed and restarted. Previously the PD would send messages into the ether and timeout.
