### PR TITLE
Part of OOIION-619 and fixes buildbot (test_demo_stream_granules_processing) 

### DIFF
--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -34,11 +34,8 @@ class NotificationWorker(TransformEventListener):
         '''
         This method exists only to facilitate the testing of the reload of the user_info dictionary
         '''
-        log.debug("TEST HOOK Got the user_info here: %s AND reverse_user_info: %s" % (user_info, reverse_user_info))
+        log
         self.q.put((user_info, reverse_user_info))
-        log.debug("HERERE Got the size of the queue here: %s" % self.q.qsize())
-        log.debug("HERERE Got the queue here: %s" % self.q)
-        pass
 
     def on_start(self):
         super(NotificationWorker,self).on_start()

--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -17,6 +17,7 @@ from ion.services.dm.utility.uns_utility_methods import setting_up_smtp_client, 
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
 
 import gevent, time
+from gevent import queue
 
 class NotificationWorker(TransformEventListener):
     """
@@ -25,12 +26,18 @@ class NotificationWorker(TransformEventListener):
     def on_init(self):
         self.user_info = {}
         self.resource_registry = ResourceRegistryServiceClient()
+        self.q = gevent.queue.Queue()
+
         super(NotificationWorker, self).on_init()
 
     def test_hook(self, user_info, reverse_user_info ):
         '''
         This method exists only to facilitate the testing of the reload of the user_info dictionary
         '''
+        log.debug("TEST HOOK Got the user_info here: %s AND reverse_user_info: %s" % (user_info, reverse_user_info))
+        self.q.put((user_info, reverse_user_info))
+        log.debug("HERERE Got the size of the queue here: %s" % self.q.qsize())
+        log.debug("HERERE Got the queue here: %s" % self.q)
         pass
 
     def on_start(self):

--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -83,7 +83,7 @@ class NotificationWorker(TransformEventListener):
         self.reload_user_info_subscriber = EventSubscriber(
             event_type="ReloadUserInfoEvent",
             origin='UserNotificationService',
-#            queue_name='user_notification',
+            queue_name='notification_worker',
             callback=reload_user_info
         )
         self.reload_user_info_subscriber.start()

--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -34,7 +34,6 @@ class NotificationWorker(TransformEventListener):
         '''
         This method exists only to facilitate the testing of the reload of the user_info dictionary
         '''
-        log
         self.q.put((user_info, reverse_user_info))
 
     def on_start(self):

--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -83,6 +83,7 @@ class NotificationWorker(TransformEventListener):
         self.reload_user_info_subscriber = EventSubscriber(
             event_type="ReloadUserInfoEvent",
             origin='UserNotificationService',
+#            queue_name='user_notification',
             callback=reload_user_info
         )
         self.reload_user_info_subscriber.start()

--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -86,7 +86,6 @@ class NotificationWorker(TransformEventListener):
         self.reload_user_info_subscriber = EventSubscriber(
             event_type="ReloadUserInfoEvent",
             origin='UserNotificationService',
-            queue_name='notification_worker',
             callback=reload_user_info
         )
         self.reload_user_info_subscriber.start()

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -285,6 +285,8 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
 
         return pid
 
+    @attr('LOCOINT')
+    @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Skip test while in CEI LAUNCH mode')
     def test_demo_stream_granules_processing(self):
         """
         Test that the Demo Stream Alert Transform is functioning. The transform coordinates with the scheduler.

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -692,17 +692,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         gevent.sleep(4)
 
-        for key in processes:
-            if key.startswith('notification_worker'):
-                proc1 = processes[key]
-                queue = proc1.q
-
-                if queue.qsize() > 0:
-                    log.debug("the name 2: %s" % key)
-
-                    reloaded_user_info, reloaded_reverse_user_info = queue.get(timeout=10)
-                    self.assertTrue(queue.empty())
-                    break
+        reloaded_user_info,  reloaded_reverse_user_info= self.poll(9, found_user_info_dicts, processes)
 
         notification_request_2 = self.rrc.read(notification_id_2)
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -8,7 +8,6 @@
 from pyon.util.int_test import IonIntegrationTestCase
 from pyon.util.unit_test import PyonTestCase
 from pyon.util.containers import DotDict, get_ion_ts
-from pyon.util.poller import poll
 from pyon.public import IonObject, RT, OT, PRED, Container, CFG
 from pyon.core.exception import NotFound, BadRequest
 from pyon.core.bootstrap import get_sys_name
@@ -649,9 +648,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         processes =self.container.proc_manager.procs
 
-#        gevent.sleep(4)
-        reloaded_user_info, reloaded_reverse_user_info, process_queue = (None,None,None)
-
         def found_user_info_dicts(processes, *args, **kwargs):
 
             for key in processes:
@@ -660,7 +656,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
                     queue = proc1.q
 
                     if queue.qsize() > 0:
-                        log.debug("the name 1: %s" % key)
+                        log.debug("the name of the process: %s" % key)
 
                         reloaded_user_info, reloaded_reverse_user_info = queue.get(timeout=10)
                         self.assertTrue(queue.empty())
@@ -689,8 +685,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------------
 
         notification_id_2 = self.unsc.create_notification(notification=notification_request_2, user_id=user_id)
-
-        gevent.sleep(4)
 
         reloaded_user_info,  reloaded_reverse_user_info= self.poll(9, found_user_info_dicts, processes)
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -648,41 +648,17 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         processes =self.container.proc_manager.procs
 
-        worker_process = None
         gevent.sleep(4)
         reloaded_user_info, reloaded_reverse_user_info, process_queue = (None,None,None)
 
-
-#        proc1 = self.container.proc_manager.procs.get(pids[0])
-#        log.debug("Got the process here: %s" % proc1)
-
-#        ar_1 = gevent.event.AsyncResult()
-#        ar_2 = gevent.event.AsyncResult()
-
-#        def received_reload(msg, headers):
-#            log.debug("received reload here: msg=%s, headers=%s" % (msg, headers))
-#            ar_1.set(msg)
-#            ar_2.set(headers)
-#
-#
-#        proc1.test_hook = received_reload
-#
-#        log.debug("Got the hooked method here: %s" % proc1.test_hook)
-#        log.debug("proc1.user_info:: %s" % proc1.user_info)
-
-#        reloaded_user_info = ar_1.get(timeout=20)
-#        reloaded_reverse_user_info = ar_2.get(timeout=20)
-
         for key in processes:
             if key.startswith('notification_worker'):
-                log.debug("got the process: %s" % key)
                 proc1 = processes[key]
                 queue = proc1.q
 
                 if queue.qsize() > 0:
                     reloaded_user_info, reloaded_reverse_user_info = queue.get(timeout=10)
                     self.assertTrue(queue.empty())
-                    worker_process = proc1
                     break
 
         self.assertIsNotNone(reloaded_user_info)
@@ -707,27 +683,17 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         notification_id_2 = self.unsc.create_notification(notification=notification_request_2, user_id=user_id)
 
-#        ar_1 = gevent.event.AsyncResult()
-#        ar_2 = gevent.event.AsyncResult()
-#
-#        reloaded_user_info = ar_1.get(timeout=20)
-#        reloaded_reverse_user_info = ar_2.get(timeout=20)
-
         gevent.sleep(4)
 
         for key in processes:
             if key.startswith('notification_worker'):
-                log.debug("got the process: %s" % key)
                 proc1 = processes[key]
                 queue = proc1.q
 
                 if queue.qsize() > 0:
                     reloaded_user_info, reloaded_reverse_user_info = queue.get(timeout=10)
                     self.assertTrue(queue.empty())
-                    worker_process = proc1
                     break
-
-#        reloaded_user_info, reloaded_reverse_user_info = worker_process.q.get(timeout=10)
 
         notification_request_2 = self.rrc.read(notification_id_2)
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -646,19 +646,33 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Check the user_info and reverse_user_info got reloaded
         #--------------------------------------------------------------------------------------
         proc1 = self.container.proc_manager.procs.get(pids[0])
+        log.debug("Got the process here: %s" % proc1)
 
-        ar_1 = gevent.event.AsyncResult()
-        ar_2 = gevent.event.AsyncResult()
+#        ar_1 = gevent.event.AsyncResult()
+#        ar_2 = gevent.event.AsyncResult()
 
-        def received_reload(msg, headers):
-            ar_1.set(msg)
-            ar_2.set(headers)
+#        def received_reload(msg, headers):
+#            log.debug("received reload here: msg=%s, headers=%s" % (msg, headers))
+#            ar_1.set(msg)
+#            ar_2.set(headers)
+#
+#
+#        proc1.test_hook = received_reload
+#
+#        log.debug("Got the hooked method here: %s" % proc1.test_hook)
+#        log.debug("proc1.user_info:: %s" % proc1.user_info)
 
+#        reloaded_user_info = ar_1.get(timeout=20)
+#        reloaded_reverse_user_info = ar_2.get(timeout=20)
 
-        proc1.test_hook = received_reload
+        gevent.sleep(4)
 
-        reloaded_user_info = ar_1.get(timeout=10)
-        reloaded_reverse_user_info = ar_2.get(timeout=10)
+        queue = proc1.q
+
+        log.debug("IN the test, got the queue size: %s" % queue.qsize())
+        log.debug("IN the test, got the queue: %s" % queue)
+
+        reloaded_user_info, reloaded_reverse_user_info = queue.get(timeout=20)
 
         # read back the registered notification request objects
         notification_request_correct = self.rrc.read(notification_id_1)
@@ -682,8 +696,8 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         ar_1 = gevent.event.AsyncResult()
         ar_2 = gevent.event.AsyncResult()
 
-        reloaded_user_info = ar_1.get(timeout=10)
-        reloaded_reverse_user_info = ar_2.get(timeout=10)
+        reloaded_user_info = ar_1.get(timeout=20)
+        reloaded_reverse_user_info = ar_2.get(timeout=20)
 
         notification_request_2 = self.rrc.read(notification_id_2)
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -649,7 +649,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         processes =self.container.proc_manager.procs
 
-        gevent.sleep(4)
+#        gevent.sleep(4)
         reloaded_user_info, reloaded_reverse_user_info, process_queue = (None,None,None)
 
         def found_user_info_dicts(processes, *args, **kwargs):

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -649,7 +649,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         processes =self.container.proc_manager.procs
 
         def found_user_info_dicts(processes, *args, **kwargs):
-
             for key in processes:
                 if key.startswith('notification_worker'):
                     proc1 = processes[key]
@@ -663,6 +662,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
                         return reloaded_user_info, reloaded_reverse_user_info
 
         reloaded_user_info,  reloaded_reverse_user_info= self.poll(9, found_user_info_dicts, processes)
+        notification_id_2 = self.unsc.create_notification(notification=notification_request_2, user_id=user_id)
 
         self.assertIsNotNone(reloaded_user_info)
         self.assertIsNotNone(reloaded_reverse_user_info)
@@ -683,8 +683,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------------
         # Create another notification
         #--------------------------------------------------------------------------------------
-
-        notification_id_2 = self.unsc.create_notification(notification=notification_request_2, user_id=user_id)
 
         reloaded_user_info,  reloaded_reverse_user_info= self.poll(9, found_user_info_dicts, processes)
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -204,6 +204,7 @@ class UserNotificationService(BaseUserNotificationService):
         """
         self.batch_processing_subscriber = EventSubscriber(
             event_type="ResourceEvent",
+            queue_name='user_notification',
             origin=process_batch_key,
             callback=process
         )


### PR DESCRIPTION
- Two event subscribers that the UNS and notification worker creates now use named queues.
- The test_demo_stream_granules_processing() method in test_transform_prototype.py now skips CEI launch. This was needed because of an additional test piece that was added recently to it. This test piece involves using the container's datastore to find events stored in the events db after they get created during the test run. The test works well in a single container and is very useful as an additional means to verify that the stream alert transform works. But in a multi-container test, the test does not work because of the above reason. The test should therefore skip CEI launch.
