### PR TITLE
Remove DeviceCommsEvent

### DIFF
--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -42,7 +42,7 @@ class EventAlertTransform(TransformEventListener):
         self.instrument_event_queue = gevent.queue.Queue()
 
         def instrument_event_received(message, headers):
-            log.debug("EventAlertTransform received an instrument event here::: %s" % message)
+            log.debug("EventAlertTransform received an instrument event here::: %s", message)
             self.instrument_event_queue.put(message)
 
         self.instrument_event_subscriber = EventSubscriber(origin = self.instrument_origin,
@@ -167,7 +167,7 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventPublisher)
         @param stream_id str
         '''
 
-        log.debug("DemoStreamAlertTransform received a packet!: %s" % msg)
+        log.debug("DemoStreamAlertTransform received a packet!: %s", msg)
         self.started_receiving_packets = True
 
         #-------------------------------------------------------------------------------------
@@ -183,7 +183,7 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventPublisher)
         #-------------------------------------------------------------------------------------
         self.bad_values, self.bad_value_times, self.origin, self.values, self.times = AlertTransformAlgorithm.execute(msg, config = config)
 
-        log.debug("DemoStreamAlertTransform got the origin of the event as: %s" % self.origin)
+        log.debug("DemoStreamAlertTransform got the origin of the event as: %s", self.origin)
 
         #-------------------------------------------------------------------------------------
         # If there are any bad values, publish an alert event for the granule
@@ -272,7 +272,7 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
         if not origin:
             raise NotFound("The DemoStreamAlertTransform could not figure out the origin for DeviceStatusEvent. The data_producer_id attribute should be filled for the granules that are sent to it so that it can figure out the origin to use.")
 
-        log.debug("The origin the demo transform is listening to is: %s" % origin)
+        log.debug("The origin the demo transform is listening to is: %s", origin)
 
         rdt = RecordDictionaryTool.load_from_granule(input)
 
@@ -286,8 +286,8 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
 
         time_names = rdt[preferred_time][:]
 
-        log.debug("Values unravelled: %s" % values)
-        log.debug("Time names unravelled: %s" % time_names)
+        log.debug("Values unravelled: %s", values)
+        log.debug("Time names unravelled: %s", time_names)
 
         indexes = [l for l in xrange(len(time_names))]
 
@@ -298,7 +298,7 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
                 bad_values.append(val)
                 bad_value_times.append(arr[index])
 
-        log.debug("Returning bad_values: %s, bad_value_times: %s, origin: %s, all values: %s, and corresponding times: %s" % (bad_values, bad_value_times, origin, list(values), list(times)))
+        log.debug("Returning bad_values: %s, bad_value_times: %s, origin: %s, all values: %s, and corresponding times: %s", bad_values, bad_value_times, origin, list(values), list(times))
 
         # return the list of bad values and their timestamps
         return bad_values, bad_value_times, origin, list(values), list(times)

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -13,7 +13,7 @@ from pyon.event.event import EventPublisher, EventSubscriber
 from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from ion.core.function.transform_function import SimpleGranuleTransformFunction
 from ion.core.process.transform import TransformEventListener, TransformStreamListener, TransformEventPublisher
-from interface.objects import DeviceStatusType, DeviceStatusEvent, DeviceCommsEvent, DeviceCommsType
+from interface.objects import DeviceStatusType, DeviceStatusEvent
 from interface.services.cei.ischeduler_service import SchedulerServiceProcessClient
 import gevent
 from gevent import queue
@@ -252,34 +252,22 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventListener, 
 
             log.debug("DemoStreamAlertTransform published a BAD DATA event")
 
-    def process_event(self, msg, headers):
-        """
-        When timer events come, if no granule has arrived since the last timer event, publish an alarm
-        """
-        self.count += 1
-
-        log.debug("Got a timer event with count: %s" % self.count )
-
-        if msg.origin == self.timer_origin and self.origin:
-
-            if self.granules.qsize() == 0:
-                # Publish the event
-                self.publisher.publish_event(
-                    event_type = 'DeviceCommsEvent',
-                    origin = self.origin,
-                    origin_type='PlatformDevice',
-                    sub_type = self.instrument_variable_name,
-                    time_stamp =int(time.time() + 2208988800),  # granules use NTP not unix
-#                    time_stamp = get_ion_ts(),
-                    state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION,
-                    lapse_interval_seconds=self.timer_interval,
-                    description = "Event to deliver the communications status of the instrument."
-                )
-
-                log.debug("DemoStreamAlertTransform published a NO DATA event")
-
-            else:
-                self.granules.queue.clear()
+#    def process_event(self, msg, headers):
+#        """
+#        When timer events come, if no granule has arrived since the last timer event, publish an alarm
+#        """
+#        self.count += 1
+#
+#        log.debug("Got a timer event with count: %s" % self.count )
+#
+#        if msg.origin == self.timer_origin and self.origin:
+#
+#            if self.granules.qsize() == 0:
+#                # Publish the event
+#                log.debug("DemoStreamAlertTransform published a NO DATA event")
+#
+#            else:
+#                self.granules.queue.clear()
 
 class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
 
@@ -302,7 +290,7 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
         variable_name = config.get_safe('variable_name', 'input_voltage')
         preferred_time = config.get_safe('time_field_name', 'preferred_timestamp')
 
-        # Get the source of the granules which will be used to set the origin of the DeviceStatusEvent and DeviceCommsEvent events
+        # Get the source of the granules which will be used to set the origin of the DeviceStatusEvents
 
         origin = input.data_producer_id
 

--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -196,6 +196,8 @@ class DemoStreamAlertTransform(TransformStreamListener, TransformEventPublisher)
 
             if self.bad_values:
                 state = DeviceStatusType.OUT_OF_RANGE
+                # Store the granule received
+                self.bad_granules.put(msg)
             else:
                 state = DeviceStatusType.OK
 

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -403,8 +403,21 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
 
 #        self.assertTrue(queue_bad_data.empty())
 
+        gevent.sleep(10)
+
         now = TransformPrototypeIntTest.makeEpochTime(datetime.utcnow())
-        events_in_db = self.user_notification.find_events(origin='instrument_1',limit=100, max_datetime=now, descending=True)
+
+        log.debug("now::: %s" % now)
+#        events_in_db = self.user_notification.find_events(origin='instrument_1',limit=100, max_datetime=now, descending=True)
+
+#        events_in_db = self.user_notification.find_events(origin='my_special_find_events_origin', type = 'PlatformEvent', min_datetime= 4, max_datetime=7)
+        events_in_db = self.user_notification.find_events(origin= 'instrument_1',type = 'DeviceStatusEvent', limit=100,  max_datetime= now)
+
+        now = TransformPrototypeIntTest.makeEpochTime(datetime.utcnow())
+        events_in_db = self.user_notification.find_events(origin= 'instrument_1', limit=5,  max_datetime= now, descending=True)
+        evts = self.user_notification.get_recent_events(resource_id='instrument_1', limit = 5)
+
+        log.debug("evts got here using get_recent_events::: %s" % evts)
 
         log.debug("events::: %s" % events_in_db)
 
@@ -414,7 +427,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
             if event.type_ == 'DeviceStatusEvent':
                 bad_data_events.append(event)
                 self.assertEquals(event.origin, "instrument_1")
-                self.assertEquals(event.state, DeviceStatusType.OUT_OF_RANGE)
+                self.assertTrue(event.state in [DeviceStatusType.OUT_OF_RANGE, DeviceStatusType.OK])
                 self.assertEquals(event.valid_values, self.valid_values)
                 self.assertEquals(event.sub_type, 'input_voltage')
 

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -300,26 +300,19 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         #-------------------------------------------------------------------------------------
 
         queue_bad_data = gevent.queue.Queue()
-        queue_no_data = gevent.queue.Queue()
 
         def bad_data(message, headers):
             log.debug("Got a BAD data event: %s" % message)
             if message.type_ == "DeviceStatusEvent":
                 queue_bad_data.put(message)
 
-        def no_data(message, headers):
-            log.debug("Got a NO data event: %s" % message)
-            queue_no_data.put(message)
-
         event_subscriber_bad_data = EventSubscriber( origin="instrument_1",
             event_type="DeviceStatusEvent",
             callback=bad_data)
 
         event_subscriber_bad_data.start()
-        event_subscriber_no_data.start()
 
         self.addCleanup(event_subscriber_bad_data.stop)
-        self.addCleanup(event_subscriber_no_data.stop)
 
         #-------------------------------------------------------------------------------------
         # The configuration for the Stream Alert Transform... set up the event types to listen to
@@ -402,7 +395,6 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         # Empty the queues and repeat tests
         #-------------------------------------------------------------------------------------
         queue_bad_data.queue.clear()
-        queue_no_data.queue.clear()
 
         #-------------------------------------------------------------------------------------
         # publish a *GOOD* granule again
@@ -418,7 +410,6 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         log.debug("events::: %s" % events_in_db)
 
         bad_data_events = []
-        no_data_events = []
 
         for event in events_in_db:
             if event.type_ == 'DeviceStatusEvent':
@@ -429,7 +420,6 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
                 self.assertEquals(event.sub_type, 'input_voltage')
 
         self.assertTrue(len(bad_data_events) > 0)
-        self.assertTrue(len(no_data_events) > 0)
 
         log.debug("This satisfies L4-CI-SA-RQ-114 : 'Marine facility shall monitor marine infrastructure usage by instruments.'"
                   " The req is satisfied because the stream alert transform"

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -375,18 +375,17 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         val = numpy.array([(110 + l)  for l in xrange(self.length)])
         self._publish_granules(stream_id= stream_id, stream_route= stream_route, number= self.number, values=val)
 
-        for number in xrange(self.number):
-            event = queue_bad_data.get(timeout=40)
-            self.assertEquals(event.type_, "DeviceStatusEvent")
-            self.assertEquals(event.origin, "instrument_1")
-            self.assertEquals(event.state, DeviceStatusType.OUT_OF_RANGE)
-            self.assertEquals(event.valid_values, self.valid_values)
-            self.assertEquals(event.sub_type, 'input_voltage')
-            self.assertTrue(set(event.values) ==  set(val))
+        event = queue_bad_data.get(timeout=40)
+        self.assertEquals(event.type_, "DeviceStatusEvent")
+        self.assertEquals(event.origin, "instrument_1")
+        self.assertEquals(event.state, DeviceStatusType.OUT_OF_RANGE)
+        self.assertEquals(event.valid_values, self.valid_values)
+        self.assertEquals(event.sub_type, 'input_voltage')
+        self.assertTrue(set(event.values) ==  set(val))
 
-            s = set(event.time_stamps)
-            cond = s in [set(numpy.array([1  for l in xrange(self.length)]).tolist()), set(numpy.array([2  for l in xrange(self.length)]).tolist())]
-            self.assertTrue(cond)
+        s = set(event.time_stamps)
+        cond = s in [set(numpy.array([1  for l in xrange(self.length)]).tolist()), set(numpy.array([2  for l in xrange(self.length)]).tolist())]
+        self.assertTrue(cond)
 
         # To ensure that only the bad values generated the alert events. Queue should be empty now
         self.assertEquals(queue_bad_data.qsize(), 0)

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -302,7 +302,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         queue_bad_data = gevent.queue.Queue()
 
         def bad_data(message, headers):
-            log.debug("Got a BAD data event: %s" % message)
+            log.debug("In the test callback, got a DeviceStatusEvent: %s" % message)
             if message.type_ == "DeviceStatusEvent":
                 queue_bad_data.put(message)
 
@@ -402,7 +402,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         val = numpy.array([(l + 20)  for l in xrange(self.length)])
         self._publish_granules(stream_id= stream_id, stream_route= stream_route, number=1, values=val)
 
-        self.assertTrue(queue_bad_data.empty())
+#        self.assertTrue(queue_bad_data.empty())
 
         now = TransformPrototypeIntTest.makeEpochTime(datetime.utcnow())
         events_in_db = self.user_notification.find_events(origin='instrument_1',limit=100, max_datetime=now, descending=True)

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -66,7 +66,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         if not end_time:
             end_time = start_time + 2 * timer_interval + 1
 
-        log.debug("got the end time here!! %s" % end_time)
+        log.debug("got the end time here!! %s" , end_time)
 
         # Set up the interval timer. The scheduler will publish event with origin set as "Interval Timer"
         sid = self.ssclient.create_interval_timer(start_time="now" ,
@@ -163,7 +163,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
 
         event = queue.get(timeout=10)
 
-        log.debug("Alarm event received from the EventAertTransform %s" % event)
+        log.debug("Alarm event received from the EventAertTransform %s" , event)
 
         self.assertEquals(event.type_, "DeviceEvent")
         self.assertEquals(event.origin, "EventAlertTransform")
@@ -317,7 +317,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         queue_good_data = gevent.queue.Queue()
 
         def bad_data(message, headers):
-            log.debug("In the test callback, got a DeviceStatusEvent: %s" % message)
+            log.debug("In the test callback, got a DeviceStatusEvent: %s" , message)
             if message.type_ == "DeviceStatusEvent":
                 if message.state == DeviceStatusType.OUT_OF_RANGE:
                     queue_bad_data.put(message)
@@ -434,7 +434,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
 
         events_in_db = self.poll(40, find_the_events, number_of_retvals=2)
 
-        log.debug("events::: %s" % events_in_db)
+        log.debug("events::: %s" , events_in_db)
 
         bad_data_events = []
         good_data_events = []
@@ -490,7 +490,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
             g = rdt.to_granule()
             g.data_producer_id = 'instrument_1'
 
-            log.debug("granule #%s published by instrument:: %s" % ( number,g))
+            log.debug("granule #%s published by instrument:: %s",  number,g)
 
             pub.publish(g)
 

--- a/ion/processes/data/transforms/test/test_transform_prototype.py
+++ b/ion/processes/data/transforms/test/test_transform_prototype.py
@@ -401,17 +401,7 @@ class TransformPrototypeIntTest(IonIntegrationTestCase):
         val = numpy.array([(l + 20)  for l in xrange(self.length)])
         self._publish_granules(stream_id= stream_id, stream_route= stream_route, number=1, values=val)
 
-#        self.assertTrue(queue_bad_data.empty())
-
         gevent.sleep(10)
-
-        now = TransformPrototypeIntTest.makeEpochTime(datetime.utcnow())
-
-        log.debug("now::: %s" % now)
-#        events_in_db = self.user_notification.find_events(origin='instrument_1',limit=100, max_datetime=now, descending=True)
-
-#        events_in_db = self.user_notification.find_events(origin='my_special_find_events_origin', type = 'PlatformEvent', min_datetime= 4, max_datetime=7)
-        events_in_db = self.user_notification.find_events(origin= 'instrument_1',type = 'DeviceStatusEvent', limit=100,  max_datetime= now)
 
         now = TransformPrototypeIntTest.makeEpochTime(datetime.utcnow())
         events_in_db = self.user_notification.find_events(origin= 'instrument_1', limit=5,  max_datetime= now, descending=True)

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1152,8 +1152,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         event_publisher.publish_event(
             event_type = "DetectionEvent",
-            origin="instrument_3",
-            time_stamp = get_ion_ts())
+            origin="instrument_3")
 
 
         #--------------------------------------------------------------------------------------

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -988,7 +988,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
             event_type = "DetectionEvent",
             origin="instrument_3",
             origin_type="type_3",
-            time_stamp = get_ion_ts())
+            )
 
 
         #--------------------------------------------------------------------------------------

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -917,7 +917,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         notification_request_3 = NotificationRequest(   name = "notification_3",
             origin="instrument_3",
             origin_type="type_3",
-            event_type='DeviceCommsEvent',
+            event_type='DetectionEvent',
             event_subtype=''
         )
 
@@ -985,7 +985,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
             time_stamps = [get_ion_ts(), str(int(get_ion_ts()) + 60*20*1000)])
 
         event_publisher.publish_event(
-            event_type = "DeviceCommsEvent",
+            event_type = "DetectionEvent",
             origin="instrument_3",
             origin_type="type_3",
             time_stamp = get_ion_ts())
@@ -1031,7 +1031,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
             if msg_recipient == 'user_1@gmail.com':
                 self.assertTrue(event_type in ['ResourceLifecycleEvent', 'DeviceStatusEvent'])
             elif msg_recipient == 'user_2@gmail.com':
-                self.assertTrue(event_type in ['DeviceCommsEvent', 'DeviceStatusEvent'])
+                self.assertTrue(event_type in ['DetectionEvent', 'DeviceStatusEvent'])
 
 
     @attr('LOCOINT')

--- a/ion/services/sa/observatory/observatory_util.py
+++ b/ion/services/sa/observatory/observatory_util.py
@@ -9,7 +9,7 @@ import time
 from pyon.core.exception import BadRequest
 from pyon.public import RT, PRED, OT, IonObject, log
 
-from interface.objects import DeviceStatusType, DeviceCommsType
+from interface.objects import DeviceStatusType
 from interface.objects import ComputedValueAvailability, StatusType
 
 
@@ -153,7 +153,6 @@ class ObservatoryUtil(object):
         min_ts = str(int(time.time() - 3) * 1000)
         # Events come back as 3-tuples of (id, key, obj)
         pwr_events = self.container.event_repository.find_events(event_type=OT.DeviceStatusEvent, start_ts=min_ts, descending=True)
-        comm_events = self.container.event_repository.find_events(event_type=OT.DeviceCommsEvent, start_ts=min_ts, descending=True)
         events = []
         events.extend(pwr_events)
         events.extend(comm_events)
@@ -296,8 +295,6 @@ class ObservatoryUtil(object):
             event_type = event._get_type()
             if event_type == OT.DeviceStatusEvent and event.state == DeviceStatusType.OUT_OF_RANGE:
                 status['power'] = StatusType.STATUS_WARNING
-            elif event_type == OT.DeviceCommsEvent and event.state == DeviceCommsType.DATA_DELIVERY_INTERRUPTION:
-                status['comms'] = StatusType.STATUS_WARNING
             # @TODO data, loc
 
         status['agg'] = self._consolidate_status(status.values())

--- a/ion/services/sa/observatory/observatory_util.py
+++ b/ion/services/sa/observatory/observatory_util.py
@@ -155,7 +155,7 @@ class ObservatoryUtil(object):
         pwr_events = self.container.event_repository.find_events(event_type=OT.DeviceStatusEvent, start_ts=min_ts, descending=True)
         events = []
         events.extend(pwr_events)
-        events.extend(comm_events)
+#        events.extend(comm_events)
         device_events = {}
         for ev_id, ev_key, event in events:
             if device_list and event.origin not in device_list:

--- a/ion/services/sa/observatory/test/test_observatory_util.py
+++ b/ion/services/sa/observatory/test/test_observatory_util.py
@@ -10,7 +10,7 @@ from pyon.public import RT, log
 from ion.services.sa.observatory.mockutil import MockUtil
 from ion.services.sa.observatory.observatory_util import ObservatoryUtil
 
-from interface.objects import StatusType, DeviceStatusType, DeviceCommsType
+from interface.objects import StatusType, DeviceStatusType
 
 
 @attr('UNIT', group='saob')
@@ -171,12 +171,8 @@ class TestObservatoryUtil(unittest.TestCase):
     event_list2 = [
         dict(et='DeviceStatusEvent', o='ID_1', attr=dict(state=DeviceStatusType.OUT_OF_RANGE))
     ]
-    event_list3 = [
-        dict(et='DeviceCommsEvent', o='ID_1', attr=dict(state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION))
-    ]
     event_list4 = [
         dict(et='DeviceStatusEvent', o='PD_1', attr=dict(state=DeviceStatusType.OUT_OF_RANGE)),
-        dict(et='DeviceCommsEvent', o='PD_1', attr=dict(state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION))
     ]
 
     def test_get_status_roll_ups(self):
@@ -261,7 +257,7 @@ class TestObservatoryUtil(unittest.TestCase):
         self._assert_status(status_rollups, 'IS_1', agg=StatusType.STATUS_WARNING, power=StatusType.STATUS_WARNING)
 
         # ID_1 power+comms warning
-        self.mu.load_mock_events(self.event_list3)
+#        self.mu.load_mock_events(self.event_list3)
         status_rollups = self.obs_util.get_status_roll_ups('ID_1', RT.InstrumentDevice)
         self._assert_status(status_rollups, 'ID_1', agg=StatusType.STATUS_WARNING, power=StatusType.STATUS_WARNING, comms=StatusType.STATUS_WARNING)
 

--- a/ion/services/sa/observatory/test/test_observatory_util.py
+++ b/ion/services/sa/observatory/test/test_observatory_util.py
@@ -376,5 +376,7 @@ class TestObservatoryUtil(unittest.TestCase):
         self.assertEquals(res_status['agg'], agg)
         self.assertEquals(res_status['loc'], loc)
         self.assertEquals(res_status['data'], data)
-        self.assertEquals(res_status['comms'], comms)
+
+        #todo After dropping the DeviceCommsEvents, we do not have a way right now to check comms status, hence commenting out the check below
+#        self.assertEquals(res_status['comms'], comms)
         self.assertEquals(res_status['power'], power)

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -31,7 +31,7 @@ from pyon.agent.agent import ResourceAgentClient, ResourceAgentState
 from pyon.agent.agent import ResourceAgentEvent
 
 from ion.services.dm.utility.granule_utils import RecordDictionaryTool
-from interface.objects import Granule, DeviceStatusType, DeviceCommsType, StatusType, StreamConfiguration
+from interface.objects import Granule, DeviceStatusType, StatusType, StreamConfiguration
 from interface.objects import AgentCommand, ProcessDefinition, ProcessStateEnum
 
 from nose.plugins.attrib import attr
@@ -383,8 +383,6 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         t = get_ion_ts()
         self.event_publisher.publish_event(  ts_created= t,  event_type = 'DeviceStatusEvent',
                 origin = instDevice_id, state=DeviceStatusType.OUT_OF_RANGE, values = [200] )
-        self.event_publisher.publish_event( ts_created= t,   event_type = 'DeviceCommsEvent',
-                origin = instDevice_id, state=DeviceCommsType.DATA_DELIVERY_INTERRUPTION, lapse_interval_seconds = 20 )
 
         extended_instrument = self.imsclient.get_instrument_device_extension(instDevice_id)
         log.debug( "test_activateInstrumentSample: extended_instrument %s", str(extended_instrument) )

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -386,7 +386,7 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         extended_instrument = self.imsclient.get_instrument_device_extension(instDevice_id)
         log.debug( "test_activateInstrumentSample: extended_instrument %s", str(extended_instrument) )
-        self.assertEqual(extended_instrument.computed.communications_status_roll_up.value, StatusType.STATUS_WARNING)
+#        self.assertEqual(extended_instrument.computed.communications_status_roll_up.value, StatusType.STATUS_WARNING)
         self.assertEqual(extended_instrument.computed.data_status_roll_up.value, StatusType.STATUS_OK)
         self.assertEqual(extended_instrument.computed.power_status_roll_up.value, StatusType.STATUS_WARNING)
 


### PR DESCRIPTION
The transform that monitors the platform agent will only use DeviceStatusEvent. Both OK and OUT_OF_RANGE status will be sent using the latter event.

DeviceCommsEvent is removed from the system.
