### PR TITLE
Switch to egg version of dashi

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -39,6 +39,7 @@ simplejson=2.1.6
 greenlet=0.4.0
 mock=0.8
 nose=1.1.2
+dashi=0.2.3
 
 ###
 #
@@ -88,7 +89,6 @@ eggs =
     dashi
 find-links =
     https://github.com/nimbusproject/pidantic/tarball/master#egg=pidantic-0.2
-    https://github.com/nimbusproject/dashi/tarball/master#egg=dashi-0.2
     https://github.com/nimbusproject/eeagent/tarball/master#egg=eeagent-0.2
     https://github.com/ooici/epu/tarball/master#egg=epu-1.3
 


### PR DESCRIPTION
This will also update to the newer version of dashi, which enables heartbeats, and should fix OOIION-643
