### PR TITLE
Notification preferences (digest, realtime) - Implements part of OOIION-563

### DIFF
--- a/ion/processes/data/transforms/notification_worker.py
+++ b/ion/processes/data/transforms/notification_worker.py
@@ -143,10 +143,14 @@ class NotificationWorker(TransformEventListener):
 
         for user in users:
             notifications = []
+            notification_preferences = None
             for variable in user.variables:
                 if variable['name'] == 'notifications':
                     notifications = variable['value']
 
-            user_info[user._id] = { 'user_contact' : user.contact, 'notifications' : notifications}
+                if variable['name'] == 'notification_preferences':
+                    notification_preferences = variable['value']
+
+            user_info[user._id] = { 'user_contact' : user.contact, 'notifications' : notifications, 'notification_preferences' : notification_preferences}
 
         return user_info

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -443,13 +443,13 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Create user 1
         #--------------------------------------------------------------------------------------
 
-        notification_preferences = NotificationPreferences()
-        notification_preferences.delivery_mode = NotificationDeliveryModeEnum.REALTIME
+        notification_preferences_1 = NotificationPreferences()
+        notification_preferences_1.delivery_mode = NotificationDeliveryModeEnum.REALTIME
 
         user_1 = UserInfo()
         user_1.name = 'user_1'
         user_1.contact.email = 'user_1@yahoo.com'
-        user_1.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences})
+        user_1.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences_1})
 
         user_id_1, _ = self.rrc.create(user_1)
 
@@ -457,15 +457,15 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # user 2
         #--------------------------------------------------------------------------------------
 
-        notification_preferences = NotificationPreferences()
-        notification_preferences.delivery_mode = NotificationDeliveryModeEnum.BATCH
-        notification_preferences.delivery_enabled = False
+        notification_preferences_2 = NotificationPreferences()
+        notification_preferences_2.delivery_mode = NotificationDeliveryModeEnum.BATCH
+        notification_preferences_2.delivery_enabled = False
 
 
         user_2 = UserInfo()
         user_2.name = 'user_2'
         user_2.contact.email = 'user_2@yahoo.com'
-        user_2.variables.append({'notification_preferences': notification_preferences})
+        user_2.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences_2})
 
         user_id_2, _ = self.rrc.create(user_2)
 
@@ -478,6 +478,12 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         notifications = set([notification_id_1, notification_id_2])
 
+        proc1 = self.container.proc_manager.procs_by_name['user_notification']
+
+        # check user_info dictionary
+        self.assertEquals(proc1.user_info[user_id_1]['notification_preferences'], notification_preferences_1)
+
+        self.assertEquals(proc1.user_info[user_id_2]['notification_preferences'], notification_preferences_2)
 
 
     @attr('LOCOINT')

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1465,9 +1465,14 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #----------------------------------------------------------------------------------------
 
         # user_1
+        notification_preferences_1 = NotificationPreferences()
+        notification_preferences_1.delivery_mode = NotificationDeliveryModeEnum.BATCH
+        notification_preferences_1.delivery_enabled = True
+
         user_1 = UserInfo()
         user_1.name = 'user_1'
         user_1.contact.email = 'user_1@gmail.com'
+        user_1.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences_1})
 
         # this part of code is in the beginning to allow enough time for the users_index creation
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -480,9 +480,10 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         proc1 = self.container.proc_manager.procs_by_name['user_notification']
 
-        # check user_info dictionary
+        #--------------------------------------------------------------------------------------------------------------------------------------
+        # check user_info dictionary to see that the notification preferences are properly loaded to the user info dictionaries
+        #--------------------------------------------------------------------------------------------------------------------------------------
         self.assertEquals(proc1.user_info[user_id_1]['notification_preferences'], notification_preferences_1)
-
         self.assertEquals(proc1.user_info[user_id_2]['notification_preferences'], notification_preferences_2)
 
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -819,26 +819,59 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Create users and get the user_ids
         #----------------------------------------------------------------------------------------
 
-        # user_1
+        # user_1  -- default notification preferences
         user_1 = UserInfo()
         user_1.name = 'user_1'
         user_1.contact.email = 'user_1@gmail.com'
 
-        # user_2
+        # user_2   --- prefers BATCH notification
+        notification_preferences_2 = NotificationPreferences()
+        notification_preferences_2.delivery_mode = NotificationDeliveryModeEnum.BATCH
+        notification_preferences_2.delivery_enabled = True
+
         user_2 = UserInfo()
         user_2.name = 'user_2'
         user_2.contact.email = 'user_2@gmail.com'
+        user_2.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences_2})
 
-        # user_3
+        # user_3  --- delivery enabled at default
+        notification_preferences_3 = NotificationPreferences()
+        notification_preferences_3.delivery_mode = NotificationDeliveryModeEnum.BATCH
+
         user_3 = UserInfo()
         user_3.name = 'user_3'
         user_3.contact.email = 'user_3@gmail.com'
+        user_3.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences_3})
+
+        # user_4   --- prefers REALTIME notification
+
+        notification_preferences_4 = NotificationPreferences()
+        notification_preferences_4.delivery_mode = NotificationDeliveryModeEnum.REALTIME
+        notification_preferences_4.delivery_enabled = True
+
+        user_4 = UserInfo()
+        user_4.name = 'user_4'
+        user_4.contact.email = 'user_4@gmail.com'
+        user_4.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences_4})
+
+        # user_5   --- delivery disabled
+
+        notification_preferences_5 = NotificationPreferences()
+        notification_preferences_5.delivery_mode = NotificationDeliveryModeEnum.BATCH
+        notification_preferences_5.delivery_enabled = False
+
+        user_5 = UserInfo()
+        user_5.name = 'user_5'
+        user_5.contact.email = 'user_5@gmail.com'
+        user_5.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences_5})
 
         # this part of code is in the beginning to allow enough time for the users_index creation
 
         user_id_1, _ = self.rrc.create(user_1)
         user_id_2, _ = self.rrc.create(user_2)
         user_id_3, _ = self.rrc.create(user_3)
+        user_id_4, _ = self.rrc.create(user_4)
+        user_id_5, _ = self.rrc.create(user_5)
 
         #--------------------------------------------------------------------------------------
         # Grab the UNS process
@@ -879,6 +912,12 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         self.unsc.create_notification(notification=notification_request_2, user_id=user_id_3)
         self.unsc.create_notification(notification=notification_request_3, user_id=user_id_3)
+
+        self.unsc.create_notification(notification=notification_request_correct, user_id=user_id_4)
+        self.unsc.create_notification(notification=notification_request_3, user_id=user_id_4)
+
+        self.unsc.create_notification(notification=notification_request_correct, user_id=user_id_5)
+        self.unsc.create_notification(notification=notification_request_3, user_id=user_id_5)
 
         #--------------------------------------------------------------------------------------
         # Do a process_batch() in order to start the batch notifications machinery

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -838,7 +838,7 @@ class UserNotificationService(BaseUserNotificationService):
         notification_preferences = None
         user = self.clients.resource_registry.read(user_id)
 
-        log.debug("user.variables::: %s" % user.variables)
+        log.debug("user.variables::: %s", user.variables)
 
         #------------------------------------------------------------------------------------
         # If there was a previous notification which is being updated, check the dictionaries and update there
@@ -866,7 +866,7 @@ class UserNotificationService(BaseUserNotificationService):
 
         self.user_info[user_id] = {'user_contact' : user.contact, 'notifications' : notifications, 'notification_preferences' : notification_preferences}
 
-        log.debug("self.user_info::: %s" % self.user_info)
+        log.debug("self.user_info::: %s" , self.user_info)
 
         self.reverse_user_info = calculate_reverse_user_info(self.user_info)
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -16,7 +16,7 @@ from pyon.event.event import EventPublisher, EventSubscriber
 from interface.services.dm.idiscovery_service import DiscoveryServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
-from interface.objects import ComputedValueAvailability
+from interface.objects import ComputedValueAvailability, NotificationPreferences, NotificationDeliveryModeEnum
 
 import string
 import time

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -666,6 +666,14 @@ class UserNotificationService(BaseUserNotificationService):
         for user_id, value in self.user_info.iteritems():
 
             notifications = value['notifications']
+            notification_preferences = value['notification_preferences']
+
+            # Ignore users who do NOT want batch notifications or who have disabled the delivery switch
+            # However, if notification preferences have not been set for the user, use the default mechanism and do not bother
+            if notification_preferences:
+                if notification_preferences.delivery_mode != NotificationDeliveryModeEnum.BATCH \
+                    or not notification_preferences.delivery_enabled:
+                    continue
 
             events_for_message = []
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -827,7 +827,10 @@ class UserNotificationService(BaseUserNotificationService):
     def update_user_info_dictionary(self, user_id, new_notification, old_notification):
 
         notifications = []
+        notification_preferences = None
         user = self.clients.resource_registry.read(user_id)
+
+        log.debug("user.variables::: %s" % user.variables)
 
         #------------------------------------------------------------------------------------
         # If there was a previous notification which is being updated, check the dictionaries and update there
@@ -848,7 +851,12 @@ class UserNotificationService(BaseUserNotificationService):
         #------------------------------------------------------------------------------------
         notifications.append(new_notification)
 
-        self.user_info[user_id] = {'user_contact' : user.contact, 'notifications' : notifications}
+        # Get the user's notification preferences
+        for item in user.variables:
+            if item.has_key('notification_preferences'):
+                notification_preferences = item['notification_preferences']
+
+        self.user_info[user_id] = {'user_contact' : user.contact, 'notifications' : notifications, 'notification_preferences' : notification_preferences}
 
         self.reverse_user_info = calculate_reverse_user_info(self.user_info)
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -853,10 +853,12 @@ class UserNotificationService(BaseUserNotificationService):
 
         # Get the user's notification preferences
         for item in user.variables:
-            if item.has_key('notification_preferences'):
-                notification_preferences = item['notification_preferences']
+            if item['name'] == 'notification_preferences':
+                notification_preferences = item['value']
 
         self.user_info[user_id] = {'user_contact' : user.contact, 'notifications' : notifications, 'notification_preferences' : notification_preferences}
+
+        log.debug("self.user_info::: %s" % self.user_info)
 
         self.reverse_user_info = calculate_reverse_user_info(self.user_info)
 

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -9,7 +9,7 @@ from pyon.util.arg_check import validate_is_not_none
 from pyon.util.log import log
 from pyon.core.exception import NotFound, BadRequest
 from pyon.event.event import EventPublisher
-from interface.objects import NotificationRequest, Event
+from interface.objects import NotificationRequest, Event, NotificationDeliveryModeEnum
 import smtplib
 import gevent
 from gevent.timeout import Timeout
@@ -252,6 +252,15 @@ def calculate_reverse_user_info(user_info=None):
     for user_id, value in user_info.iteritems():
 
         notifications = value['notifications']
+
+        notification_preferences = value['notification_preferences']
+
+        # Ignore users who do NOT want REALTIME notifications or who have disabled the delivery switch
+        # However, if notification preferences have not been set at all for the user, do not bother
+        if notification_preferences:
+            if notification_preferences.delivery_mode != NotificationDeliveryModeEnum.REALTIME\
+            or not notification_preferences.delivery_enabled:
+                continue
 
         if notifications:
 


### PR DESCRIPTION
# What is implemented?

A user is now able to specify the manner in which notifications were sent. 

UNS delivery code includes logic to check this flag and send real time to only users who have requested that route. During batch processing, digests notifications are sent to only users that have that option.

The notification preferences include a flag for delivery_enabled (the default being true). If set to False, the user will not receive any notification emails, digest or real time.
# How notification preferences are set?

An example:

```
        from interface.objects import  NotificationPreferences, NotificationDeliveryModeEnum  

        notification_preferences = NotificationPreferences()
        notification_preferences.delivery_mode = NotificationDeliveryModeEnum.REALTIME
        notification_preferences.delivery_enabled = True

        user = UserInfo()
        user.name = 'user_1'
        user.contact.email = 'user_1@gmail.com'
        user.variables.append({'name' : 'notification_preferences', 'value' : notification_preferences})

```
# What if the notification preferences are not set at all for a user?

No harm done. This pull request is backward compatible!

The code checks to see if the notification preferences have been set. If not, then it goes along the way it used to earlier. So if you have not set notification preferences for your user, there will be no harm done.  Nothing should break.
# What is not implemented?

We have not yet implemented logic that limits number of emails sent to a user in a day,... or hour?... since more clarification is needed regarding the appropriate time window. Also, more clarification is needed regarding whether the UNS will coordinate with a interval timer (scheduler service) in order to determine whether the above limit has been reached.
