### PR TITLE
Shoud fix the status roll up seen through the UI (OOIION 622)

### DIFF
--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -269,8 +269,8 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
                     origin = self.origin,
                     origin_type='PlatformDevice',
                     sub_type = self.instrument_variable_name,
-#                    time_stamp =int(time.time() + 2208988800),  # granules use NTP not unix
-                    time_stamp = get_ion_ts(),
+                    time_stamp =int(time.time() + 2208988800),  # granules use NTP not unix
+#                    time_stamp = get_ion_ts(),
                     state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION,
                     lapse_interval_seconds=self.timer_interval,
                     description = "Event to deliver the communications status of the instrument."


### PR DESCRIPTION
Fixes the timestamp being published for the DeviceCommsEvent so that it uses NTP time.

Have verified that the status icon (which resembles the power symbol) changes to good/bad when the UI page is refreshed.

This, therefore, should fix the status roll up.

All tests working.
