### PR TITLE
CEI HA Agent restart fixes

### DIFF
--- a/ion/agents/cei/execution_engine_agent.py
+++ b/ion/agents/cei/execution_engine_agent.py
@@ -132,7 +132,15 @@ class HeartBeater(object):
             beat = make_beat_msg(self._factory, self._CFG)
             message = dict(beat=beat, eeagent_id=self.process_id, resource_id=self._CFG.agent.resource_id)
             to_name = self._pd_name
-            self._log.debug("Send heartbeat: %s to %s", message, self._pd_name)
+
+            if self._log.isEnabledFor(logging.DEBUG):
+                processes = beat.get('processes')
+                if processes is not None:
+                    processes_str = "processes=%d" % len(processes)
+                else:
+                    processes_str = ""
+                self._log.debug("Sending heartbeat to %s %s", self._pd_name, processes_str)
+
             self._publisher.publish(message, to_name=to_name)
         except Exception:
             self._log.exception("beat failed")

--- a/ion/agents/cei/high_availability_agent.py
+++ b/ion/agents/cei/high_availability_agent.py
@@ -349,8 +349,7 @@ class HAProcessControl(object):
         state = event.state
         state_str = ProcessStateEnum._str_map.get(state, str(state))
         if not (process_id and process_id in self.processes):
-            log.debug("%sreceived event for unknown process %s: state=%s",
-                self.logprefix, process_id, state_str)
+            # we receive events for all processes but ignore most
             return
 
         process = None

--- a/ion/agents/cei/high_availability_agent.py
+++ b/ion/agents/cei/high_availability_agent.py
@@ -1,24 +1,28 @@
+from copy import deepcopy
+
 import gevent
+from gevent.event import Event
 
 from pyon.agent.simple_agent import SimpleResourceAgent
-from pyon.event.event import EventPublisher
+from pyon.event.event import EventSubscriber
 from pyon.public import log, get_sys_name
 from pyon.core.exception import BadRequest
 
-from interface.objects import AgentCommand, ProcessDefinition, ProcessSchedule,\
-        ProcessStateEnum, ProcessQueueingMode, ProcessTarget, ProcessRestartMode,\
-        Service, ServiceStateEnum
+from interface.objects import AgentCommand, ProcessSchedule, \
+        ProcessStateEnum, ProcessQueueingMode, ProcessTarget, \
+        ProcessRestartMode, Service, ServiceStateEnum
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
-from ion.agents.cei.util import looping_call
-from ion.services.cei.process_dispatcher_service import _core_process_definition_from_ion, \
-    ProcessDispatcherService
+from ion.services.cei.process_dispatcher_service import ProcessDispatcherService, \
+        process_state_to_pd_core
 
 try:
     from epu.highavailability.core import HighAvailabilityCore
     import epu.highavailability.policy as policy
+    from epu.states import ProcessState as CoreProcessState
 except ImportError:
     HighAvailabilityCore = None
-    #raise
+    policy = None
+    CoreProcessState = None
 
 
 """
@@ -41,6 +45,8 @@ class HighAvailabilityAgent(SimpleResourceAgent):
         SimpleResourceAgent.__init__(self)
         self.dashi_handler = None
         self.service_id = None
+        self.policy_thread = None
+        self.policy_event = None
 
     def on_init(self):
         if not HighAvailabilityCore:
@@ -68,23 +74,25 @@ class HighAvailabilityAgent(SimpleResourceAgent):
         # use default PD name as the sole PD if none are provided in config
         self.pds = self.CFG.get_safe("highavailability.process_dispatchers",
             [ProcessDispatcherService.name])
+        if not len(self.pds) == 1:
+            raise Exception("HA Service doesn't support multiple Process Dispatchers")
 
         self.process_definition_id = self.CFG.get_safe("highavailability.process_definition_id")
         self.process_configuration = self.CFG.get_safe("highavailability.process_configuration")
         aggregator_config = _get_aggregator_config(self.CFG)
 
         self.service_id = self._register_service()
+        self.policy_event = Event()
 
-        # TODO: Allow other core class?
-        self.core = HighAvailabilityCore(cfg, ProcessDispatcherSimpleAPIClient,
+        self.control = HAProcessControl(self.pds[0],
+            self.container.resource_registry, self.service_id,
+            self.policy_event.set)
+
+        self.core = HighAvailabilityCore(cfg, self.control,
                 self.pds, self.policy, process_definition_id=self.process_definition_id,
                 parameters=policy_parameters,
                 process_configuration=self.process_configuration,
-                aggregator_config=aggregator_config,
-                pd_client_kwargs={'container': self.container,
-                    'service_id': self.service_id})
-
-        self.policy_thread = looping_call(self.policy_interval, self._apply_policy)
+                aggregator_config=aggregator_config)
 
         dashi_messaging = self.CFG.get_safe("highavailability.dashi_messaging", False)
         if dashi_messaging:
@@ -116,12 +124,25 @@ class HighAvailabilityAgent(SimpleResourceAgent):
         if self.dashi_handler:
             self.dashi_handler.start()
 
+        self.control.start()
+
+        # override the core's list of currently managed processes. This is to support
+        # restart of an HAAgent.
+        self.core.set_managed_upids(self.control.get_managed_upids())
+
+        self.policy_thread = gevent.spawn(self._policy_thread_loop)
+
+        # kickstart the policy once. future invocations will happen via event callbacks.
+        self.policy_event.set()
+
     def on_quit(self):
+        self.control.stop()
         self.policy_thread.kill(block=True, timeout=3)
         if self.dashi_handler:
             self.dashi_handler.stop()
 
-        self._unregister_service()
+        # DL: do we ever want to remove this object?
+        #self._unregister_service()
 
     def _register_service(self):
         if not self.process_definition_id:
@@ -166,18 +187,28 @@ class HighAvailabilityAgent(SimpleResourceAgent):
 
         self.container.resource_registry.delete(self.service_id, del_associations=True)
 
+    def _policy_thread_loop(self):
+        """Single thread runs policy loops, to prevent races
+        """
+        while True:
+            # wait until our event is set, up to policy_interval seconds
+            self.policy_event.wait(self.policy_interval)
+            self.policy_event.clear()
+
+            self._apply_policy()
+
     def _apply_policy(self):
 
         self.core.apply_policy()
 
         try:
-            service = self.container.resource_registry.read(self.service_id)
             new_service_state = _core_hastate_to_service_state(self.core.status())
+            service = self.container.resource_registry.read(self.service_id)
             if service.state != new_service_state:
                 service.state = new_service_state
                 self.container.resource_registry.update(service)
         except Exception:
-            log.exception("Problem when updating Service state")
+            log.warn("Problem when updating Service state", exc_info=True)
 
     def rcmd_reconfigure_policy(self, new_policy):
         """Service operation: Change the parameters of the policy used for service
@@ -186,6 +217,8 @@ class HighAvailabilityAgent(SimpleResourceAgent):
         @return:
         """
         self.core.reconfigure_policy(new_policy)
+        #trigger policy thread to wake up
+        self.policy_event.set()
 
     def rcmd_status(self):
         """Service operation: Get the status of the HA Service
@@ -260,118 +293,127 @@ class HighAvailabilityAgentClient(object):
         return self.client.execute(cmd)
 
 
-class ProcessDispatcherSimpleAPIClient(object):
+class HAProcessControl(object):
 
-    # State to use when state returned from PD is None
-    unknown_state = "400-PENDING"
+    def __init__(self, pd_name, resource_registry, service_id, callback=None):
+        self.pd_name = pd_name
+        self.resource_registry = resource_registry
+        self.service_id = service_id
+        self.callback = callback
+        if callback and not callable(callback):
+            raise ValueError("callback is not callable")
 
-    state_map = {
-        ProcessStateEnum.RUNNING: '500-RUNNING',
-        ProcessStateEnum.TERMINATED: '700-TERMINATED',
-        ProcessStateEnum.FAILED: '850-FAILED'
-    }
+        self.client = ProcessDispatcherServiceClient(to_name=pd_name)
+        self.event_sub = EventSubscriber(event_type="ProcessLifecycleEvent",
+            callback=self._event_callback, origin_type="DispatchedProcess")
 
-    def __init__(self, name, real_client=None, **kwargs):
-        self.container = kwargs.get('container')
-        if self.container:
-            del(kwargs['container'])
-        self.service_id = kwargs.get('service_id')
-        if self.service_id:
-            del(kwargs['service_id'])
+        self.processes = {}
 
-        if real_client is not None:
-            self.real_client = real_client
-        else:
-            self.real_client = ProcessDispatcherServiceClient(to_name=name, **kwargs)
-        self.event_pub = EventPublisher()
+    def start(self):
+        service = self.resource_registry.read(self.service_id)
+        process_assocs = self.resource_registry.find_associations(service, "hasProcess")
+
+        for process_assoc in process_assocs:
+            process_id = process_assoc.o
+            if process_id:
+                process = self.client.read_process(process_id)
+                self.processes[process.process_id] = _process_dict_from_object(process)
+
+        self.event_sub.start()
+
+    def stop(self):
+        self.event_sub.stop()
+
+    def get_managed_upids(self):
+        return self.processes.keys()
+
+    def _event_callback(self, event, *args, **kwargs):
+        if not event:
+            return
+
+        process_id = event.origin
+        if not (process_id and process_id in self.processes):
+            return
+
+        process = self.client.read_process(process_id)
+        if not process:
+            log.warn("Received process %s event but it is unknown to process dispatcher")
+            return
+
+        log.info("HAAgent received process %s state=%s", process_id, event.state)
+
+        # replace the cached data about this process
+        self.processes[process_id] = _process_dict_from_object(process)
+
+        if self.callback:
+            try:
+                self.callback()
+            except Exception, e:
+                log.warn("Error in HAAgent callback: %s", e, exc_info=True)
 
     def _associate_process(self, process):
         try:
-            self.container.resource_registry.create_association(self.service_id,
+            self.resource_registry.create_association(self.service_id,
                 "hasProcess", process.process_id)
         except Exception:
             log.exception("Couldn't associate service %s to process %s" % (self.service_id, process.process_id))
 
-    def create_definition(self, definition_id, definition_type, executable,
-                          name=None, description=None):
+    def schedule_process(self, pd_name, process_definition_id, **kwargs):
 
-        if name is None:
-            raise BadRequest("create_definition must have a name supplied")
+        if pd_name != self.pd_name:
+            raise Exception("schedule_process request received for unknown PD: %s" % pd_name)
 
-        # note: we lose the description
-        definition = ProcessDefinition(name=name)
-        definition.executable = {'module': executable.get('module'),
-                'class': executable.get('class')}
-        definition.definition_type = definition_type
-        created_definition = self.real_client.create_process_definition(
-                definition, definition_id)
+        # figure out if there is an existing PID which can be reused
+        found_upid = None
+        for process in self.processes.values():
+            upid = process.get('upid')
+            state = process.get('state')
+            if not (upid and state):
+                continue
 
-    def describe_definition(self, definition_id):
+            if state in CoreProcessState.TERMINAL_STATES:
+                found_upid = upid
 
-        definition = self.real_client.read_process_definition(definition_id)
-        core_defintion = _core_process_definition_from_ion(definition)
-        return core_defintion
+        if found_upid:
+            upid = found_upid
+            proc = self.client.read_process(upid)
 
-    def schedule_process(self, upid, definition_id, configuration=None,
-            subscribers=None, constraints=None, queueing_mode=None,
-            restart_mode=None, execution_engine_id=None, node_exclusive=None):
+        else:
+            # otherwise create a new process and associate
+            upid = self.client.create_process(process_definition_id)
 
-        definition = self.real_client.read_process_definition(definition_id)
-        self.event_pub.publish_event(event_type="ProcessLifecycleEvent",
-            origin=definition.name, origin_type="DispatchedHAProcess",
-            state=ProcessStateEnum.RUNNING)
+            # note: if the HAAgent fails between the create call above and the
+            # associate call below, there may be orphaned Process objects. These
+            # processes will not however be running, so are largely harmless.
+            proc = self.client.read_process(upid)
+            self._associate_process(proc)
 
-        create_upid = self.real_client.create_process(definition_id)
+        process_schedule = _get_process_schedule(**kwargs)
+        configuration = kwargs.get('configuration')
 
-        process_schedule = ProcessSchedule()
-        if queueing_mode is not None:
-            try:
-                process_schedule.queueing_mode = ProcessQueueingMode._value_map[queueing_mode]
-            except KeyError:
-                msg = "%s is not a known ProcessQueueingMode" % (queueing_mode)
-                raise BadRequest(msg)
+        # cheat and roll the process state to REQUESTED before we actually
+        # schedule it. this is in-memory only, so should be harmless. This
+        # avoids a race between this scheduling process and the event
+        # subscriber.
+        proc.process_state = ProcessStateEnum.REQUESTED
+        self.processes[upid] = _process_dict_from_object(proc)
 
-        if restart_mode is not None:
-            try:
-                process_schedule.restart_mode = ProcessRestartMode._value_map[restart_mode]
-            except KeyError:
-                msg = "%s is not a known ProcessRestartMode" % (restart_mode)
-                raise BadRequest(msg)
-
-        target = ProcessTarget()
-        if execution_engine_id is not None:
-            target.execution_engine_id = execution_engine_id
-        if node_exclusive is not None:
-            target.node_exclusive = node_exclusive
-        if constraints is not None:
-            target.constraints = constraints
-
-        process_schedule.target = target
-
-        sched_pid = self.real_client.schedule_process(definition_id,
-                process_schedule, configuration=configuration, process_id=create_upid)
-
-        proc = self.real_client.read_process(sched_pid)
-
-        self._associate_process(proc)
-
-        dict_proc = {'upid': proc.process_id,
-                'state': self.state_map.get(proc.process_state, self.unknown_state),
-                }
-        return dict_proc
+        self.client.schedule_process(process_definition_id, process_schedule,
+            configuration=configuration, process_id=upid)
+        return upid
 
     def terminate_process(self, pid):
-        return self.real_client.cancel_process(pid)
+        return self.client.cancel_process(pid)
 
-    def describe_processes(self):
-        procs = self.real_client.list_processes()
-        dict_procs = []
-        for proc in procs:
-            dict_proc = {'upid': proc.process_id,
-                    'state': self.state_map.get(proc.process_state, self.unknown_state),
-                    }
-            dict_procs.append(dict_proc)
-        return dict_procs
+    def get_all_processes(self):
+        processes = deepcopy(self.processes.values())
+        return {self.pd_name: processes}
+
+
+def _process_dict_from_object(process):
+    state = process_state_to_pd_core(process.process_state)
+    dict_proc = {'upid': process.process_id, 'state': state}
+    return dict_proc
 
 
 def _core_hastate_to_service_state(core):
@@ -398,3 +440,37 @@ def _get_aggregator_config(config):
 
     # return None if no config. policy will error out if it needs aggregator.
     return None
+
+
+def _get_process_schedule(**kwargs):
+    queueing_mode = kwargs.get('queueing_mode')
+    restart_mode = kwargs.get('restart_mode')
+    execution_engine_id = kwargs.get('execution_engine_id')
+    node_exclusive = kwargs.get('node_exclusive')
+    constraints = kwargs.get('constraints')
+
+    process_schedule = ProcessSchedule()
+    if queueing_mode is not None:
+        try:
+            process_schedule.queueing_mode = ProcessQueueingMode._value_map[queueing_mode]
+        except KeyError:
+            msg = "%s is not a known ProcessQueueingMode" % (queueing_mode)
+            raise BadRequest(msg)
+
+    if restart_mode is not None:
+        try:
+            process_schedule.restart_mode = ProcessRestartMode._value_map[restart_mode]
+        except KeyError:
+            msg = "%s is not a known ProcessRestartMode" % (restart_mode)
+            raise BadRequest(msg)
+
+    target = ProcessTarget()
+    if execution_engine_id is not None:
+        target.execution_engine_id = execution_engine_id
+    if node_exclusive is not None:
+        target.node_exclusive = node_exclusive
+    if constraints is not None:
+        target.constraints = constraints
+
+    process_schedule.target = target
+    return process_schedule

--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -2,6 +2,7 @@
 
 import uuid
 import json
+import logging
 from time import time
 
 import gevent
@@ -890,7 +891,6 @@ class PDNativeBackend(object):
         self.core.node_state(node_id, domain_id, state, properties=properties)
 
     def _heartbeat_callback(self, heartbeat, headers):
-        log.debug("Got EEAgent heartbeat. headers=%s msg=%s", headers, heartbeat)
 
         try:
             eeagent_id = heartbeat['eeagent_id']
@@ -898,6 +898,14 @@ class PDNativeBackend(object):
         except KeyError, e:
             log.warn("Invalid EEAgent heartbeat received. Missing: %s -- %s", e, heartbeat)
             return
+
+        if log.isEnabledFor(logging.DEBUG):
+            processes = beat.get('processes')
+            if processes is not None:
+                processes_str = "processes=%d" % len(processes)
+            else:
+                processes_str = ""
+            log.debug("Received heartbeat from EEAgent %s %s", eeagent_id, processes_str)
 
         try:
             self.core.ee_heartbeat(eeagent_id, beat)

--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -693,6 +693,14 @@ _PD_PYON_PROCESS_STATE_MAP = {
 }
 
 
+def process_state_to_pd_core(process_state):
+    return _PD_PYON_PROCESS_STATE_MAP[process_state]
+
+
+def process_state_from_pd_core(core_process_state):
+    return _PD_PROCESS_STATE_MAP[core_process_state]
+
+
 class Notifier(object):
     """Sends Process state notifications via ION events
 


### PR DESCRIPTION
This pull request -- along with the [supporting epu changes](https://github.com/ooici/epu/compare/865e57aebfd0...b06bc8c8f771) -- fixes several issues surrounding HA Agents and is another milestone along the way to full system restart support.
- [OOIION-640](https://jira.oceanobservatories.org/tasks/browse/OOIION-640) - restarted processes are now correctly given `process.start_mode=RESTART` configuration.
- [OOIION-581](https://jira.oceanobservatories.org/tasks/browse/OOIION-581) - HA Agents now correctly restart and recover on failure (or container failure)
- [OOIION-570](https://jira.oceanobservatories.org/tasks/browse/OOIION-570) - HA Agent was reworked to use events instead of polling. This significantly reduces CPU utilization on the PD and HAAgent containers in an idle system.
