### PR TITLE
Reduce the number of required granules by half so SMOKE passes

### DIFF
--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -301,7 +301,7 @@ class TestDMEnd2End(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------
 
         self.launch_producer(stream_id)
-        self.wait_until_we_have_enough_granules(dataset_id,4)
+        self.wait_until_we_have_enough_granules(dataset_id,2)
         
         #--------------------------------------------------------------------------------
         # Now get the data in one chunk using an RPC Call to start_retreive


### PR DESCRIPTION
SMOKE tests timeout on buildbot, this reduces the number of granules to
test by half so that it doesn't timeout
