### PR TITLE
Adds replace data process functionality to data process management service

### DIFF
--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -656,7 +656,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
     def update_data_process(self,):
         #todo: What are valid ways to update a data process?.
 
-        return
+        raise NotImplementedError()
 
     def read_data_process(self, data_process_id=""):
 

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -500,8 +500,6 @@ class DataProcessManagementService(BaseDataProcessManagementService):
 
             self.clients.resource_registry.create_association(data_process._id, PRED.hasInputProduct, in_data_product_id)
 
-            log.debug("created the associations")
-
             #check if in data product is attached to an instrument, check instrumentDevice and InstrumentModel for lookup table attachments
             instdevice_ids, _ = self.clients.resource_registry.find_subjects(RT.InstrumentDevice, PRED.hasOutputProduct, in_data_product_id, True)
 
@@ -515,14 +513,11 @@ class DataProcessManagementService(BaseDataProcessManagementService):
                 for instmodel_id in instmodel_ids:
                     # check for attachments in instrument model
                     configuration = self._find_lookup_tables(instmodel_id, configuration)
-            log.debug("came here!! XX ")
 
         #------------------------------------------------------------------------------------------------------------------------------------------
         # Get the input stream from the input_data_product, which should already be associated with a stream via the Data Producer
         #------------------------------------------------------------------------------------------------------------------------------------------
         input_stream_ids = self._get_input_stream_ids(in_data_product_ids)
-
-        log.debug("got the input stream ids:: %s", input_stream_ids)
 
         #------------------------------------------------------------------------------------------------------------------------------------------
         # Update the subscriptions of the data process
@@ -602,9 +597,13 @@ class DataProcessManagementService(BaseDataProcessManagementService):
             process_definition_id=process_definition_id,
             configuration=configuration)
 
+        log.debug("On relaunching the data process, got the new process id: %s", new_pid)
+
         data_process.process_id = new_pid
 
         self.clients.resource_registry.update(data_process)
+
+        log.debug("Replaced the old data process object with the new one: %s", data_process)
 
     def _find_lookup_tables(self, resource_id="", configuration=None):
         #check if resource has lookup tables attached

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -438,6 +438,132 @@ class DataProcessManagementService(BaseDataProcessManagementService):
 
         return pid
 
+    def replace_data_process(self, data_process=None, data_process_definition= None, in_data_product_ids=None, out_data_products=None, configuration=None):
+
+        # Get the data process id
+        data_process_id = data_process._id
+
+        # Cancel the running data process. todo: we might have tried just pause here, but right now we have only cancel functionality
+        process_id = data_process.process_id
+        self.clients.process_dispatcher.cancel_process(process_id)
+
+        #------------------------------------------------------------------------------------------------------------------------------------------
+        # Update stuff.... before restarting the process
+        #------------------------------------------------------------------------------------------------------------------------------------------
+
+        # Get the new data process definition containing module, class etc to run
+        data_process_def = None
+
+        if data_process_definition:
+            self.update_data_process_definition(data_process_definition)
+            output_bindings = data_process_definition.output_bindings
+
+            # Check for attachments in data process definition and put them into the configuration
+            configuration = self._find_lookup_tables(data_process_definition._id, configuration)
+
+        else:
+            data_proc_def_ids, _ = self.clients.resource_registry.find_objects(subject=data_process_id, predicate=PRED.hasProcessDefinition, object_type=RT.DataProcessDefinition, id_only=True )
+            data_process_def = self.clients.resource_registry.read(data_proc_def_ids[0])
+
+        data_process_definition = data_process_def
+        data_process_definition_id = data_process_definition._id
+
+        output_stream_dict = {}
+
+        if out_data_products:
+
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            # If out_data_products have been provided, find the ones already associated to the data process and remove them first before associate the new ones
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            _, assocs = self.clients.resource_registry.find_associations(subject=data_process_id, predicate=PRED.hasOutputProduct, id_only=True)
+
+            for assoc in assocs:
+                self.clients.resource_registry.delete_association(assoc)
+
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            # Now get the new data products in
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            for binding, output_data_product_id in out_data_products.iteritems():
+
+                # check that the product is not already associated with a producer
+                producer_ids, _ = self.clients.resource_registry.find_objects(output_data_product_id, PRED.hasDataProducer, RT.DataProducer, True)
+                if producer_ids:
+                    raise BadRequest("Data Product should not already be associated to a DataProducer %s hasDataProducer %s", str(data_process_id), str(producer_ids[0]))
+
+                # Associate with DataProcess: register as an output product for this process
+                log.debug("Link data process %s and output out data product: %s  (L4-CI-SA-RQ-260)", str(data_process_id), str(output_data_product_id))
+                self.clients.data_acquisition_management.assign_data_product(input_resource_id= data_process_id,data_product_id= output_data_product_id)
+
+                # Retrieve the id of the OUTPUT stream from the out Data Product
+                stream_ids, _ = self.clients.resource_registry.find_objects(output_data_product_id, PRED.hasStream, RT.Stream, True)
+
+                if not stream_ids:
+                    raise NotFound("No Stream created for output Data Product " + str(output_data_product_id))
+
+                if len(stream_ids) != 1:
+                    raise BadRequest("Data Product should only have ONE stream at this time" + str(output_data_product_id))
+
+                output_stream_dict[binding] = stream_ids[0]
+
+        if in_data_product_ids:
+
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            # If input data products have been provided, find the ones already associated to the data process and remove them first before associating the new ones
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            _, assocs = self.rrclient.find_objects(subject=data_process_id, predicate=PRED.hasOutputProduct, id_only=True)
+
+            for assoc in assocs:
+                self.clients.resource_registry.delete_association(assoc)
+
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            # Now get the new input data products
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            for  in_data_product_id in in_data_product_ids:
+
+                self.clients.resource_registry.create_association(data_process_id, PRED.hasInputProduct, in_data_product_id)
+
+                #check if in data product is attached to an instrument, check instrumentDevice and InstrumentModel for lookup table attachments
+                instdevice_ids, _ = self.clients.resource_registry.find_subjects(RT.InstrumentDevice, PRED.hasOutputProduct, in_data_product_id, True)
+
+                for instdevice_id in instdevice_ids:
+                    log.debug("Instrument device_id assoc to the input data product of this data process: %s   (L4-CI-SA-RQ-231)", str(instdevice_id))
+
+                    # check for attachments in instrument device
+                    configuration = self._find_lookup_tables(instdevice_id, configuration)
+                    instmodel_ids, _ = self.clients.resource_registry.find_objects(instdevice_id, PRED.hasModel, RT.InstrumentModel, True)
+
+                    for instmodel_id in instmodel_ids:
+                        # check for attachments in instrument model
+                        configuration = self._find_lookup_tables(instmodel_id, configuration)
+
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            # Get the input stream from the input_data_product, which should already be associated with a stream via the Data Producer
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            input_stream_ids = self._get_input_stream_ids(in_data_product_ids)
+
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            # Update the subscriptions of the data process
+            #------------------------------------------------------------------------------------------------------------------------------------------
+            self.update_data_process_inputs(data_process_id=data_process_id, in_stream_ids= input_stream_ids)
+
+        procdef_ids,_ = self.clients.resource_registry.find_objects(data_process_definition_id, PRED.hasProcessDefinition, RT.ProcessDefinition, id_only=True)
+        if not procdef_ids:
+            raise BadRequest("Cannot find associated ProcessDefinition for DataProcessDefinition id=%s" % data_process_definition_id)
+
+        process_definition_id = procdef_ids[0]
+
+        log.info("Relaunching the data process")
+        debug_str = "\n\tQueue Name: %s\n\tOutput Streams: %s\n\tProcess Definition ID: %s\n\tConfiguration: %s" % (data_process_name, output_stream_dict, process_definition_id, configuration)
+        log.debug(debug_str)
+
+        new_pid = self._launch_process(
+            queue_name=data_process.name,
+            out_streams=output_stream_dict,
+            process_definition_id=process_definition_id,
+            configuration=configuration)
+
+        data_process_obj.process_id = new_pid
+        self.clients.resource_registry.update(data_process)
 
     def _find_lookup_tables(self, resource_id="", configuration=None):
         #check if resource has lookup tables attached

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -478,10 +478,9 @@ class DataProcessManagementService(BaseDataProcessManagementService):
             #------------------------------------------------------------------------------------------------------------------------------------------
             # If out_data_products have been provided, find the ones already associated to the data process and remove them first before associate the new ones
             #------------------------------------------------------------------------------------------------------------------------------------------
-            _, assocs = self.clients.resource_registry.find_associations(subject=data_process_id, predicate=PRED.hasOutputProduct, id_only=True)
+            assocs = self.clients.resource_registry.find_associations(subject=data_process_id, predicate=PRED.hasOutputProduct, id_only=True)
 
-            for assoc in assocs:
-                self.clients.resource_registry.delete_association(assoc)
+            [self.clients.resource_registry.delete_association(assoc) for assoc in assocs]
 
             #------------------------------------------------------------------------------------------------------------------------------------------
             # Now get the new data products in

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -563,7 +563,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         process_definition_id = procdef_ids[0]
 
         log.info("Relaunching the data process")
-        debug_str = "\n\tQueue Name: %s\n\tOutput Streams: %s\n\tProcess Definition ID: %s\n\tConfiguration: %s" % (data_process_name, output_stream_dict, process_definition_id, configuration)
+        debug_str = "\n\tQueue Name: %s\n\tOutput Streams: %s\n\tProcess Definition ID: %s\n\tConfiguration: %s" % (data_process.name, output_stream_dict, process_definition_id, configuration)
         log.debug(debug_str)
 
         new_pid = self._launch_process(
@@ -572,7 +572,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
             process_definition_id=process_definition_id,
             configuration=configuration)
 
-        data_process_obj.process_id = new_pid
+        data_process.process_id = new_pid
         self.clients.resource_registry.update(data_process)
 
     def _find_lookup_tables(self, resource_id="", configuration=None):

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -489,8 +489,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         #------------------------------------------------------------------------------------------------------------------------------------------
         # If input data products have been provided, find the ones already associated to the data process and remove them first before associating the new ones
         #------------------------------------------------------------------------------------------------------------------------------------------
-        _, assocs = self.clients.resource_registry.find_objects(subject=data_process._id, predicate=PRED.hasOutputProduct, id_only=True)
-
+        _, assocs = self.clients.resource_registry.find_objects(subject=data_process._id, predicate=PRED.hasInputProduct, id_only=True)
         [self.clients.resource_registry.delete_association(assoc) for assoc in assocs]
 
         #------------------------------------------------------------------------------------------------------------------------------------------

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -230,18 +230,6 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         # Create InstrumentAgentInstance to hold configuration information
         #-------------------------------
 
-
-        port_agent_config = {
-            'device_addr': 'sbe37-simulator.oceanobservatories.org',
-            'device_port': 4001,
-            'process_type': PortAgentProcessType.UNIX,
-            'binary_path': "port_agent",
-            'command_port': 4002,
-            'data_port': 4003,
-            'log_level': 5,
-        }
-
-
         port_agent_config = {
             'device_addr':  CFG.device.sbe37.host,
             'device_port':  CFG.device.sbe37.port,
@@ -548,18 +536,6 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         # Create InstrumentAgentInstance to hold configuration information
         #-------------------------------
 
-
-        port_agent_config = {
-            'device_addr': 'sbe37-simulator.oceanobservatories.org',
-            'device_port': 4001,
-            'process_type': PortAgentProcessType.UNIX,
-            'binary_path': "port_agent",
-            'command_port': 4002,
-            'data_port': 4003,
-            'log_level': 5,
-            }
-
-
         port_agent_config = {
             'device_addr':  CFG.device.sbe37.host,
             'device_port':  CFG.device.sbe37.port,
@@ -691,3 +667,16 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
 
         process_obj = self.process_dispatcher.read_process(data_process.process_id)
         self.assertEquals(process_obj.process_state, ProcessStateEnum.RUNNING)
+
+        #-----------------------------------------------------------------------------
+        # Now test the replacing of the data process
+        #-----------------------------------------------------------------------------
+
+        # Change only the data process definition and test if the replace works
+        data_process_definition = self.rrclient.read(ctd_L0_all_dprocdef_id)
+        data_process_definition.name = 'an updated data process definition'
+        data_process_definition.description = 'to test the replace method'
+
+        self.dataprocessclient.replace_data_process( data_process_id=data_process_id, data_process_definition= data_process_definition)
+
+

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -696,6 +696,22 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         old_proc_obj = self.process_dispatcher.read_process(old_pid)
         self.assertEquals(old_proc_obj.process_state, ProcessStateEnum.TERMINATED)
 
+        # Assert that the data process definition has changed
+        process_def_ids, _ = self.rrclient.find_objects(data_process_id, PRED.hasProcessDefinition)
+
+        self.assertEquals(len(process_def_ids), 1)
+        self.assertEquals(process_def_ids[0]._id, ctd_L0_all_dprocdef_id)
+        self.assertEquals(process_def_ids[0].name, data_process_definition.name)
+        self.assertEquals(process_def_ids[0].description, data_process_definition.description)
+
+        # Assert that the input and output subscriptions are unchanged
+        output_dps, _ = self.rrclient.find_objects(data_process_id, PRED.hasOutputProduct)
+        [self.assertTrue(out_dp._id in self.output_products.values()) for out_dp in output_dps]
+
+        input_dps, _ = self.rrclient.find_objects(data_process_id, PRED.hasInputProduct)
+        self.assertEquals(input_dps[0]._id, ctd_parsed_data_product)
+        self.assertEquals(len(input_dps), 1)
+
         #-------------------------------------------------------------------------------------------------------------
         # Change only the input subscriptions and test if replace_data_process() works
         #-------------------------------------------------------------------------------------------------------------

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -739,6 +739,26 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         old_proc_obj = self.process_dispatcher.read_process(pid)
         self.assertEquals(old_proc_obj.process_state, ProcessStateEnum.TERMINATED)
 
+        # Assert that the data process definition has NOT changed
+        process_def_ids, _ = self.rrclient.find_objects(data_process_id, PRED.hasProcessDefinition)
+        old_data_process_def = self.rrclient.read(ctd_L0_all_dprocdef_id)
+
+        self.assertEquals(len(process_def_ids), 1)
+        self.assertEquals(process_def_ids[0]._id, ctd_L0_all_dprocdef_id)
+        self.assertEquals(process_def_ids[0].name, old_data_process_def.name)
+        self.assertEquals(process_def_ids[0].description, old_data_process_def.description)
+
+        # Assert that the output subscriptions have NOT changed
+        output_dps, _ = self.rrclient.find_objects(data_process_id, PRED.hasOutputProduct)
+        [self.assertTrue(out_dp._id in self.output_products.values()) for out_dp in output_dps]
+
+        # Assert that the input subscription has changed to the new one
+        input_dps, _ = self.rrclient.find_objects(data_process_id, PRED.hasInputProduct)
+        self.assertEquals(input_dps[0]._id, new_in_dp_id)
+        self.assertEquals(len(input_dps), 1)
+        self.assertEquals( input_dps[0].name, new_dp_obj.name)
+        self.assertEquals( input_dps[0].description, new_dp_obj.description)
+
         #-------------------------------------------------------------------------------------------------------------
         # Change only the output data products for the data process and use the replace_data_process()
         #-------------------------------------------------------------------------------------------------------------
@@ -792,3 +812,26 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         # Check that the old process has stopped
         old_proc_obj = self.process_dispatcher.read_process(pid_2)
         self.assertEquals(old_proc_obj.process_state, ProcessStateEnum.TERMINATED)
+
+        # Assert that the data process definition has NOT changed
+        process_def_ids, _ = self.rrclient.find_objects(data_process_id, PRED.hasProcessDefinition)
+        old_data_process_def = self.rrclient.read(ctd_L0_all_dprocdef_id)
+
+        self.assertEquals(len(process_def_ids), 1)
+        self.assertEquals(process_def_ids[0]._id, ctd_L0_all_dprocdef_id)
+        self.assertEquals(process_def_ids[0].name, old_data_process_def.name)
+        self.assertEquals(process_def_ids[0].description, old_data_process_def.description)
+
+        # Assert that the input subscription has NOT changed to the new one
+        input_dps, _ = self.rrclient.find_objects(data_process_id, PRED.hasInputProduct)
+
+        self.assertEquals(input_dps[0]._id, new_in_dp_id)
+        self.assertEquals(len(input_dps), 1)
+        self.assertEquals( input_dps[0].name, new_dp_obj.name)
+        self.assertEquals( input_dps[0].description, new_dp_obj.description)
+
+        # Assert that the output subscriptions have changed to the new ones
+        output_dps, _ = self.rrclient.find_objects(data_process_id, PRED.hasOutputProduct)
+        [self.assertTrue(out_dp._id in self.output_products.values()) for out_dp in output_dps]
+
+

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -722,3 +722,57 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         # Check that the old process has stopped
         old_proc_obj = self.process_dispatcher.read_process(pid)
         self.assertEquals(old_proc_obj.process_state, ProcessStateEnum.TERMINATED)
+
+        #-------------------------------------------------------------------------------------------------------------
+        # Change only the output data products for the data process and use the replace_data_process()
+        #-------------------------------------------------------------------------------------------------------------
+        self.output_products={}
+
+        dp_1 = IonObject(  RT.DataProduct,
+            name='new out data product 1',
+            description='to test replace_data_process()',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        dp_id_1 = self.dataproductclient.create_data_product(dp_1,
+            out_stream_cond_id)
+
+        self.output_products['conductivity'] = dp_id_1
+
+        dp_2 = IonObject(RT.DataProduct,
+            name='new out data product 2',
+            description='to test replace_data_process()',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        dp_id_2 = self.dataproductclient.create_data_product(dp_2,
+            out_stream_pres_id)
+
+        self.output_products['pressure'] = dp_id_2
+
+        dp_3 = IonObject(RT.DataProduct,
+            name='new data product',
+            description='for test',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+
+        dp_id_3 = self.dataproductclient.create_data_product(dp_3,
+            out_stream_temp_id)
+        self.output_products['temperature'] = dp_id_3
+
+        self.dataprocessclient.replace_data_process( data_process_id=data_process_id, out_data_products=self.output_products)
+
+        # get the process id from the data process
+        rep_dp_obj = self.rrclient.read(data_process_id)
+        pid_3 = rep_dp_obj.process_id
+
+        self.assertNotEquals(pid_3, pid_2)
+
+        # Check that the new process is running
+        process_obj = self.process_dispatcher.read_process(pid_3)
+        self.assertEquals(process_obj.process_state, ProcessStateEnum.RUNNING)
+
+        # Check that the old process has stopped
+        old_proc_obj = self.process_dispatcher.read_process(pid_2)
+        self.assertEquals(old_proc_obj.process_state, ProcessStateEnum.TERMINATED)

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -665,7 +665,8 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         subs = self.rrclient.read(input_subscription_id)
         self.assertTrue(subs.activated)
 
-        process_obj = self.process_dispatcher.read_process(data_process.process_id)
+        old_pid =  data_process.process_id
+        process_obj = self.process_dispatcher.read_process(old_pid)
         self.assertEquals(process_obj.process_state, ProcessStateEnum.RUNNING)
 
         #-----------------------------------------------------------------------------
@@ -679,4 +680,15 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
 
         self.dataprocessclient.replace_data_process( data_process_id=data_process_id, data_process_definition= data_process_definition)
 
+        # get the process id from the data process
+        rep_dp_obj = self.rrclient.read(data_process_id)
+        pid = rep_dp_obj.process_id
+
+        self.assertNotEquals(pid, old_pid)
+
+        # Check that the new process is running
+        process_obj = self.process_dispatcher.read_process(pid)
+        self.assertEquals(process_obj.process_state, ProcessStateEnum.RUNNING)
+
+        # Check that the old process has stopped
 

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -518,3 +518,176 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
 
         with self.assertRaises(NotFound):
             self.rrclient.read(ctd_l0_all_data_process_id)
+
+
+    @patch.dict(CFG, {'endpoint':{'receive':{'timeout': 60}}})
+    def test_replace_data_process_using_sim(self):
+
+        #-------------------------------
+        # Create InstrumentModel
+        #-------------------------------
+        instModel_obj = IonObject(RT.InstrumentModel, name='SBE37IMModel', description="SBE37IMModel" )
+        instModel_id = self.imsclient.create_instrument_model(instModel_obj)
+
+        #-------------------------------
+        # Create InstrumentAgent
+        #-------------------------------
+        instAgent_obj = IonObject(RT.InstrumentAgent, name='agent007', description="SBE37IMAgent", driver_module="mi.instrument.seabird.sbe37smb.ooicore.driver", driver_class="SBE37Driver" )
+        instAgent_id = self.imsclient.create_instrument_agent(instAgent_obj)
+
+        self.imsclient.assign_instrument_model_to_instrument_agent(instModel_id, instAgent_id)
+
+        #-------------------------------
+        # Create InstrumentDevice
+        #-------------------------------
+        instDevice_obj = IonObject(RT.InstrumentDevice, name='SBE37IMDevice', description="SBE37IMDevice", serial_number="12345" )
+        instDevice_id = self.imsclient.create_instrument_device(instrument_device=instDevice_obj)
+        self.imsclient.assign_instrument_model_to_instrument_device(instModel_id, instDevice_id)
+
+        #-------------------------------
+        # Create InstrumentAgentInstance to hold configuration information
+        #-------------------------------
+
+
+        port_agent_config = {
+            'device_addr': 'sbe37-simulator.oceanobservatories.org',
+            'device_port': 4001,
+            'process_type': PortAgentProcessType.UNIX,
+            'binary_path': "port_agent",
+            'command_port': 4002,
+            'data_port': 4003,
+            'log_level': 5,
+            }
+
+
+        port_agent_config = {
+            'device_addr':  CFG.device.sbe37.host,
+            'device_port':  CFG.device.sbe37.port,
+            'process_type': PortAgentProcessType.UNIX,
+            'binary_path': "port_agent",
+            'port_agent_addr': 'localhost',
+            'command_port': CFG.device.sbe37.port_agent_cmd_port,
+            'data_port': CFG.device.sbe37.port_agent_data_port,
+            'log_level': 5,
+            'type': PortAgentType.ETHERNET
+        }
+
+        instAgentInstance_obj = IonObject(RT.InstrumentAgentInstance, name='SBE37IMAgentInstance', description="SBE37IMAgentInstance", svr_addr="localhost",
+            comms_device_address=CFG.device.sbe37.host, comms_device_port=CFG.device.sbe37.port,
+            port_agent_config = port_agent_config)
+        instAgentInstance_id = self.imsclient.create_instrument_agent_instance(instAgentInstance_obj, instAgent_id, instDevice_id)
+
+
+        #-------------------------------
+        # Create CTD Parsed as the first data product
+        #-------------------------------
+        # create a stream definition for the data from the ctd simulator
+        pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
+        ctd_stream_def_id = self.pubsubclient.create_stream_definition(name='SBE32_CDM', parameter_dictionary_id=pdict_id)
+
+        # Construct temporal and spatial Coordinate Reference System objects
+        tdom, sdom = time_series_domain()
+
+        sdom = sdom.dump()
+        tdom = tdom.dump()
+
+
+
+        dp_obj = IonObject(RT.DataProduct,
+            name='ctd_parsed',
+            description='ctd stream test',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        ctd_parsed_data_product = self.dataproductclient.create_data_product(dp_obj, ctd_stream_def_id)
+
+        self.damsclient.assign_data_product(input_resource_id=instDevice_id, data_product_id=ctd_parsed_data_product)
+
+        # Retrieve the id of the OUTPUT stream from the out Data Product
+        stream_ids, _ = self.rrclient.find_objects(ctd_parsed_data_product, PRED.hasStream, None, True)
+
+        #-------------------------------
+        # Create CTD Raw as the second data product
+        #-------------------------------
+        raw_stream_def_id = self.pubsubclient.create_stream_definition(name='SBE37_RAW', parameter_dictionary_id=pdict_id)
+
+        dp_obj.name = 'ctd_raw'
+        ctd_raw_data_product = self.dataproductclient.create_data_product(dp_obj, raw_stream_def_id)
+
+        self.damsclient.assign_data_product(input_resource_id=instDevice_id, data_product_id=ctd_raw_data_product)
+
+        # Retrieve the id of the OUTPUT stream from the out Data Product
+        stream_ids, _ = self.rrclient.find_objects(ctd_raw_data_product, PRED.hasStream, None, True)
+
+        #-------------------------------
+        # L0 Conductivity - Temperature - Pressure: Data Process Definition
+        #-------------------------------
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+            name='ctd_L0_all',
+            description='transform ctd package into three separate L0 streams',
+            module='ion.processes.data.transforms.ctd.ctd_L0_all',
+            class_name='ctd_L0_all')
+        ctd_L0_all_dprocdef_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
+
+        #-------------------------------
+        # L0 Conductivity - Temperature - Pressure: Output Data Products
+        #-------------------------------
+
+        out_stream_cond_id = self.pubsubclient.create_stream_definition(name='L0_Conductivity', parameter_dictionary_id=pdict_id)
+        self.dataprocessclient.assign_stream_definition_to_data_process_definition(out_stream_cond_id, ctd_L0_all_dprocdef_id, binding='conductivity' )
+
+        out_stream_pres_id = self.pubsubclient.create_stream_definition(name='L0_Pressure', parameter_dictionary_id=pdict_id)
+        self.dataprocessclient.assign_stream_definition_to_data_process_definition(out_stream_pres_id, ctd_L0_all_dprocdef_id, binding='pressure' )
+
+        out_stream_temp_id = self.pubsubclient.create_stream_definition(name='L0_Temperature', parameter_dictionary_id=pdict_id)
+        self.dataprocessclient.assign_stream_definition_to_data_process_definition(out_stream_temp_id, ctd_L0_all_dprocdef_id, binding='temperature' )
+
+
+        self.output_products={}
+
+        out_cond_dp_obj = IonObject(  RT.DataProduct,
+            name='L0_Conductivity',
+            description='transform output conductivity',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+
+        out_cond_dp_id = self.dataproductclient.create_data_product(out_cond_dp_obj,
+            out_stream_cond_id)
+        self.output_products['conductivity'] = out_cond_dp_id
+
+        out_pres_dp_obj = IonObject(RT.DataProduct,
+            name='L0_Pressure',
+            description='transform output pressure',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        out_pres_dp_id = self.dataproductclient.create_data_product(out_pres_dp_obj,
+            out_stream_pres_id)
+        self.output_products['pressure'] = out_pres_dp_id
+
+        out_temp_dp_obj = IonObject(RT.DataProduct,
+            name='L0_Temperature',
+            description='transform output temperature',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+
+        out_temp_dp_id = self.dataproductclient.create_data_product(out_temp_dp_obj,
+            out_stream_temp_id)
+        self.output_products['temperature'] = out_temp_dp_id
+
+        #-------------------------------
+        # L0 Conductivity - Temperature - Pressure: Create the data process
+        #-------------------------------
+        data_process_id = self.dataprocessclient.create_data_process(ctd_L0_all_dprocdef_id, [ctd_parsed_data_product], self.output_products)
+
+        self.dataprocessclient.activate_data_process(data_process_id)
+
+        data_process = self.rrclient.read(data_process_id)
+        input_subscription_id = data_process.input_subscription_id
+        subs = self.rrclient.read(input_subscription_id)
+        self.assertTrue(subs.activated)
+
+        process_obj = self.process_dispatcher.read_process(data_process.process_id)
+        self.assertEquals(process_obj.process_state, ProcessStateEnum.RUNNING)


### PR DESCRIPTION
- Adds replace_data_process() to data process management to satisfy SA requirement for replace functionality.
- Adds test code to verify that that the replace method works.

For the replace functionality, what we are doing is:
1. Stop the running process (We do not yet have a pause functionality in process dispatcher). Its process_id is stored in the process_id attribute of the data process object
2. Update the data process object with the new params
3. Restart the process associated with the data process (and update the data process object's process_id with that of the new running process)

The id of the original data process object is maintained since the data process object is a resource object.
