### PR TITLE
OOIION-703: Process dispatcher termination race

### DIFF
--- a/ion/services/cei/test/test_process_dispatcher.py
+++ b/ion/services/cei/test/test_process_dispatcher.py
@@ -730,6 +730,10 @@ class ProcessDispatcherServiceIntTest(IonIntegrationTestCase):
                 process_schedule, configuration={"bad": o})
         self.assertTrue(ar.exception.message.startswith("bad configuration"))
 
+    def test_cancel_notfound(self):
+        with self.assertRaises(NotFound):
+            self.pd_cli.cancel_process("not-a-real-process-id")
+
     def test_create_invalid_definition(self):
         # create process definition missing module and class
         # verifies L4-CI-CEI-RQ137


### PR DESCRIPTION
This PR and the underlying epu changes rework the Process Dispatcher cancel_process operation to eliminate a race condition. It also improves the error handling and test coverage of this operation.

ooici/epu#5
