### PR TITLE
Fix for OOIION-636 - Patches for the scenario where we have multiple uns instances 

### DIFF
--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -107,7 +107,6 @@ class UserNotificationTest(PyonTestCase):
         self.user_notification.notifications = {}
 
         self.user_notification.event_processor.add_notification_for_user = mocksignature(self.user_notification.event_processor.add_notification_for_user)
-        self.user_notification.update_user_info_dictionary = mocksignature(self.user_notification.update_user_info_dictionary)
         self.user_notification.event_publisher.publish_event = mocksignature(self.user_notification.event_publisher.publish_event)
 
         self.user_notification._notification_in_notifications = mocksignature(self.user_notification._notification_in_notifications)
@@ -175,13 +174,9 @@ class UserNotificationTest(PyonTestCase):
 #        self.user_notification.update_user_info_object = mocksignature(self.user_notification.update_user_info_object)
 #        self.user_notification.update_user_info_object.return_value = 'user'
 #
-#        self.user_notification.update_user_info_dictionary = mocksignature(self.user_notification.update_user_info_dictionary)
-#        self.user_notification.update_user_info_dictionary.return_value = ''
-#
 #        self.user_notification.notifications = []
 #
 #        self.user_notification._update_notification_in_notifications_dict = mocksignature(self.user_notification._update_notification_in_notifications_dict)
-#        self.user_notification.update_user_info_dictionary.return_value = ''
 #
 #        self.user_notification.event_publisher.publish_event = mocksignature(self.user_notification.event_publisher.publish_event)
 #
@@ -208,7 +203,6 @@ class UserNotificationTest(PyonTestCase):
 #        #-------------------------------------------------------------------------------------------------------------------
 #
 #        self.user_notification.update_user_info_object.assert_called_once_with(user_id, notification, notification)
-#        self.user_notification.update_user_info_dictionary.assert_called_once_with('user_id_1', notification, notification)
 
 
     def test_delete_user_notification(self):

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -8,9 +8,9 @@
 from pyon.util.int_test import IonIntegrationTestCase
 from pyon.util.unit_test import PyonTestCase
 from pyon.util.containers import DotDict, get_ion_ts
-from pyon.public import IonObject, RT, OT, PRED, Container, CFG
+from pyon.public import IonObject, RT, OT, PRED, Container
 from pyon.core.exception import NotFound, BadRequest
-from pyon.core.bootstrap import get_sys_name
+from pyon.core.bootstrap import get_sys_name, CFG
 from ion.services.dm.utility.granule_utils import time_series_domain
 from interface.services.coi.iidentity_management_service import IdentityManagementServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1997,10 +1997,20 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         self.assertEquals(len(res_notifs), 2)
 
         for notific in res_notifs:
+
+            notific_in_db = self.rrc.read(notific._id)
+            self.assertTrue(notific_in_db)
+
             self.assertEquals(notific.origin, data_product_id)
             self.assertEquals(notific.temporal_bounds.end_datetime, '')
             self.assertTrue(notific.origin_type == 'type_1' or  notific.origin_type =='type_2')
             self.assertEquals(notific.event_type, 'ResourceLifecycleEvent')
+
+            self.assertEquals(notific_in_db.origin, data_product_id)
+            self.assertEquals(notific_in_db.temporal_bounds.end_datetime, '')
+            self.assertTrue(notific_in_db.origin_type == 'type_1' or  notific_in_db.origin_type =='type_2')
+            self.assertEquals(notific_in_db.event_type, 'ResourceLifecycleEvent')
+
 
         #--------------------------------------------------------------------------------------
         # Use UNS to get the all subscriptions --- including retired
@@ -2009,9 +2019,18 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         for notific in res_notifs:
             log.debug("notif.origin_type:: %s", notific.origin_type)
+
+            notific_in_db = self.rrc.read(notific._id)
+            self.assertTrue(notific_in_db)
+
             self.assertEquals(notific.origin, data_product_id)
             self.assertTrue(notific.origin_type in ['type_1', 'type_2', 'type_3', 'type_4'])
             self.assertTrue(notific.event_type in ['ResourceLifecycleEvent', 'DetectionEvent'])
+
+            self.assertEquals(notific_in_db.origin, data_product_id)
+            self.assertTrue(notific_in_db.origin_type in ['type_1', 'type_2', 'type_3', 'type_4'])
+            self.assertTrue(notific_in_db.event_type in ['ResourceLifecycleEvent', 'DetectionEvent'])
+
 
         self.assertEquals(len(res_notifs), 4)
 
@@ -2142,19 +2161,38 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         for notif in n_for_user_1:
             log.debug("notif_active::: %s" % notif)
+
+            notific_in_db = self.rrc.read(notif._id)
+            self.assertTrue(notific_in_db)
+
             self.assertEquals(notif.origin, data_product_id)
             self.assertEquals(notif.temporal_bounds.end_datetime, '')
             self.assertEquals(notif.origin_type, 'active_1')
             self.assertEquals(notif.event_type, 'ResourceLifecycleEvent')
 
+            self.assertEquals(notific_in_db.origin, data_product_id)
+            self.assertEquals(notific_in_db.temporal_bounds.end_datetime, '')
+            self.assertEquals(notific_in_db.origin_type, 'active_1')
+            self.assertEquals(notific_in_db.event_type, 'ResourceLifecycleEvent')
+
+
         n_for_user_2 = self.unsc.get_subscriptions(resource_id=data_product_id, user_id = user_id_2, include_nonactive=False)
         self.assertEquals(len(n_for_user_2), 1)
 
         for notif in n_for_user_2:
+
+            notific_in_db = self.rrc.read(notif._id)
+            self.assertTrue(notific_in_db)
+
             self.assertEquals(notif.origin, data_product_id)
             self.assertEquals(notif.temporal_bounds.end_datetime, '')
             self.assertEquals(notif.origin_type, 'active_2')
             self.assertEquals(notif.event_type, 'ResourceLifecycleEvent')
+
+            self.assertEquals(notific_in_db.origin, data_product_id)
+            self.assertEquals(notific_in_db.temporal_bounds.end_datetime, '')
+            self.assertEquals(notific_in_db.origin_type, 'active_2')
+            self.assertEquals(notific_in_db.event_type, 'ResourceLifecycleEvent')
 
 
         #--------------------------------------------------------------------------------------
@@ -2167,17 +2205,34 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         for notif in notifs_for_user_1:
             log.debug("notif.origin_type:: %s", notif.origin_type)
             log.debug("notif::: %s", notif)
+
+            notific_in_db = self.rrc.read(notif._id)
+            self.assertTrue(notific_in_db)
+
             self.assertEquals(notif.origin, data_product_id)
             self.assertTrue(notif.origin_type == 'active_1' or notif.origin_type == 'past_1')
             self.assertTrue(notif.event_type== 'ResourceLifecycleEvent' or notif.event_type=='DetectionEvent')
+
+            self.assertEquals(notific_in_db.origin, data_product_id)
+            self.assertTrue(notific_in_db.origin_type == 'active_1' or notific_in_db.origin_type == 'past_1')
+            self.assertTrue(notific_in_db.event_type== 'ResourceLifecycleEvent' or notific_in_db.event_type=='DetectionEvent')
+
 
         notifs_for_user_2 = self.unsc.get_subscriptions(resource_id=data_product_id, user_id = user_id_2, include_nonactive=True)
 
         for notif in notifs_for_user_2:
             self.assertEquals(notif.origin, data_product_id)
             log.debug("notif_past::: %s" % notif)
+
+            notific_in_db = self.rrc.read(notif._id)
+            self.assertTrue(notific_in_db)
+
             self.assertTrue(notif.origin_type == 'active_2' or notif.origin_type == 'past_2')
             self.assertTrue(notif.event_type== 'ResourceLifecycleEvent' or notif.event_type=='DetectionEvent')
+
+            self.assertTrue(notific_in_db.origin_type == 'active_2' or notific_in_db.origin_type == 'past_2')
+            self.assertTrue(notific_in_db.event_type== 'ResourceLifecycleEvent' or notific_in_db.event_type=='DetectionEvent')
+
         log.debug("number of returned notif object for user 2: %s", len(notifs_for_user_2))
 
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -581,6 +581,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
             if notifications:
                 for notific in notifications:
+                    self.assertTrue(notific._id != '')
                     origins.append(notific.origin)
                     event_types.append(notific.event_type)
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -841,41 +841,6 @@ class UserNotificationService(BaseUserNotificationService):
 
         return user
 
-#    def update_user_info_dictionary(self, user_id, new_notification, old_notification):
-#
-#        notifications = []
-#        notification_preferences = None
-#        user = self.clients.resource_registry.read(user_id)
-#
-#        #------------------------------------------------------------------------------------
-#        # If there was a previous notification which is being updated, check the dictionaries and update there
-#        #------------------------------------------------------------------------------------
-#        if old_notification:
-#            # Remove the old notifications
-#            if old_notification in self.user_info[user_id]['notifications']:
-#
-#                # remove from notifications list
-#                self.user_info[user_id]['notifications'].remove(old_notification)
-#
-#        # find the already existing notifications for the user
-#        if self.user_info.has_key(user_id):
-#            notifications = self.user_info[user_id]['notifications']
-#
-#        #------------------------------------------------------------------------------------
-#        # update the user info - contact information, notifications
-#        #------------------------------------------------------------------------------------
-#        notifications.append(new_notification)
-#
-#        # Get the user's notification preferences
-#        for item in user.variables:
-#            if item['name'] == 'notification_preferences':
-#                notification_preferences = item['value']
-#
-#        self.user_info[user_id] = {'user_contact' : user.contact, 'notifications' : notifications, 'notification_preferences' : notification_preferences}
-#
-#        log.debug("self.user_info::: %s" , self.user_info)
-#
-#        self.reverse_user_info = calculate_reverse_user_info(self.user_info)
 
     def _get_subscriptions(self, resource_id='', include_nonactive=False):
         """

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -176,7 +176,8 @@ class UserNotificationService(BaseUserNotificationService):
             callback=reload_user_info
         )
         self.reload_user_info_subscriber.start()
-
+        # For cleanup of the subscriber
+        self._subscribers.append(self.reload_user_info_subscriber)
 
     def on_quit(self):
         """

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -225,6 +225,7 @@ class UserNotificationService(BaseUserNotificationService):
         self.batch_processing_subscriber = EventSubscriber(
             event_type="ResourceEvent",
             origin=process_batch_key,
+            queue_name='user_notification',
             callback=process
         )
         self.batch_processing_subscriber.start()

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -8,7 +8,9 @@
 """
 
 from pyon.core.exception import BadRequest, IonException, NotFound
+from pyon.core.bootstrap import CFG
 from pyon.util.log import log
+from pyon.public import RT, PRED, get_sys_name, Container, OT, IonObject
 from pyon.event.event import EventPublisher, EventSubscriber
 from interface.services.dm.idiscovery_service import DiscoveryServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient


### PR DESCRIPTION
- Just as the notification workers do, a subscriber in UNS now listens
  for the reload user info event that gets published anytime a create, update
  or delete method is used in UNS. The callback used by the subscriber reloads
  the user info dictionaries from the resource registry the same way the 
  notification workers do. This ensures that all instances of the UNS can reload the
  user info from the resource registry in a common way whenever there has been a change in the notifications.

Now the notification workers and the UNS have a common framework for reloading the user info dictionaries.
