### PR TITLE
Replay alignment

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -184,7 +184,7 @@ class ScienceGranuleIngestionWorker(TransformStreamListener):
         elements = len(rdt)
         if not elements:
             return
-        coverage.insert_timesteps(elements)
+        coverage.insert_timesteps(elements, oob=False)
         start_index = coverage.num_timesteps - elements
 
         for k,v in rdt.iteritems():

--- a/ion/processes/data/replay/replay_process.py
+++ b/ion/processes/data/replay/replay_process.py
@@ -15,6 +15,8 @@ from pyon.util.log import log
 from ion.services.dm.inventory.dataset_management_service import DatasetManagementService
 from ion.services.dm.utility.granule import RecordDictionaryTool
 
+from coverage_model import utils
+
 from interface.services.dm.idataset_management_service import DatasetManagementServiceProcessClient
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
 from interface.services.dm.ireplay_process import BaseReplayProcess
@@ -135,6 +137,7 @@ class ReplayProcess(BaseReplayProcess):
         else:
             rdt = RecordDictionaryTool(param_dictionary=coverage.parameter_dictionary)
         if parameters is not None:
+            # TODO: Improve efficiency here
             fields = list(set(parameters).intersection(rdt.fields))
         else:
             fields = rdt.fields
@@ -145,6 +148,12 @@ class ReplayProcess(BaseReplayProcess):
             if n is None:
                 rdt[field] = [n]
             elif isinstance(n,np.ndarray):
+                if coverage.get_data_extents(field)[0] != coverage.num_timesteps:
+                    log.error("Misformed coverage detected, padding with fill_value")
+                    arr_len = utils.slice_len(slice_, (coverage.num_timesteps,))[0]
+                    fill_arr = np.empty(arr_len - n.shape[0] , dtype=n.dtype)
+                    fill_arr.fill(coverage.get_parameter_context(field).fill_value)
+                    n = np.append(n,fill_arr)
                 rdt[field] = n
             else:
                 rdt[field] = [n]


### PR DESCRIPTION
This patch handles a certain race condition where an ingested coverage is in the middle of extending the dataset when another coverage is instantiated during a retrieval request. The new coverage is not fully consistent and causes a mis-formed granule to be created.
