### PR TITLE
Renames the data product in test_granule_publish

### DIFF
--- a/ion/services/sa/test/test_granule_publish.py
+++ b/ion/services/sa/test/test_granule_publish.py
@@ -22,6 +22,7 @@ from interface.services.sa.idata_product_management_service import DataProductMa
 from interface.services.sa.idata_process_management_service import DataProcessManagementServiceClient
 
 from nose.plugins.attrib import attr
+import uuid
 import numpy
 import gevent
 
@@ -80,7 +81,7 @@ class TestGranulePublish(IonIntegrationTestCase):
         tdom, sdom = time_series_domain()
 
         dp_obj = IonObject(RT.DataProduct,
-            name='the parsed data',
+            name=str(uuid.uuid4()),
             description='ctd stream test',
             temporal_domain = tdom.dump(),
             spatial_domain = sdom.dump())


### PR DESCRIPTION
The granule in test_granule_publish isn't formed for transforms or to be
ingested but because another test still has transforms running on the
services container this granule gets routed to those processes and
causes problems, by renaming the data product to something unique the
data will never go somwhere it does not belong.
