### PR TITLE
System restart support

### DIFF
--- a/ion/agents/cei/high_availability_agent.py
+++ b/ion/agents/cei/high_availability_agent.py
@@ -33,7 +33,7 @@ except ImportError:
 @brief Pyon port of HAAgent
  """
 
-DEFAULT_INTERVAL = 30
+DEFAULT_INTERVAL = 60
 
 
 class HighAvailabilityAgent(SimpleResourceAgent):
@@ -553,6 +553,9 @@ def _get_process_schedule(**kwargs):
         except KeyError:
             msg = "%s is not a known ProcessRestartMode" % (restart_mode)
             raise BadRequest(msg)
+    else:
+        # if restart mode isn't specified, use NEVER. HA Agent itself will reschedule failures.
+        process_schedule.restart_mode = ProcessRestartMode.NEVER
 
     target = ProcessTarget()
     if execution_engine_id is not None:

--- a/ion/agents/cei/test/test_haagent.py
+++ b/ion/agents/cei/test/test_haagent.py
@@ -374,7 +374,9 @@ class HAAgentMockTest(PyonTestCase):
         self.ha_agent.container.resource_registry.read = Mock()
         self.ha_agent.container.resource_registry.update = Mock()
 
-        self.ha_agent.init()
+        with patch('ion.agents.cei.high_availability_agent.ProcessDispatcherServiceClient') as pd_client:
+            pd_client.read_process_definition.return_value = Mock()
+            self.ha_agent.init()
 
         self.ha_agent.control = Mock()
         self.ha_agent.control.get_all_processes = Mock(return_value={})
@@ -394,7 +396,6 @@ class HAAgentMockTest(PyonTestCase):
         This test ensures that the policy thread will catch any exceptions
         arising from deep inside HA Agent
         """
-
 
         # First make reload_processes raise an Exception
         self.ha_agent.control.reload_processes = Mock(side_effect=ValueError)
@@ -425,7 +426,6 @@ class HAAgentMockTest(PyonTestCase):
         while not self.ha_agent.control.get_all_processes.called:
             gevent.sleep(0.5)
         self.assertFalse(self.policy_thread.dead)
-
 
 
 @attr('INT', group='cei')

--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -382,13 +382,20 @@ class ProcessDispatcherService(BaseProcessDispatcherService):
 
     def _get_process_name(self, process_definition, configuration):
 
-        ha_pd_id = configuration.get('highavailability', {}).get('process_definition_id')
+        base_name = ""
         name_suffix = ""
-        if ha_pd_id is not None:
-            process_definition = self.backend.read_definition(ha_pd_id)
-            name_suffix = "ha"
+        ha_config = configuration.get('highavailability')
+        if ha_config:
+            if ha_config.get('process_definition_name'):
+                base_name = ha_config['process_definition_name']
+                name_suffix = "ha"
+            elif ha_config.get('process_definition_id'):
+                inner_definition = self.backend.read_definition(
+                    ha_config['process_definition_id'])
+                base_name = inner_definition.name
+                name_suffix = "ha"
 
-        name_parts = [str(process_definition.name or "process")]
+        name_parts = [str(base_name or process_definition.name or "process")]
         if name_suffix:
             name_parts.append(name_suffix)
         name_parts.append(uuid.uuid4().hex)

--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -730,6 +730,7 @@ class PDLocalBackend(object):
 
 _PD_PROCESS_STATE_MAP = {
     "100-UNSCHEDULED": ProcessStateEnum.REQUESTED,
+    "150-UNSCHEDULED_PENDING": ProcessStateEnum.REQUESTED,
     "200-REQUESTED": ProcessStateEnum.REQUESTED,
     "250-DIED_REQUESTED": ProcessStateEnum.REQUESTED,
     "300-WAITING": ProcessStateEnum.WAITING,

--- a/ion/services/cei/test/test_process_dispatcher.py
+++ b/ion/services/cei/test/test_process_dispatcher.py
@@ -171,6 +171,7 @@ class ProcessDispatcherServiceDashiHandlerTest(PyonTestCase):
         self.mock_backend['read_process'] = Mock()
         self.mock_backend['list'] = Mock()
         self.mock_backend['cancel'] = Mock()
+        self.mock_backend['set_system_boot'] = Mock()
 
         self.mock_dashi = DotDict()
         self.mock_dashi['handle'] = Mock()
@@ -252,6 +253,10 @@ class ProcessDispatcherServiceDashiHandlerTest(PyonTestCase):
         passed_schedule = args[2]
         assert passed_schedule.queueing_mode == ProcessQueueingMode.RESTART_ONLY
         assert passed_schedule.restart_mode == ProcessRestartMode.ABNORMAL
+
+    def test_set_system_boot(self):
+        self.pd_dashi_handler.set_system_boot(False)
+        self.mock_backend.set_system_boot.assert_called_once_with(False)
 
 
 @attr('UNIT', group='cei')

--- a/ion/services/cei/test/test_process_dispatcher.py
+++ b/ion/services/cei/test/test_process_dispatcher.py
@@ -165,6 +165,7 @@ class ProcessDispatcherServiceDashiHandlerTest(PyonTestCase):
         self.mock_backend['create_definition'] = Mock()
         self.mock_backend['read_definition'] = Mock()
         self.mock_backend['read_definition_by_name'] = Mock()
+        self.mock_backend['update_definition'] = Mock()
         self.mock_backend['delete_definition'] = Mock()
         self.mock_backend['create'] = Mock()
         self.mock_backend['schedule'] = Mock()
@@ -193,23 +194,18 @@ class ProcessDispatcherServiceDashiHandlerTest(PyonTestCase):
         self.pd_dashi_handler.describe_definition(definition_id)
         self.assertEqual(self.mock_backend.read_definition.call_count, 1)
 
-        raised = False
-        try:
-            self.pd_dashi_handler.update_definition(definition_id, definition_type,
-                executable, name, description)
-        except BadRequest:
-            raised = True
-        assert raised, "update_definition didn't raise badrequest"
+        self.pd_dashi_handler.describe_definition(definition_name=name)
+        self.assertEqual(self.mock_backend.read_definition_by_name.call_count, 1)
+
+        self.pd_dashi_handler.update_definition(definition_id, definition_type,
+            executable, name, description)
+        self.assertEqual(self.mock_backend.update_definition.call_count, 1)
 
         self.pd_dashi_handler.remove_definition(definition_id)
         self.assertEqual(self.mock_backend.delete_definition.call_count, 1)
 
-        raised = False
-        try:
+        with self.assertRaises(BadRequest):
             self.pd_dashi_handler.list_definitions()
-        except BadRequest:
-            raised = True
-        assert raised, "list_definitions didn't raise badrequest"
 
     def test_schedule(self):
 


### PR DESCRIPTION
**DO NOT MERGE -- must occur in unison with several other repos**

These changes are part of the broader system restart support. On a high level, the following changes were made in coi-services:
- Account for changes in underlying Process Dispatcher core (from ooici/epu repo). Integrate PD Doctor and PD initialization handling to Process Dispatcher Service lifecycle handlers.
- Add support to HA Agent for scheduling processes by definition name.
- Improve exception handling in PD dashi handers, using a decorator to map Pyon exceptions to Dashi
