### PR TITLE
Schedule service on_quit cancels pending scheduled events

### DIFF
--- a/ion/services/cei/scheduler_service.py
+++ b/ion/services/cei/scheduler_service.py
@@ -42,7 +42,8 @@ class SchedulerService(BaseSchedulerService):
                 gls.append(s)
                 if s._start_event is not None:  # still pending
                     s.kill()
-                    self.__delete(i, idx)
+
+        self.schedule_entries.clear()
 
         # wait for all running gls to finish up
         gevent.joinall(gls, timeout=10)


### PR DESCRIPTION
Currently, `on_quit` does not attempt to handle the greenlets started with `spawn_later` that is the core of the SchedulerService.  This patch attempts to fix that, with respect to the possible coming restart.

I notice there is an `on_system_restart` but I am not sure where this is called from - maybe a bootstrap service call?  That would make the most sense.

This PR for review please.
