### PR TITLE
Remove assert from UNS set_process_batch_key handler

### DIFF
--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -190,8 +190,6 @@ class UserNotificationService(BaseUserNotificationService):
         """
 
         def process(event_msg, headers):
-            assert event_msg.origin == process_batch_key
-
             self.end_time = UserNotificationService.makeEpochTime(self.__now())
 
             # run the process_batch() method


### PR DESCRIPTION
Using a named queue in this EventSubscriber, multiple
UNS instances will receive these messages in round-robin.
They will likely not line up with the exact instance that
created the subscriber with this exact binding/batch_key.

This will at least allow them to proceed.
