### PR TITLE
Changes file modes in ingestion workers to a

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -97,7 +97,7 @@ class ScienceGranuleIngestionWorker(TransformStreamListener):
             dataset_id = self.get_dataset(stream_id)
             if dataset_id is None:
                 return None
-            result = DatasetManagementService._get_coverage(dataset_id)
+            result = DatasetManagementService._get_coverage(dataset_id, mode='a')
             if result is None:
                 return None
             if len(self._coverages) >= self.CACHE_LIMIT:


### PR DESCRIPTION
Before it was using 'w' which wasn't respected, but going forward it
should be a to ensure the HDF file is not reset.

Part of [OOIION-660](https://jira.oceanobservatories.org/tasks/browse/OOIION-660)
