### PR TITLE
Fixes cleanup in DPMS and added data product cleanup in some tests.

### DIFF
--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -961,9 +961,9 @@ class TestExternalDatasetAgent_Dummy(ExternalDatasetAgentTestBase, IonIntegratio
 
         #create temp streamdef so the data product can create the stream
         #@TODO Luke - I do not know if this param dict is the right choice here please review Tim G
-        parameter_dictionary = dataset_management_cli.read_parameter_dictionary_by_name('dummy', id_only=True)
+        parameter_dictionary_id = dataset_management_cli.read_parameter_dictionary_by_name('dummy', id_only=True)
         
-        streamdef_id = pubsub_cli.create_stream_definition(name="temp", parameter_dictionary_id=parameter_dictionary, description="temp")
+        streamdef_id = pubsub_cli.create_stream_definition(name="temp", parameter_dictionary_id=parameter_dictionary_id, description="temp")
 
         tdom, sdom = time_series_domain()
         tdom, sdom = tdom.dump(), sdom.dump()

--- a/ion/agents/data/test/test_external_dataset_agent_ruv.py
+++ b/ion/agents/data/test/test_external_dataset_agent_ruv.py
@@ -14,8 +14,9 @@ from pyon.ion.resource import PRED, RT
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
-from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance, ExternalDataProvider, DataProduct, DataSourceModel, ContactInformation, UpdateDescription, DatasetDescription, ExternalDataset, Institution, DataSource
-from ion.services.dm.utility.granule_utils import CoverageCraft
+from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
+from interface.objects import ExternalDatasetAgent, ExternalDatasetAgentInstance, ExternalDataProvider, DataSourceModel, ContactInformation, UpdateDescription, DatasetDescription, ExternalDataset, Institution, DataSource
+from ion.services.dm.utility.granule_utils import time_series_domain
 
 from ion.agents.data.test.test_external_dataset_agent import ExternalDatasetAgentTestBase, IonIntegrationTestCase
 from nose.plugins.attrib import attr
@@ -47,6 +48,7 @@ class TestExternalDatasetAgent_Ruv(ExternalDatasetAgentTestBase, IonIntegrationT
         dpms_cli = DataProductManagementServiceClient()
         rr_cli = ResourceRegistryServiceClient()
         pubsub_cli = PubsubManagementServiceClient()
+        dataset_management = DatasetManagementServiceClient()
 
         eda = ExternalDatasetAgent()
         eda_id = dams_cli.create_external_dataset_agent(eda)
@@ -106,12 +108,12 @@ class TestExternalDatasetAgent_Ruv(ExternalDatasetAgentTestBase, IonIntegrationT
 
         #create temp streamdef so the data product can create the stream
 
-        craft = CoverageCraft
-        sdom, tdom = craft.create_domains()
+        pdict_id = dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
+        streamdef_id = pubsub_cli.create_stream_definition(name="temp", description="temp", parameter_diction_id=pdict_id)
+
+        tdom, sdom = time_series_domain()
         sdom = sdom.dump()
         tdom = tdom.dump()
-        parameter_dictionary = craft.create_parameters()
-        parameter_dictionary = parameter_dictionary.dump()
 
         dprod = IonObject(RT.DataProduct,
             name='ruv_parsed_product',
@@ -119,12 +121,11 @@ class TestExternalDatasetAgent_Ruv(ExternalDatasetAgentTestBase, IonIntegrationT
             temporal_domain = tdom,
             spatial_domain = sdom)
 
-        streamdef_id = pubsub_cli.create_stream_definition(name="temp", description="temp")
 
         # Generate the data product and associate it to the ExternalDataset
         dproduct_id = dpms_cli.create_data_product(data_product=dprod,
-                                                    stream_definition_id=streamdef_id,
-                                                    parameter_dictionary=parameter_dictionary)
+                                                    stream_definition_id=streamdef_id)
+
 
         dams_cli.assign_data_product(input_resource_id=ds_id, data_product_id=dproduct_id)
 

--- a/ion/agents/instrument/test/test_instrument_agent.py
+++ b/ion/agents/instrument/test/test_instrument_agent.py
@@ -361,7 +361,7 @@ class TestInstrumentAgent(IonIntegrationTestCase):
 
         streams = {
             'parsed' : 'ctd_parsed_param_dict',
-            'raw' : 'ctd_raw_param_dict'
+            'raw'    : 'ctd_raw_param_dict'
         }
 
 

--- a/ion/services/dm/presentation/test/event_management_test.py
+++ b/ion/services/dm/presentation/test/event_management_test.py
@@ -413,7 +413,6 @@ class EventManagementIntTest(IonIntegrationTestCase):
 
         # Create a stream
         param_dict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict',id_only=True)
-        parameter_dictionary = self.dataset_management.read_parameter_dictionary(parameter_dictionary_id=param_dict_id)
 
         stream_def_id = self.pubsub.create_stream_definition('cond_stream_def', parameter_dictionary_id=param_dict_id)
 
@@ -427,7 +426,7 @@ class EventManagementIntTest(IonIntegrationTestCase):
             spatial_domain = sdom)
 
         # Create a data product
-        data_product_id = self.data_product_management.create_data_product(data_product=dp_obj, stream_definition_id=stream_def_id, parameter_dictionary=parameter_dictionary)
+        data_product_id = self.data_product_management.create_data_product(data_product=dp_obj, stream_definition_id=stream_def_id)
 
         output_products = {}
         output_products['conductivity'] = data_product_id

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -27,6 +27,8 @@ from nose.plugins.attrib import attr
 from ooi.logging import log
 import unittest
 
+import gevent
+
 from ion.services.sa.test.helpers import any_old
 
 
@@ -413,4 +415,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         instance_obj = self.RR.read(instAgentInstance_id)
         self.assertNotEqual("BAD_DATA", instance_obj.driver_config["comms_config"])
 
+        
+        self.DP.delete_data_product(data_product_id1)
+        self.DP.delete_data_product(data_product_id2)
 

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -329,11 +329,11 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         tdom = tdom.dump()
 
 
-        spdict_id = self.DSC.read_parameter_dictionary_by_name('ctd_parsed_param_dict')
-        parsed_stream_def_id = self.PSC.create_stream_definition(name='parsed', parameter_dictionary=spdict_id)
+        spdict_id = self.DSC.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
+        parsed_stream_def_id = self.PSC.create_stream_definition(name='parsed', parameter_dictionary_id=spdict_id)
 
-        rpdict_id = self.DSC.read_parameter_dictionary_by_name('ctd_raw_param_dict')
-        raw_stream_def_id = self.PSC.create_stream_definition(name='raw', parameter_dictionary=rpdict_id)
+        rpdict_id = self.DSC.read_parameter_dictionary_by_name('ctd_raw_param_dict', id_only=True)
+        raw_stream_def_id = self.PSC.create_stream_definition(name='raw', parameter_dictionary_id=rpdict_id)
 
 
         #-------------------------------
@@ -347,8 +347,8 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
                            spatial_domain = sdom)
 
         data_product_id1 = self.DP.create_data_product(data_product=dp_obj,
-                                                       stream_definition_id=parsed_stream_def_id,
-                                                       parameter_dictionary=spdict_id)
+                                                       stream_definition_id=parsed_stream_def_id)
+                                                       
         log.debug( 'new dp_id = %s', data_product_id1)
 
         self.DAMS.assign_data_product(input_resource_id=instDevice_id, data_product_id=data_product_id1)

--- a/ion/services/sa/observatory/test/test_observatory_management_service_integration.py
+++ b/ion/services/sa/observatory/test/test_observatory_management_service_integration.py
@@ -4,10 +4,8 @@
 from pyon.util.containers import DotDict, get_ion_ts
 from pyon.util.int_test import IonIntegrationTestCase
 from pyon.util.context import LocalContextMixin
-from pyon.util.ion_time import IonTime
-from pyon.core.exception import BadRequest, NotFound, Conflict, Inconsistent
 from pyon.public import RT, PRED
-from pyon.public import Container, log, IonObject
+from pyon.public import log, IonObject
 from pyon.event.event import EventPublisher
 from pyon.agent.agent import ResourceAgentState
 from ion.services.dm.utility.granule_utils import time_series_domain
@@ -21,11 +19,8 @@ from interface.services.dm.ipubsub_management_service import PubsubManagementSer
 from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
 
 from nose.plugins.attrib import attr
-import unittest, time
-from ooi.logging import log
 
 from ion.services.sa.test.helpers import any_old
-from ion.services.dm.utility.granule_utils import time_series_domain
 
 
 class FakeProcess(LocalContextMixin):
@@ -511,4 +506,8 @@ class TestObservatoryManagementServiceIntegration(IonIntegrationTestCase):
         extended_site =  self.OMS.get_site_extension(inst_site_id)
 
         log.debug("test_observatory_org_extended: extended_site:  %s ", str(extended_site))
+
+        self.dpclient.delete_data_product(data_product_id1)
+
+
 

--- a/ion/services/sa/product/data_product_management_service.py
+++ b/ion/services/sa/product/data_product_management_service.py
@@ -119,10 +119,10 @@ class DataProductManagementService(BaseDataProductManagementService):
 
         #Check if this data product is associated to a producer
         #todo: convert to impl call
-        producer_ids = self.data_product.find_stemming_data_producer(data_product_id)
+        producer_objs = self.data_product.find_stemming_data_producer(data_product_id)
 
-        for producer_id in producer_ids:
-            self.clients.data_acquisition_management.unassign_data_product(producer_id, data_product_id)
+        for producer_obj in producer_objs:
+            self.clients.data_acquisition_management.unassign_data_product(data_product_id, producer_obj._id)
 
         #--------------------------------------------------------------------------------
         # suspend persistence
@@ -252,13 +252,11 @@ class DataProductManagementService(BaseDataProductManagementService):
 
     def is_persisted(self, data_product_id=''):
         # Is the data product currently persisted into a data set?
-        retval = False
         if data_product_id:
             stream_id = self._get_stream_id(data_product_id)
             if stream_id:
-                retval =  self.clients.ingestion_management.is_persisted(stream_id)
-        else:
-            return retval
+                return self.clients.ingestion_management.is_persisted(stream_id)
+        return False
 
 
 

--- a/ion/services/sa/product/test/test_data_product_provenance.py
+++ b/ion/services/sa/product/test/test_data_product_provenance.py
@@ -583,3 +583,19 @@ class TestDataProductProvenance(IonIntegrationTestCase):
         #-------------------------------
         results = self.dpmsclient.get_data_product_provenance_report(ctd_l2_density_output_dp_id)
 
+
+        #-------------------------------
+        # Cleanup
+        #-------------------------------
+
+        self.dpmsclient.delete_data_product(ctd_parsed_data_product)
+        self.dpmsclient.delete_data_product(log_data_product_id)
+        self.dpmsclient.delete_data_product(ctd_l0_conductivity_output_dp_id)
+        self.dpmsclient.delete_data_product(ctd_l0_pressure_output_dp_id)
+        self.dpmsclient.delete_data_product(ctd_l0_temperature_output_dp_id)
+        self.dpmsclient.delete_data_product(ctd_l1_conductivity_output_dp_id)
+        self.dpmsclient.delete_data_product(ctd_l1_pressure_output_dp_id)
+        self.dpmsclient.delete_data_product(ctd_l1_temperature_output_dp_id)
+        self.dpmsclient.delete_data_product(ctd_l2_salinity_output_dp_id)
+        self.dpmsclient.delete_data_product(ctd_l2_density_output_dp_id)
+

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -400,3 +400,6 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         for pid in self.loggerpids:
             self.processdispatchclient.cancel_process(pid)
 
+        self.dpclient.delete_data_product(data_product_id1)
+        self.dpclient.delete_data_product(data_product_id2)
+

--- a/ion/services/sa/test/test_ctd_transforms_L0_L1_L2.py
+++ b/ion/services/sa/test/test_ctd_transforms_L0_L1_L2.py
@@ -1,4 +1,4 @@
-from pyon.public import Container, log, IonObject
+from pyon.public import log, IonObject
 from pyon.util.int_test import IonIntegrationTestCase
 
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
@@ -11,33 +11,18 @@ from interface.services.sa.iinstrument_management_service import InstrumentManag
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
 
-from prototype.sci_data.stream_defs import ctd_stream_definition, L0_pressure_stream_definition, L0_temperature_stream_definition, L0_conductivity_stream_definition
-from prototype.sci_data.stream_defs import L1_pressure_stream_definition, L1_temperature_stream_definition, L1_conductivity_stream_definition, L2_practical_salinity_stream_definition, L2_density_stream_definition
-from prototype.sci_data.stream_defs import SBE37_CDM_stream_definition, SBE37_RAW_stream_definition
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37Parameter, SBE37ProtocolEvent
 
-from pyon.public import log
 from nose.plugins.attrib import attr
-from coverage_model.coverage import CRS, GridDomain, GridShape
-from coverage_model.basic_types import AxisTypeEnum, MutabilityEnum
-from ion.util.parameter_yaml_IO import get_param_dict
 from ion.services.dm.utility.granule_utils import time_series_domain
 
-from ion.services.dm.utility.granule.taxonomy import TaxyTool
 
-from pyon.util.int_test import IonIntegrationTestCase
-from pyon.public import CFG, RT, LCS, PRED
-from pyon.core.exception import BadRequest, NotFound, Conflict
+from pyon.public import CFG, RT, PRED
 
-from pyon.agent.agent import ResourceAgentState
 from pyon.agent.agent import ResourceAgentEvent
 from pyon.agent.agent import ResourceAgentClient
 
-from pyon.util.unit_test import PyonTestCase
-from nose.plugins.attrib import attr
-import unittest
 from mock import patch
-import time
 import gevent
 
 from pyon.util.context import LocalContextMixin
@@ -676,3 +661,14 @@ class TestCTDTransformsIntegration(IonIntegrationTestCase):
         #-------------------------------------------------------------------------------------------------
         for pid in self.loggerpids:
             self.processdispatchclient.cancel_process(pid)
+
+
+        #--------------------------------------------------------------------------------
+        # Cleanup data products
+        #--------------------------------------------------------------------------------
+        dp_ids, _ = self.rrclient.find_resources(restype=RT.DataProduct, id_only=True)
+
+        for dp_id in dp_ids:
+            self.dataproductclient.delete_data_product(dp_id)
+
+

--- a/ion/services/sa/test/test_granule_publish.py
+++ b/ion/services/sa/test/test_granule_publish.py
@@ -23,7 +23,7 @@ from interface.services.sa.idata_process_management_service import DataProcessMa
 
 from nose.plugins.attrib import attr
 import numpy
-import time
+import gevent
 
 
 @attr('INT', group='sa')
@@ -115,9 +115,16 @@ class TestGranulePublish(IonIntegrationTestCase):
 
         publisher.publish(g)
 
-        time.sleep(3)
+        gevent.sleep(3)
 
         for pid in self.loggerpids:
             self.processdispatchclient.cancel_process(pid)
-
   
+        #--------------------------------------------------------------------------------
+        # Cleanup data products
+        #--------------------------------------------------------------------------------
+        dp_ids, _ = self.rrclient.find_resources(restype=RT.DataProduct, id_only=True)
+
+        for dp_id in dp_ids:
+            self.dataproductclient.delete_data_product(dp_id)
+


### PR DESCRIPTION
The coi_pycc builder had several issues with certain tests. This should help alleviate some of the issues by properly cleaning up some resources and processes at the end of tests.
