### PR TITLE
Removes the C,T, P from the output granules when the L2 transforms publish their granules

### DIFF
--- a/ion/processes/data/transforms/ctd/ctd_L2_density.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_density.py
@@ -43,11 +43,11 @@ class DensityTransform(TransformDataProcess):
         """
         if packet == {}:
             return
-#        log.debug("L2 density transform received granule with record dict: %s", packet.record_dictionary)
+        log.debug("L2 density transform received granule with record dict: %s", packet.record_dictionary)
 
         granule = CTDL2DensityTransformAlgorithm.execute(packet, params=self.stream_definition._id)
 
-#        log.debug("L2 density transform publishing granule with record dict: %s", granule.record_dictionary)
+        log.debug("L2 density transform publishing granule with record dict: %s", granule.record_dictionary)
 
         self.density.publish(msg=granule)
 

--- a/ion/processes/data/transforms/ctd/ctd_L2_density.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_density.py
@@ -78,9 +78,11 @@ class CTDL2DensityTransformAlgorithm(SimpleGranuleTransformFunction):
 
         dens_value = rho(sa, temperature, pressure)
 
-#        for key, value in rdt.iteritems():
-#            if key in out_rdt:
-#                out_rdt[key] = value[:]
+        for key, value in rdt.iteritems():
+            if key in out_rdt:
+                if key=='conductivity' or key=='temp' or key=='pressure':
+                    continue
+                out_rdt[key] = value[:]
 
         out_rdt['density'] = dens_value
 

--- a/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
@@ -72,9 +72,11 @@ class CTDL2SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
 
         log.debug("Salinity algorithm calculated the sp (practical salinity) values: %s", sal_value)
 
-#        for key, value in rdt.iteritems():
-#            if key in out_rdt:
-#                out_rdt[key] = value[:]
+        for key, value in rdt.iteritems():
+            if key in out_rdt:
+                if key=='conductivity' or key=='temp' or key=='pressure':
+                    continue
+                out_rdt[key] = value[:]
 
         out_rdt['salinity'] = sal_value
 

--- a/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
@@ -45,7 +45,12 @@ class SalinityTransform(TransformDataProcess):
         if packet == {}:
             return
 
+        log.debug("L2 salinity transform received granule with record dict: %s", packet.record_dictionary)
+
         granule = CTDL2SalinityTransformAlgorithm.execute(packet, params=self.stream_definition._id)
+
+        log.debug("L2 salinity transform publishing granule with record dict: %s", granule.record_dictionary)
+
         granule.data_producer_id=self.id
         self.salinity.publish(msg=granule)
 

--- a/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
+++ b/ion/processes/data/transforms/ctd/ctd_L2_salinity.py
@@ -4,7 +4,7 @@
 @file ion/processes/data/transforms/ctd/ctd_L2_salinity.py
 @description Transforms CTD parsed data into L2 product for salinity
 '''
-
+from pyon.util.log import log
 from ion.core.process.transform import TransformDataProcess
 from pyon.core.exception import BadRequest
 from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
@@ -65,9 +65,11 @@ class CTDL2SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
 
         sal_value = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=pressure)
 
-        for key, value in rdt.iteritems():
-            if key in out_rdt:
-                out_rdt[key] = value[:]
+        log.debug("Salinity algorithm calculated the sp (practical salinity) values: %s", sal_value)
+
+#        for key, value in rdt.iteritems():
+#            if key in out_rdt:
+#                out_rdt[key] = value[:]
 
         out_rdt['salinity'] = sal_value
 


### PR DESCRIPTION
- Removes the C,T, P from the output granules when the L2 transforms publish their granules. L2 transforms publish granule containing only the physical variable they are for, apart from the lat, lon, time etc passed in. 
- Log debug statements have been added in the L2 transforms so that we can trace where the sea water algorithms may return NAN values for presumably unphysical input values for pressure, temperature etc present in the input granule.
