### PR TITLE
Deserializes the IonObject going into the JSON request

### DIFF
--- a/ion/agents/instrument/test/test_gateway_to_instrument_agent.py
+++ b/ion/agents/instrument/test/test_gateway_to_instrument_agent.py
@@ -266,7 +266,10 @@ def _process_gateway_request(resource_id, operation, json_request, requester):
     if requester is not None:
         json_request["agentRequest"]["requester"] = requester
 
-    payload = simplejson.dumps(json_request)
+    
+    decoder = IonObjectSerializer()
+    decoded_msg = decoder.serialize(json_request)
+    payload = simplejson.dumps(decoded_msg)
 
     response = _agent_gateway_request(resource_id + '/' + operation,   payload)
 

--- a/ion/agents/instrument/test/test_instrument_agent.py
+++ b/ion/agents/instrument/test/test_instrument_agent.py
@@ -941,8 +941,8 @@ class TestInstrumentAgent(IonIntegrationTestCase):
         self._ia_client.set_agent({'alarms' : ['set', alarm1, alarm2]})
         retval = self._ia_client.get_agent(['alarms'])['alarms']
         self.assertItemsEqual([x.name for x in [alarm1, alarm2]],
-            [x.name for x in retval])
-        self.assertTrue(all([len(x.expr)>0 for x in retval]))
+            [x['name'] for x in retval])
+        self.assertTrue(all([len(x['expr'])>0 for x in retval]))
 
         kwargs3 = {
             'name' : 'high_temperature_alert',
@@ -974,29 +974,29 @@ class TestInstrumentAgent(IonIntegrationTestCase):
         self._ia_client.set_agent({'alarms' : ['add', alarm3, alarm4]})
         retval = self._ia_client.get_agent(['alarms'])['alarms']
         self.assertItemsEqual([x.name for x in [alarm1, alarm2, alarm3,
-            alarm4]], [x.name for x in retval])
-        self.assertTrue(all([len(x.expr)>0 for x in retval]))
+            alarm4]], [x['name'] for x in retval])
+        self.assertTrue(all([len(x['expr'])>0 for x in retval]))
 
         self._ia_client.set_agent({'alarms' : ['remove', alarm3, alarm4]})
         retval = self._ia_client.get_agent(['alarms'])['alarms']
         self.assertItemsEqual([x.name for x in [alarm1, alarm2]],
-            [x.name for x in retval])
-        self.assertTrue(all([len(x.expr)>0 for x in retval]))
+            [x['name'] for x in retval])
+        self.assertTrue(all([len(x['expr'])>0 for x in retval]))
 
         self._ia_client.set_agent({'alarms' : ['set', alarm1, alarm2,
                 alarm3, alarm4]})
         retval = self._ia_client.get_agent(['alarms'])['alarms']
         self.assertItemsEqual([x.name for x in [alarm1, alarm2, alarm3,
-            alarm4]], [x.name for x in retval])
-        self.assertTrue(all([len(x.expr)>0 for x in retval]))
+            alarm4]], [x['name'] for x in retval])
+        self.assertTrue(all([len(x['expr'])>0 for x in retval]))
 
         self._ia_client.set_agent({'alarms' : ['remove',
                 'lower_current_warning_interval',
                 'upper_current_warning_interval']})
         retval = self._ia_client.get_agent(['alarms'])['alarms']
         self.assertItemsEqual([x.name for x in [alarm3, alarm4]],
-            [x.name for x in retval])
-        self.assertTrue(all([len(x.expr)>0 for x in retval]))
+            [x['name'] for x in retval])
+        self.assertTrue(all([len(x['expr'])>0 for x in retval]))
 
         self._ia_client.set_agent({'alarms' : ['clear']})
         retval = self._ia_client.get_agent(['alarms'])['alarms']


### PR DESCRIPTION
An IonObject was getting serialized with the JSON encoder, this patch
applies an IonObject deserializer before the json encoding to patch the
test:
ion/agents/instrument/test/test_gateway_to_instrument_agent.py:TestInstrumentAgentViaGateway.test_get_set_agent
