### PR TITLE
Adds skipTest to oob_retrieve

### DIFF
--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -525,6 +525,8 @@ class TestDMEnd2End(IonIntegrationTestCase):
         self.assertTrue(success)
 
 
+    @attr('LOCOINT')
+    @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Host requires file-system access to coverage files, CEI mode does not support.')
     def test_out_of_band_retrieve(self):
         # Setup the environemnt
         stream_id, route, stream_def_id, dataset_id = self.make_simple_dataset()


### PR DESCRIPTION
Skips a test in the CEI environment, the test can't retrieve a coverage if the host does not share the filesystem where the coverages reside.
