### PR TITLE
Adds short circuit None evaluation to rdt

### DIFF
--- a/ion/services/dm/utility/granule/record_dictionary.py
+++ b/ion/services/dm/utility/granule/record_dictionary.py
@@ -144,6 +144,9 @@ class RecordDictionaryTool(object):
         """
         if name not in self._rd:
             raise KeyError(name)
+        if vals is None:
+            self._rd[name] = None
+            return
         context = self._pdict.get_context(name)
         if self._shp is None: # Not initialized:
             if isinstance(vals, np.ndarray):


### PR DESCRIPTION
If a parameter in an RDT needs to be deleted or removed for any specific
reason, this bypasses the checking done in the Coverage layer and just
sets the field to None.

Part of [OOIION-579](https://jira.oceanobservatories.org/tasks/browse/OOIION-579)
