### PR TITLE
Adds conditional for closing coverage in retrieve_oob

### DIFF
--- a/ion/services/dm/inventory/data_retriever_service.py
+++ b/ion/services/dm/inventory/data_retriever_service.py
@@ -104,7 +104,7 @@ class DataRetrieverService(BaseDataRetrieverService):
     @classmethod
     def retrieve_oob(cls, dataset_id='', query=None, delivery_format=None):
         query = query or {}
-
+        coverage = None
         try:
             coverage = DatasetManagementService._get_coverage(dataset_id, mode='r')
             if coverage.num_timesteps == 0:
@@ -117,7 +117,8 @@ class DataRetrieverService(BaseDataRetrieverService):
             traceback.print_exc(e)
             raise BadRequest('Problems reading from the coverage')
         finally:
-            coverage.close(timeout=5)
+            if coverage is not None:
+                coverage.close(timeout=5)
         return rdt.to_granule()
 
   


### PR DESCRIPTION
There is a chance that _get_coverage could fail and if it does then
coverage is not defined when it reaches the finally block to close the
coverage, this patch addresses this case.

Addresses the failure [here](http://buildbot.oceanobservatories.org:8010/builders/r2_full/builds/260/)
Part of [OOIION-663](https://jira.oceanobservatories.org/tasks/browse/OOIION-663)
