### PR TITLE
Fixes retrieve time issue

### DIFF
--- a/ion/processes/data/replay/replay_process.py
+++ b/ion/processes/data/replay/replay_process.py
@@ -28,6 +28,7 @@ import dateutil.parser
 import gevent
 import netCDF4
 import numpy as np
+import calendar
 import time
 
 
@@ -293,7 +294,7 @@ class ReplayProcess(BaseReplayProcess):
         if 'since' in units:
             t = netCDF4.netcdftime.utime(units)
             dtg = t.num2date(val)
-            return time.mktime(dtg.timetuple())
+            return calendar.timegm(dtg.timetuple())
         elif 'iso' in units:
             t = dateutil.parser.parse(val)
             return time.mktime(t.timetuple())


### PR DESCRIPTION
`time.mktime()` returns the time value in the local timezone.  All of our unix timestamp representations are UTC (as per POSIX standard) so this was offsetting our desired values by hours according to which timezone we were in.  On a positive note, it would work fine if you took a trip to the UK.

Part of [OOIION-695](https://jira.oceanobservatories.org/tasks/browse/OOIION-695)
