### PR TITLE
Fix ooiion 674 set resource type to platform device

### DIFF
--- a/ion/agents/platform/notes.txt
+++ b/ion/agents/platform/notes.txt
@@ -8,6 +8,9 @@ some noteworthy notes (occasionaly updated)
   test suite might be even better):
   bin/nosetests --with-coverage --cover-package=ion.agents.platform ion/agents/platform ion/services/sa/observatory/test/test_oms_launch2.py
 
+2013-01-22
+- fix OOIION-674 Set resource_type in Platform Agent to be PlatformDevice.
+
 2013-01-11
 - OOIION-631 Use system time (get_ion_ts and similar) instead of NTP
   - get_resource and set_resource adjusted.

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -11,7 +11,7 @@ __author__ = 'Carlos Rueda'
 __license__ = 'Apache 2.0'
 
 
-from pyon.public import log
+from pyon.public import log, RT
 from pyon.ion.stream import StreamPublisher
 from pyon.agent.agent import ResourceAgent
 from pyon.agent.agent import ResourceAgentState
@@ -119,6 +119,10 @@ class PlatformAgent(ResourceAgent):
     def __init__(self):
         log.info("PlatformAgent constructor called")
         ResourceAgent.__init__(self)
+
+        #This is the type of Resource managed by this agent
+        self.resource_type = RT.PlatformDevice
+
         self._plat_config = None
         self._platform_id = None
         self._topology = None


### PR DESCRIPTION
As indicated, followed same pattern as in InstrumentAgent, in concrete, added the following to the PlatformAgent constructor:
    self.resource_type = RT.PlatformDevice
