### PR TITLE
OOIION-550: use a preloaded logical transform definition

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -90,7 +90,7 @@ CANDIDATE_UI_ASSETS = 'https://userexperience.oceanobservatories.org/database-ex
 MASTER_DOC = "https://docs.google.com/spreadsheet/pub?key=0AttCeOvLP6XMdG82NHZfSEJJOGdQTkgzb05aRjkzMEE&output=xls"
 
 ### the URL below should point to a COPY of the master google spreadsheet that works with this version of the loader
-TESTED_DOC = "https://docs.google.com/spreadsheet/pub?key=0AlWnRoFa9JrTdEdiYXkxMzdmQUtwS0dZTFpySjJtQVE&output=xls"
+TESTED_DOC = "https://docs.google.com/spreadsheet/pub?key=0AiJoHeWBzmnAdGxnWkl0WUNmdDhlOGlyODBfWGFRQ3c&output=xls"
 #
 ### while working on changes to the google doc, use this to run test_loader.py against the master spreadsheet
 #TESTED_DOC=MASTER_DOC

--- a/ion/processes/bootstrap/test/test_loader.py
+++ b/ion/processes/bootstrap/test/test_loader.py
@@ -146,12 +146,14 @@ class TestLoader(IonIntegrationTestCase):
         self.assertEquals('platform_eng_parsed', parsed.parameter_dictionary_name)
 
         # check for platform agents
-        found_it = self.find_object_by_name('Unit Test Platform Agent Instance', RT.PlatformAgentInstance)
+        self.find_object_by_name('Unit Test Platform Agent Instance', RT.PlatformAgentInstance)
 
         # check for platform model boolean values
         model = self.find_object_by_name('Nose Testing Platform Model', RT.PlatformModel)
         self.assertEquals(True, model.shore_networked)
-        self.assertNotEqual('str', model.shore_networked.__class__.__name__)        self.find_object_by_name('Unit Test Platform Agent Instance', RT.PlatformAgentInstance)
+        self.assertNotEqual('str', model.shore_networked.__class__.__name__)
+
 
         # check for data process definition
         self.find_object_by_name("Logical Transform Definition", RT.DataProcessDefinition)
+

--- a/ion/processes/bootstrap/test/test_loader.py
+++ b/ion/processes/bootstrap/test/test_loader.py
@@ -151,4 +151,7 @@ class TestLoader(IonIntegrationTestCase):
         # check for platform model boolean values
         model = self.find_object_by_name('Nose Testing Platform Model', RT.PlatformModel)
         self.assertEquals(True, model.shore_networked)
-        self.assertNotEqual('str', model.shore_networked.__class__.__name__)
+        self.assertNotEqual('str', model.shore_networked.__class__.__name__)        self.find_object_by_name('Unit Test Platform Agent Instance', RT.PlatformAgentInstance)
+
+        # check for data process definition
+        self.find_object_by_name("Logical Transform Definition", RT.DataProcessDefinition)

--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -37,7 +37,7 @@ INSTRUMENT_OPERATOR_ROLE  = 'INSTRUMENT_OPERATOR'
 OBSERVATORY_OPERATOR_ROLE = 'OBSERVATORY_OPERATOR'
 DATA_OPERATOR_ROLE        = 'DATA_OPERATOR'
 AGENT_STATUS_EVENT_DELTA_DAYS = 5
-
+LOGICAL_TRANSFORM_DEFINITION_NAME = "Logical Transform Definition" # defined in preload
 
 class ObservatoryManagementService(BaseObservatoryManagementService):
 
@@ -577,52 +577,19 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
 
         #todo: re-use existing defintion?  how?
 
-        #-------------------------------
-        # Process Definition
-        #-------------------------------
-#        process_definition = ProcessDefinition()
-#        process_definition.name = 'SiteDataProduct'
-#        process_definition.description = site_id
-#
-#        process_definition.executable = {'module':'ion.processes.data.transforms.logical_transform', 'class':'logical_transform'}
-#
-#        process_dispatcher = ProcessDispatcherServiceClient()
-#        process_definition_id = process_dispatcher.create_process_definition(process_definition=process_definition)
-
-#        subscription = self.clients.pubsub_management.read_subscription(subscription_id = in_subscription_id)
-#        queue_name = subscription.exchange_name
-#
-#
-#        configuration = DotDict()
-#
-#        configuration['process'] = dict({
-#            'output_streams' : [stream_ids[0]],
-#            'publish_streams': {data_product_id: }
-#        })
-#
-#        # ------------------------------------------------------------------------------------
-#        # Process Spawning
-#        # ------------------------------------------------------------------------------------
-#        # Spawn the process
-#        process_dispatcher.schedule_process(
-#            process_definition_id=process_definition_id,
-#            configuration=configuration
-#        )
-#
-#        ###########
 
         #----------------------------------------------------------------------------------------------------
-        # Create a data process definition
+        # Get the data process definition added during preload
         #----------------------------------------------------------------------------------------------------
 
-        dpd_obj = IonObject(RT.DataProcessDefinition,
-            name= create_unique_identifier(prefix='SiteDataProduct'), #as per Maurice.  todo: constant?
-            description=site_id,    #as per Maurice.
-            module='ion.processes.data.transforms.logical_transform',
-            class_name='logical_transform')
-
-
-        data_process_def_id = self.dataprocessclient.create_data_process_definition(dpd_obj)
+        data_process_def_ids, _ = self.container.resource_registry.find_resources(RT.DataProcessDefinition,
+                                                                                  None,
+                                                                                  LOGICAL_TRANSFORM_DEFINITION_NAME,
+                                                                                  True)
+        if not 1 == len(data_process_def_ids):
+            raise Inconsistent("Expected 1 data process definition, got %s with name '%s'" %
+                               (len(data_process_def_ids), LOGICAL_TRANSFORM_DEFINITION_NAME))
+        data_process_def_id = data_process_def_ids[0]
 
         #----------------------------------------------------------------------------------------------------
         # Create a data process

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -64,6 +64,13 @@ class TestDeployment(IonIntegrationTestCase):
                             class_name='logical_transform')
         self.dsmsclient.create_data_process_definition(dpd_obj)
 
+        # deactivate all data processes when tests are complete
+        def killAllDataProcesses():
+            for proc_id in self.rrclient.find_resources(RT.DataProcess, None, None, True)[0]:
+                self.dsmsclient.deactivate_data_process(proc_id)
+        self.addCleanup(killAllDataProcesses)
+
+
     #@unittest.skip("targeting")
     def test_create_deployment(self):
 

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -1,5 +1,7 @@
 #from interface.services.icontainer_agent import ContainerAgentClient
 #from pyon.ion.endpoint import ProcessRPCClient
+from interface.services.sa.idata_process_management_service import DataProcessManagementServiceClient
+from ion.services.sa.observatory.observatory_management_service import LOGICAL_TRANSFORM_DEFINITION_NAME
 from ion.services.sa.resource_impl.resource_impl import ResourceImpl
 from ion.services.dm.utility.granule_utils import time_series_domain
 from pyon.public import log, IonObject
@@ -53,6 +55,14 @@ class TestDeployment(IonIntegrationTestCase):
         self.c.resource_registry = self.rrclient
         self.resource_impl = ResourceImpl(self.c)
 
+        # create missing data process definition
+        self.dsmsclient = DataProcessManagementServiceClient(node=self.container.node)
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+                            name=LOGICAL_TRANSFORM_DEFINITION_NAME,
+                            description="normally in preload",
+                            module='ion.processes.data.transforms.logical_transform',
+                            class_name='logical_transform')
+        self.dsmsclient.create_data_process_definition(dpd_obj)
 
     #@unittest.skip("targeting")
     def test_create_deployment(self):

--- a/ion/services/sa/product/test/test_data_product_provenance.py
+++ b/ion/services/sa/product/test/test_data_product_provenance.py
@@ -1,4 +1,4 @@
-
+from ion.services.sa.observatory.observatory_management_service import LOGICAL_TRANSFORM_DEFINITION_NAME
 from pyon.public import  log, IonObject
 from pyon.util.int_test import IonIntegrationTestCase
 
@@ -54,6 +54,15 @@ class TestDataProductProvenance(IonIntegrationTestCase):
         self.process_dispatcher   = ProcessDispatcherServiceClient()
 
         self.dataset_management = DatasetManagementServiceClient()
+
+        # create missing data process definition
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+                            name=LOGICAL_TRANSFORM_DEFINITION_NAME,
+                            description="normally in preload",
+                            module='ion.processes.data.transforms.logical_transform',
+                            class_name='logical_transform')
+        self.dataprocessclient.create_data_process_definition(dpd_obj)
+
 
     #@unittest.skip('not ready')
     def test_get_provenance(self):

--- a/ion/services/sa/product/test/test_data_product_provenance.py
+++ b/ion/services/sa/product/test/test_data_product_provenance.py
@@ -63,6 +63,12 @@ class TestDataProductProvenance(IonIntegrationTestCase):
                             class_name='logical_transform')
         self.dataprocessclient.create_data_process_definition(dpd_obj)
 
+        # deactivate all data processes when tests are complete
+        def killAllDataProcesses():
+            for proc_id in self.rrclient.find_resources(RT.DataProcess, None, None, True)[0]:
+                self.dataprocessclient.deactivate_data_process(proc_id)
+        self.addCleanup(killAllDataProcesses)
+
 
     #@unittest.skip('not ready')
     def test_get_provenance(self):

--- a/ion/services/sa/test/test_assembly.py
+++ b/ion/services/sa/test/test_assembly.py
@@ -1,5 +1,6 @@
 #from interface.services.icontainer_agent import ContainerAgentClient
 #from pyon.ion.endpoint import ProcessRPCClient
+from interface.services.sa.idata_process_management_service import DataProcessManagementServiceClient
 from ion.agents.port.port_agent_process import PortAgentProcessType
 from ion.services.sa.resource_impl.resource_impl import ResourceImpl
 from pyon.public import IonObject
@@ -32,6 +33,8 @@ from ion.services.dm.utility.granule_utils import time_series_domain
 from ion.agents.port.port_agent_process import PortAgentProcessType, PortAgentType
 
 from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
+
+from ion.services.sa.observatory.observatory_management_service import LOGICAL_TRANSFORM_DEFINITION_NAME
 
 import string
 
@@ -67,39 +70,22 @@ class TestAssembly(IonIntegrationTestCase):
         self.client.IMS  = InstrumentManagementServiceClient(node=self.container.node)
         self.client.OMS  = ObservatoryManagementServiceClient(node=self.container.node)
         self.client.PSMS = PubsubManagementServiceClient(node=self.container.node)
+        self.client.DPRS = DataProcessManagementServiceClient(node=self.container.node)
 
         self.client.RR   = ResourceRegistryServiceClient(node=self.container.node)
         self.dataset_management = DatasetManagementServiceClient()
 
-#    @unittest.skip('this test just for debugging setup')
-#    def test_just_the_setup(self):
-#        return
-    
 
-    def _low_level_init(self):
-        resource_ids = {}
-
-        #TODO: still relevant?
-        ## some stream definitions
-        #resource_ids[RT.StreamDefinition] = {}
-
-        # # get module and function by name specified in strings
-        # sc_module = "prototype.sci_data.stream_defs"
-        # sc_method = "ctd_stream_definition"
-        # module = __import__(sc_module, fromlist=[sc_method])
-        # creator_func = getattr(module, sc_method)
-
-        # for n in ["SeabirdSim_raw", "SeabirdSim_parsed"]:
-        #     container = creator_func()
-            
-        #     response = self.client.PSMS.create_stream_definition(container=container,
-        #                                                          name=n,
-        #                                                          description="inserted by test_assembly.py")
-        #     resource_ids[RT.StreamDefinition][n] = response
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+                            name=LOGICAL_TRANSFORM_DEFINITION_NAME,
+                            description="normally in preload",
+                            module='ion.processes.data.transforms.logical_transform',
+                            class_name='logical_transform')
 
 
+        self.client.DPRS.create_data_process_definition(dpd_obj)
 
-        return resource_ids
+
 
 
 
@@ -133,8 +119,6 @@ class TestAssembly(IonIntegrationTestCase):
             
             return freeze()
 
-
-        #resource_ids = self._low_level_init()
 
 
         ###############################################

--- a/ion/services/sa/test/test_assembly.py
+++ b/ion/services/sa/test/test_assembly.py
@@ -85,8 +85,11 @@ class TestAssembly(IonIntegrationTestCase):
 
         self.client.DPRS.create_data_process_definition(dpd_obj)
 
-
-
+        # deactivate all data processes when tests are complete
+        def killAllDataProcesses():
+            for proc_id in self.client.RR.find_resources(RT.DataProcess, None, None, True)[0]:
+                self.client.DPRS.deactivate_data_process(proc_id)
+        self.addCleanup(killAllDataProcesses)
 
 
     #@unittest.skip('refactoring')

--- a/ion/services/sa/test/test_deploy_activate_full.py
+++ b/ion/services/sa/test/test_deploy_activate_full.py
@@ -1,3 +1,4 @@
+from ion.services.sa.observatory.observatory_management_service import LOGICAL_TRANSFORM_DEFINITION_NAME
 from pyon.public import Container, log, IonObject
 from pyon.util.int_test import IonIntegrationTestCase
 
@@ -74,6 +75,14 @@ class TestIMSDeployAsPrimaryDevice(IonIntegrationTestCase):
         self.omsclient = ObservatoryManagementServiceClient(node=self.container.node)
         self.processdispatchclient = ProcessDispatcherServiceClient(node=self.container.node)
         self.dataset_management = DatasetManagementServiceClient()
+
+        # create missing data process definition
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+                            name=LOGICAL_TRANSFORM_DEFINITION_NAME,
+                            description="normally in preload",
+                            module='ion.processes.data.transforms.logical_transform',
+                            class_name='logical_transform')
+        self.dataprocessclient.create_data_process_definition(dpd_obj)
 
 
     def create_logger(self, name, stream_id=''):

--- a/ion/services/sa/test/test_deploy_activate_full.py
+++ b/ion/services/sa/test/test_deploy_activate_full.py
@@ -1,5 +1,5 @@
 from ion.services.sa.observatory.observatory_management_service import LOGICAL_TRANSFORM_DEFINITION_NAME
-from pyon.public import Container, log, IonObject
+from pyon.public import log, IonObject
 from pyon.util.int_test import IonIntegrationTestCase
 
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
@@ -24,7 +24,6 @@ from pyon.agent.agent import ResourceAgentClient, ResourceAgentEvent
 from interface.objects import AgentCommand, StreamConfiguration, ProcessStateEnum, ProcessDefinition
 
 from ion.services.cei.process_dispatcher_service import ProcessStateGate
-from ion.services.dm.utility.granule_utils import time_series_domain
 from ion.agents.port.port_agent_process import PortAgentProcessType, PortAgentType
 
 # This import will dynamically load the driver egg.  It is needed for the MI includes below
@@ -83,6 +82,12 @@ class TestIMSDeployAsPrimaryDevice(IonIntegrationTestCase):
                             module='ion.processes.data.transforms.logical_transform',
                             class_name='logical_transform')
         self.dataprocessclient.create_data_process_definition(dpd_obj)
+
+        # deactivate all data processes when tests are complete
+        def killAllDataProcesses():
+            for proc_id in self.rrclient.find_resources(RT.DataProcess, None, None, True)[0]:
+                self.dataprocessclient.deactivate_data_process(proc_id)
+        self.addCleanup(killAllDataProcesses)
 
 
     def create_logger(self, name, stream_id=''):


### PR DESCRIPTION
Instead of creating a new data process definition of the logical transform for each new site data product, one definition is added to the preload and all site data products refer to it.
