### PR TITLE
OOIION-626: use DeviceEvent instead of PlatformAlarmEvent

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -635,11 +635,8 @@ class PlatformAgent(ResourceAgent):
                 self._platform_id, stream_name, str(rdt), str(g))
 
     def _handle_external_event_driver_event(self, driver_event):
-        #
-        # TODO appropriate granularity and structure of the event.
 
         event_type = driver_event._event_type
-        ts = driver_event._ts
 
         event_instance = driver_event._event_instance
         platform_id = event_instance.get('platform_id', None)
@@ -650,19 +647,14 @@ class PlatformAgent(ResourceAgent):
         # TODO appropriate origin for the event
         origin = platform_id  # self.resource_id
 
-        # TODO re 'external_alarm_type' and event_type='PlatformAlarmEvent' below:
-        # ion-definitions still has 'PlatformAlarmEvent' and 'external_alarm_type'
-        # but it should be changed so it reflects the more generic "platform event"
-        # term. However, note that there is already a pre-existing 'PlatformEvent'
-        # in ion-definitions so we may need to define 'PlatformExternalEvent'
-        # or something like that.
+        description  = "message: %s" % message
+        description += "; group: %s" % group
+        description += "; external_event_type: %s" % event_type
+        description += "; external_timestamp: %s" % timestamp
 
         event_data = {
-            'description':  message,
-            'sub_type':     group,      # ID of event categorization
-            'ts_created':   ts,         # time of reception at the driver
-            'external_alarm_type':   event_type,
-            'external_timestamp':    timestamp,  # as given by OMS
+            'description':  description,
+            'sub_type':     'platform_event',
         }
 
         log.info("%r: publishing external platform event: event_data=%s",
@@ -670,7 +662,7 @@ class PlatformAgent(ResourceAgent):
 
         try:
             self._event_publisher.publish_event(
-                event_type='PlatformAlarmEvent',
+                event_type='DeviceEvent',
                 origin=origin,
                 **event_data)
 

--- a/ion/services/sa/observatory/test/test_oms_launch2.py
+++ b/ion/services/sa/observatory/test/test_oms_launch2.py
@@ -501,13 +501,11 @@ class TestOmsLaunch(IonIntegrationTestCase):
         finally:
             self._data_subscribers = []
 
-    def _start_event_subscriber(self, event_type="PlatformAlarmEvent", sub_type="power"):
+    def _start_event_subscriber(self, event_type="DeviceEvent", sub_type="platform_event"):
         """
-        Starts event subscriber for events of given event_type ("PlatformAlarmEvent"
-        by default) and given sub_type ("power" by default).
+        Starts event subscriber for events of given event_type ("DeviceEvent"
+        by default) and given sub_type ("platform_event" by default).
         """
-        # TODO note: ion-definitions still using 'PlatformAlarmEvent' but we
-        # should probably define 'PlatformExternalEvent' or something like that.
 
         def consume_event(evt, *args, **kwargs):
             # A callback for consuming events.


### PR DESCRIPTION
https://jira.oceanobservatories.org/tasks/browse/OOIION-626

Changes done:

For publication of platform events, PlatformAlarmEvent is not used anymore. 
Instead, DeviceEvent is used directly. The attributes in PlatformAlarmEvent previously used,
(external_alarm_type, external_timestamp) are now captured as part of the description,
which now also includes the "group" associated to the event, eg., "power", This group
was previously captured in the event's sub_type. Now the event's sub_type is "platform_event".

NOTE: Using "platform event" termonology instead "platform alarm" because "platform event" is 
the more generic term here (not all platform events are platform alarms).

W.r.t. ion/services/sa/observatory/test/test_oms_launch2.py, the above change is reflected
as follows in the logs:
- publication of platform event:

2012-12-17 15:45:09,561 INFO Dummy-156 ion.agents.platform.platform_agent:661 'LJ01D': publishing external platform event: event_data={'description': 'message: low battery (synthetic event generated from simulator); group: power; external_event_type: 44.78; external_timestamp: 3564776709.55', 'sub_type': 'platform_event'}
2012-12-17 15:45:09,561 TRACE Dummy-156 pyon.event.event:92 Publishing event message to ('ion_test_2c14fa.pyon.events', 'Event.DeviceEvent.platform_event._.TODO_some_platform_id_of_type_UPS')
2012-12-17 15:45:09,561 DEBUG Dummy-156 pyon.net.channel:340 SendChannel.connect: NP (ion_test_2c14fa.pyon.events,Event.DeviceEvent.platform_event._.TODO_some_platform_id_of_type_UPS,B: Event.DeviceEvent.platform_event._.TODO_some_platform_id_of_type_UPS)
- reception of event by subscriber in test:

2012-12-17 15:45:09,572 INFO Dummy-142 ion.services.sa.observatory.test.test_oms_launch2:514 Event subscriber received evt: {'origin': 'TODO_some_platform_id_of_type_UPS', 'description': 'message: low battery (synthetic event generated from simulator); group: power; external_event_type: 44.78; external_timestamp: 3564776709.55', 'type_': 'DeviceEvent', 'base_types': ['Event'], 'ts_created': '1355787909561', 'sub_type': 'platform_event', 'origin_type': ''}.

Before the change, the same elements looked like the following:
- publication of platform event:

2012-12-17 15:21:56,436 INFO Dummy-157 ion.agents.platform.platform_agent:669 'LJ01D': publishing external platform event: event_data={'external_alarm_type': '44.78', 'external_timestamp': 3564775316.4313583, 'ts_created': 3564775316.436277, 'description': 'low battery (synthetic event generated from simulator)', 'sub_type': 'power'}
2012-12-17 15:21:56,436 TRACE Dummy-157 pyon.event.event:92 Publishing event message to ('ion_test_acf8c5.pyon.events', 'Event.DeviceEvent.PlatformEvent.PlatformAlarmEvent.power._.TODO_some_platform_id_of_type_UPS')
2012-12-17 15:21:56,437 DEBUG Dummy-157 pyon.net.channel:340 SendChannel.connect: NP (ion_test_acf8c5.pyon.events,Event.DeviceEvent.PlatformEvent.PlatformAlarmEvent.power._.TODO_some_platform_id_of_type_UPS,B: Event.DeviceEvent.PlatformEvent.PlatformAlarmEvent.power._.TODO_some_platform_id_of_type_UPS)
- reception of event by subscriber in test:

2012-12-17 15:41:22,753 INFO Dummy-142 ion.services.sa.observatory.test.test_oms_launch2:514 Event subscriber received evt: {'origin': 'TODO_some_platform_id_of_type_UPS', 'description': 'low battery (synthetic event generated from simulator)', 'type_': 'PlatformAlarmEvent', 'base_types': ['PlatformEvent', 'DeviceEvent', 'Event'], 'external_alarm_type': '44.78', 'external_timestamp': 3564776482.7359943, 'ts_created': 3564776482.741375, 'sub_type': 'power', 'origin_type': ''}.

---

NOTE regarding NTP:
Maurice: I haven't changed anything related with the use of NTP in the underlying RSN OMS interface. According to our conversation today, this would be a matter of doing conversions so the interface to CI is basically according to whatever is required there, but then translating back a fort the underlying NTP timestamps.  However, I'm doing the pull request with the part already implemented as indicated above as it's about a very specific change in terms of event definitions. If you agree, let's create a separate bug for the NTP conversions. Thanks. 
