### PR TITLE
Follow up to OOIION-619. Starting notification workers who know their queue_name.

### DIFF
--- a/ion/processes/bootstrap/plugins/bootstrap_process_dispatcher.py
+++ b/ion/processes/bootstrap/plugins/bootstrap_process_dispatcher.py
@@ -120,6 +120,7 @@ class BootstrapProcessDispatcher(BootstrapPlugin):
 
         for i in xrange(notification_workers):
             config.process.name = 'notification_worker_%s' % i
+            config.process.queue_name = 'notification_worker_queue'
             self.pds_client.schedule_process(process_definition_id=uns_procdef_id, configuration=config)
 
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -616,7 +616,8 @@ class UserNotificationService(BaseUserNotificationService):
             configuration = {}
             configuration['process'] = dict({
                 'name': 'notification_worker_%s' % n,
-                'type':'simple'
+                'type':'simple',
+                'queue_name': 'notification_worker_queue'
             })
 
             pid  = self.process_dispatcher.schedule_process(


### PR DESCRIPTION
The notification workers are meant to listen to events in round robin. Now, since pull request 423 has been merged, they can extend TransformEventListener as before and also process events in round robin. Also, they are listening on a named queue, which is good for debugging, incase something happens.

Since the queue of the parent transform class, TransformEventListener, is being used, the queue should get cleaned up properly when processes stop and the TransformEventListener's on_quit() gets called while quitting.
