### PR TITLE
Shuts down the demo transform safely after tests using them are completed

### DIFF
--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -38,6 +38,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         self.ssclient = SchedulerServiceClient()
         self.event_publisher = EventPublisher()
         self.user_notification = UserNotificationServiceClient()
+        self.process_dispatcher = ProcessDispatcherServiceClient()
 
         self.exchange_names = []
         self.exchange_points = []
@@ -121,7 +122,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
             module='ion.processes.data.transforms.event_alert_transform',
             class_name='EventAlertTransform',
             configuration= configuration)
-
+        self.addCleanup(self.process_dispatcher.cancel_process, pid)
         self.assertIsNotNone(pid)
 
         #-------------------------------------------------------------------------------------
@@ -232,7 +233,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
             module='ion.processes.data.transforms.event_alert_transform',
             class_name='StreamAlertTransform',
             configuration= config)
-
+        self.addCleanup(self.process_dispatcher.cancel_process, pid)
         self.assertIsNotNone(pid)
 
         #-------------------------------------------------------------------------------------
@@ -348,7 +349,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
             module='ion.processes.data.transforms.event_alert_transform',
             class_name='DemoStreamAlertTransform',
             configuration= config)
-
+        self.addCleanup(self.process_dispatcher.cancel_process, pid)
         self.assertIsNotNone(pid)
 
         #-------------------------------------------------------------------------------------

--- a/ion/services/sa/observatory/test/test_oms_launch2.py
+++ b/ion/services/sa/observatory/test/test_oms_launch2.py
@@ -591,7 +591,7 @@ class TestOmsLaunch(IonIntegrationTestCase):
 
         platform_data_process_id = self.dataprocessclient.create_data_process(self.platform_dprocdef_id, [self.data_product_id], {}, config)
         self.dataprocessclient.activate_data_process(platform_data_process_id)
-
+        self.addCleanup(self.dataprocessclient.delete_data_process, platform_data_process_id)
 
         #-------------------------------
         # Launch Base Platform AgentInstance, connect to the resource agent client


### PR DESCRIPTION
Uses the addCleanup() method of integration tests to shut down the demo transform process in integration tests which use the transform.

This should allow the container to stop nicely without problems created by the demo transform keeping on publishing DeviceCommsEvents after the platform agent has been turned off at the end of an integration test.
