### PR TITLE
Adds assertions in test_activate_instrument.py to check that subscriptions for two different users

### DIFF
--- a/ion/processes/data/transforms/event_alert_transform.py
+++ b/ion/processes/data/transforms/event_alert_transform.py
@@ -324,6 +324,7 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
 
         log.debug("Values unravelled: %s" % values)
         log.debug("Time names unravelled: %s" % time_names)
+        log.debug("Transform got the rdt here: %s", rdt)
 
         indexes = [l for l in xrange(len(time_names))]
 
@@ -331,8 +332,12 @@ class AlertTransformAlgorithm(SimpleGranuleTransformFunction):
             if val < valid_values[0] or val > valid_values[1]:
                 bad_values.append(val)
                 arr = rdt[time_names[index]]
-                bad_value_times.append(arr[index])
-
+                log.debug("In the stream alert transform, got the arr here: %s", arr)
+                if arr:
+                    bad_value_times.append(arr[index])
+                else:
+                    # Since we do not want the transform to crash because a granule came in that did not have the values of the preferred time filled as expected
+                    bad_value_times.append(None)
         log.debug("Returning bad_values: %s, bad_value_times: %s and the origin: %s" % (bad_values, bad_value_times, origin))
 
         # return the list of bad values and their timestamps

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -928,7 +928,7 @@ class UserNotificationService(BaseUserNotificationService):
             ids, _ = self.clients.resource_registry.find_subjects( subject_type = RT.UserInfo, object=notif_id, predicate=PRED.hasNotification, id_only=True)
 
             if ids and user_id in ids:
-                log.debug("Removing the notification: %s", notif)
+                log.debug("Adding for the user: %s, the notification: %s", user_id, notif)
                 notifications.append(notif)
 
         return notifications

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -548,6 +548,14 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         log.debug( "For user_2: extended_product computed user_notification_requests %s", extended_product.computed.user_notification_requests.value)
         #log.debug( "test_activateInstrumentSample: extended_product last_granule %s", str(extended_product.computed.last_granule.value) )
         self.assertEqual( 1, len(extended_product.computed.user_notification_requests.value) )
+
+        notifications = extended_product.computed.user_notification_requests.value
+        notification = notifications[0]
+        self.assertEqual(notification.origin, data_product_id1)
+        self.assertEqual(notification.name, 'notification_2_user_2')
+        self.assertEqual(notification.origin_type, "data product 2")
+        self.assertEqual(notification.event_type, 'DetectionEvent')
+
         # exact text here keeps changing to fit UI capabilities.  keep assertion general...
         self.assertTrue( 'ok' in extended_product.computed.last_granule.value['quality_flag'] )
 
@@ -570,9 +578,15 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         log.debug( "For user_2: extended_instrument %s", str(extended_instrument) )
         log.debug( "For user_2: extended_instrument computed user_notification_requests %s", extended_instrument.computed.user_notification_requests.value)
 
+        self.assertEqual( 1, len(extended_instrument.computed.user_notification_requests.value) )
 
-        # the following assert will not work without elasticsearch.
-        #self.assertEqual( 1, len(extended_instrument.computed.user_notification_requests.value) )
+        notifications = extended_instrument.computed.user_notification_requests.value
+        notification = notifications[0]
+        self.assertEqual(notification.origin, instDevice_id)
+        self.assertEqual(notification.name, 'notification_1_user_2')
+        self.assertEqual(notification.origin_type, "instrument_2")
+        self.assertEqual(notification.event_type, 'ResourceLifecycleEvent')
+
         self.assertEqual(extended_instrument.computed.communications_status_roll_up.value, StatusType.STATUS_WARNING)
         self.assertEqual(extended_instrument.computed.data_status_roll_up.value, StatusType.STATUS_OK)
         self.assertEqual(extended_instrument.computed.power_status_roll_up.value, StatusType.STATUS_WARNING)

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -515,7 +515,7 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         notifications = extended_instrument.computed.user_notification_requests.value
         notification = notifications[0]
-        self.assertEqual(notification.origin, instrument_id)
+        self.assertEqual(notification.origin, instDevice_id)
         self.assertEqual(notification.name, 'notification_1')
         self.assertEqual(notification.origin_type, "instrument")
         self.assertEqual(notification.event_type, 'ResourceLifecycleEvent')
@@ -547,9 +547,7 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         log.debug( "For user_2: extended_product computed %s", str(extended_product.computed) )
         log.debug( "For user_2: extended_product computed user_notification_requests %s", extended_product.computed.user_notification_requests.value)
         #log.debug( "test_activateInstrumentSample: extended_product last_granule %s", str(extended_product.computed.last_granule.value) )
-        # the following assert will not work without elasticsearch.
-        #self.assertEqual( 1, len(extended_product.computed.user_notification_requests.value) )
-
+        self.assertEqual( 1, len(extended_product.computed.user_notification_requests.value) )
         # exact text here keeps changing to fit UI capabilities.  keep assertion general...
         self.assertTrue( 'ok' in extended_product.computed.last_granule.value['quality_flag'] )
 

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -205,7 +205,9 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         return datastore
 
 
-    #@unittest.skip("TBD")
+    @attr('LOCOINT')
+    @unittest.skipIf(not use_es, 'No ElasticSearch')
+    @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Skip test while in CEI LAUNCH mode')
     def test_activateInstrumentSample(self):
 
         self.loggerpids = []


### PR DESCRIPTION
- We verify the computed attributes holding the subscription in extended product and extended instrument. We check that when we create notifications for another user, there is no mix up and the computed attributes are correct.
- Since UNS uses elastic search to fetch subscriptions in the methods, get_subscriptions() and get_subscriptions_attribute(), we need to turn on elastic search in the test, test_activate_instrument, to completely verify the correct computation of the computed attribute for user subscriptions.

We do this using a config. We set config.bootstrap.use_es = True, and pass this config when starting the container with r2deploy.

```
        config = DotDict()
        config.bootstrap.use_es = True
        self.container.start_rel_from_url('res/deploy/r2deploy.yml', config)
```
- We cleanup elastic search indexes using addCleanup()
