### PR TITLE
handle google/network errors in preload by retrying (max 5 times)

### DIFF
--- a/ion/processes/bootstrap/ooi_loader.py
+++ b/ion/processes/bootstrap/ooi_loader.py
@@ -84,8 +84,6 @@ class OOILoader(object):
             try:
                 if category in self.csv_files:
                     csv_doc = self.csv_files[category]
-                    # This is a hack to be able to read from string
-                    csv_doc = csv_doc.splitlines()
                     reader = csv.DictReader(csv_doc, delimiter=',')
                     filename = mapping_file + ":" + category
                 else:

--- a/ion/util/xlsparser.py
+++ b/ion/util/xlsparser.py
@@ -17,7 +17,7 @@ class XLSParser(object):
         csv_docs = {}
         for sheet_name, sheet in sheets.iteritems():
             csv_doc = self.dumps_csv(sheet)
-            csv_docs[sheet_name] = csv_doc
+            csv_docs[sheet_name] = csv_doc.splitlines()
         return csv_docs
 
     def extract_worksheets(self, file_content):


### PR DESCRIPTION
also changed the sequence a little -- fully read and parse all data into local dict rather than opening files and parsing as needed.  generally i lean toward lazy instantiation but want to make sure any parse errors are detected early in the retry loop.  has added side benefit that if one of the later tabs or CSVs is somehow garbled, you fail early instead of waiting for all the earlier tabs/CSVs to do their DB updates.  "fail early and often"
