### PR TITLE
Adds failover logic (and test) to ingestion workers

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -129,7 +129,7 @@ class ScienceGranuleIngestionWorker(TransformStreamListener):
         return self._queues[stream_id]
 
 
-    @handle_stream_exception
+    @handle_stream_exception()
     def recv_packet(self, msg, stream_route, stream_id):
         '''
         Actual ingestion mechanism


### PR DESCRIPTION
Ingestion workers now publish ExceptionEvents when corruption occurs,
the stream publishers, or a managing entity could listen for these
events and attempt to either clean the coverages or stop ingestion until
further investigation is complete.  In any case this is a step in
bullet-proofing the system.

Part of [OOIION-660](https://jira.oceanobservatories.org/tasks/browse/OOIION-660)
