### PR TITLE
Fixes OOIION-590 (Fixes UNS regarding emails being sent to events not subscribed to)

### DIFF
--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -902,23 +902,17 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         notification_request_1 = NotificationRequest(   name = "notification_1",
             origin="instrument_1",
-            origin_type="type_1",
             event_type='ResourceLifecycleEvent',
-            event_subtype=''
         )
 
         notification_request_2 = NotificationRequest(   name = "notification_2",
             origin="instrument_2",
-            origin_type="type_2",
             event_type='DeviceStatusEvent',
-            event_subtype=''
         )
 
         notification_request_3 = NotificationRequest(   name = "notification_3",
             origin="instrument_3",
-            origin_type="type_3",
             event_type='DeviceCommsEvent',
-            event_subtype=''
         )
 
         #--------------------------------------------------------------------------------------
@@ -975,19 +969,16 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         event_publisher.publish_event(
             event_type = "ResourceLifecycleEvent",
-            origin="instrument_1",
-            origin_type="type_1")
+            origin="instrument_1")
 
         event_publisher.publish_event(
             event_type = "DeviceStatusEvent",
             origin="instrument_2",
-            origin_type="type_2",
             time_stamps = [get_ion_ts(), str(int(get_ion_ts()) + 60*20*1000)])
 
         event_publisher.publish_event(
             event_type = "DeviceCommsEvent",
             origin="instrument_3",
-            origin_type="type_3",
             time_stamp = get_ion_ts())
 
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -226,6 +226,8 @@ class UserNotificationService(BaseUserNotificationService):
         if not user_id:
             raise BadRequest("User id not provided.")
 
+        log.debug("Create notification called for user_id: %s, and notification: %s" % (user_id, notification))
+
         #---------------------------------------------------------------------------------------------------
         # Persist Notification object as a resource if it has already not been persisted
         #---------------------------------------------------------------------------------------------------

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -26,14 +26,14 @@ class fake_smtplib(object):
 
     @classmethod
     def SMTP(cls,host):
-        log.info("In fake_smtplib.SMTP method call. class: %s, host: %s" % (str(cls), str(host)))
+        log.info("In fake_smtplib.SMTP method call. class: %s, host: %s", str(cls), str(host))
         return cls(host)
 
     def sendmail(self, msg_sender= None, msg_recipients=None, msg=None):
-        log.warning('Sending fake message from: %s, to: "%s"' % (msg_sender,  msg_recipients))
-        log.info("Fake message sent: %s" % msg)
+        log.warning('Sending fake message from: %s, to: "%s"', msg_sender,  msg_recipients)
+        log.info("Fake message sent: %s", msg)
         self.sent_mail.put((msg_sender, msg_recipients[0], msg))
-        log.debug("size of the sent_mail queue::: %s" % self.sent_mail.qsize())
+        log.debug("size of the sent_mail queue::: %s", self.sent_mail.qsize())
 
     def quit(self):
         """
@@ -56,7 +56,7 @@ def setting_up_smtp_client():
     smtp_password = CFG.get_safe('server.smtp.password')
 
     if CFG.get_safe('system.smtp',False): #Default is False - use the fake_smtp
-        log.debug('Using the real SMTP library to send email notifications! host = %s' % smtp_host)
+        log.debug('Using the real SMTP library to send email notifications! host = %s', smtp_host)
 
 #        smtp_client = smtplib.SMTP(smtp_host)
 #        smtp_client.ehlo()
@@ -64,8 +64,8 @@ def setting_up_smtp_client():
 #        smtp_client.login(smtp_sender, smtp_password)
 
         smtp_client = smtplib.SMTP(smtp_host, smtp_port)
-        log.debug("In setting up smtp client using the smtp client: %s" % smtp_client)
-        log.debug("Message received after ehlo exchange: %s" % str(smtp_client.ehlo()))
+        log.debug("In setting up smtp client using the smtp client: %s", smtp_client)
+        log.debug("Message received after ehlo exchange: %s", str(smtp_client.ehlo()))
 #        smtp_client.login(smtp_sender, smtp_password)
     else:
         log.debug('Using a fake SMTP library to simulate email notifications!')
@@ -90,7 +90,7 @@ def send_email(message, msg_recipient, smtp_client):
 
     '''
 
-    log.debug("Got type of event to notify on: %s" % message.type_)
+    log.debug("Got type of event to notify on: %s", message.type_)
 
     # Get the diffrent attributes from the event message
     event = message.type_
@@ -122,7 +122,7 @@ def send_email(message, msg_recipient, smtp_client):
         "\r\n")
     msg_subject = "(SysName: " + get_sys_name() + ") ION event " + event + " from " + origin
 
-    log.debug("msg_body::: %s" % msg_body)
+    log.debug("msg_body::: %s", msg_body)
 
     #------------------------------------------------------------------------------------
     # the 'from' email address for notification emails
@@ -135,14 +135,14 @@ def send_email(message, msg_recipient, smtp_client):
     msg['Subject'] = msg_subject
     msg['From'] = smtp_sender
     msg['To'] = msg_recipient
-    log.debug("UNS sending email from %s to %s for event type: %s" % ( smtp_sender,msg_recipient, message.type_))
-    log.debug("UNS using the smtp client: %s" % smtp_client)
+    log.debug("UNS sending email from %s to %s for event type: %s", smtp_sender,msg_recipient, message.type_)
+    log.debug("UNS using the smtp client: %s", smtp_client)
 
     try:
         smtp_client.sendmail(smtp_sender, [msg_recipient], msg.as_string())
     except: # Can be due to a broken connection... try to create a connection
         smtp_client = setting_up_smtp_client()
-        log.debug("Connect again...message received after ehlo exchange: %s" % str(smtp_client.ehlo()))
+        log.debug("Connect again...message received after ehlo exchange: %s", str(smtp_client.ehlo()))
         smtp_client.sendmail(smtp_sender, [msg_recipient], msg.as_string())
 
 
@@ -157,7 +157,7 @@ def check_user_notification_interest(event, reverse_user_info):
 
     @retval user_ids list
     '''
-    log.debug("Checking for interested users. Event type: %s, reverse_user_info: %s" % (event.type_, reverse_user_info))
+    log.debug("Checking for interested users. Event type: %s, reverse_user_info: %s", event.type_, reverse_user_info)
 
     if not isinstance(event, Event):
         raise BadRequest("The input parameter should have been an Event.")
@@ -186,47 +186,47 @@ def check_user_notification_interest(event, reverse_user_info):
         if reverse_user_info['event_type'].has_key(event.type_):
             user_list_1 = reverse_user_info['event_type'][event.type_]
             if reverse_user_info['event_type'].has_key(''): # for users who subscribe to any event types
-                user_list_1 += reverse_user_info['event_type']['']
+                user_list_1.extend(reverse_user_info['event_type'][''])
             users = set(user_list_1)
-            log.debug("For event_type = %s, UNS got interested users here  %s" % (event.type_, users))
+            log.debug("For event_type = %s, UNS got interested users here  %s", event.type_, users)
         else:
-            log.debug("For event_type = %s, UNS got interested users here  %s" % (event.type_, set()))
+            log.debug("After checking event_type = %s, UNS got no interested users here", event.type_)
             return []
 
     if event.origin: # for an incoming event that has origin specified (this should be true for almost all events)
         if reverse_user_info['event_origin'].has_key(event.origin):
             user_list_2 = set(reverse_user_info['event_origin'][event.origin])
             if reverse_user_info['event_origin'].has_key(''): # for users who subscribe to any event origins
-                user_list_2 += reverse_user_info['event_origin']['']
+                user_list_2.extend(reverse_user_info['event_origin'][''])
             users = set.intersection(users, user_list_2)
-            log.debug("For event origin = %s too, UNS got interested users here  %s" % (event.origin, users))
+            log.debug("For event origin = %s too, UNS got interested users here  %s", event.origin, users)
         else:
-            log.debug("For event origin = %s too, UNS got interested users here  %s" % (event.origin, set()))
+            log.debug("After checking  event origin = %s, UNS got no interested users here", event.origin)
             return []
 
     if event.sub_type: # for an incoming event with the sub type specified
         if reverse_user_info['event_subtype'].has_key(event.sub_type):
             user_list_3 = reverse_user_info['event_subtype'][event.sub_type]
             if reverse_user_info['event_subtype'].has_key(''): # for users who subscribe to any event subtypes
-                user_list_3 += reverse_user_info['event_subtype']['']
+                user_list_3.extend(reverse_user_info['event_subtype'][''])
             users = set.intersection(users, user_list_3)
-            log.debug("For event_subtype = %s too, UNS got interested users here  %s" % (event.sub_type, users))
+            log.debug("For event_subtype = %s too, UNS got interested users here  %s", event.sub_type, users)
         else:
-            log.debug("For event_subtype = %s too, UNS got interested users here  %s" % (event.sub_type, set()))
+            log.debug("After checking event_subtype = %s, UNS got no interested users here", event.sub_type)
             return []
 
     if event.origin_type: # for an incoming event with origin type specified
         if reverse_user_info['event_origin_type'].has_key(event.origin_type):
             user_list_4 = reverse_user_info['event_origin_type'][event.origin_type]
             if reverse_user_info['event_origin_type'].has_key(''): # for users who subscribe to any event origin types
-                user_list_4 += reverse_user_info['event_origin_type']['']
+                user_list_4.extend(reverse_user_info['event_origin_type'][''])
             users = set.intersection(users, user_list_4)
-            log.debug("For event_origin_type = %s too, UNS got interested users here  %s" % (event.origin_type, users))
+            log.debug("For event_origin_type = %s too, UNS got interested users here  %s", event.origin_type, users)
         else:
-            log.debug("For event_origin_type = %s too, UNS got interested users here  %s" % (event.origin_type, set()))
+            log.debug("After checking event_origin_type = %s, UNS got no interested users here", event.origin_type)
             return []
 
-    log.debug("The interested users found here are: %s, for event: %s" % (users, event))
+    log.debug("The interested users found here are: %s, for event: %s", users, event)
     return list( users)
 
 def calculate_reverse_user_info(user_info=None):

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -222,7 +222,7 @@ def check_user_notification_interest(event, reverse_user_info):
                 user_list_4 += reverse_user_info['event_origin_type']['']
             users = set.intersection(users, user_list_4)
             log.debug("For event_origin_type = %s too, UNS got interested users here  %s" % (event.origin_type, users))
-    else:
+        else:
             log.debug("For event_origin_type = %s too, UNS got interested users here  %s" % (event.origin_type, set()))
             return []
 


### PR DESCRIPTION
The UNS utility method designed to figure out interested users was not properly handling the case of events coming from the same origin and whose event subtypes and origin_type fields were empty.

This pull request patches the method so that it properly handles all cases.

It has been verified that only emails for the event subscribed to is being sent now.
