### PR TITLE
Refactors publish_event() and publish_event_object() of UNS

### DIFF
--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1506,12 +1506,16 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         event_publisher_1 = EventPublisher("PlatformEvent")
         event_publisher_2 = EventPublisher("ReloadUserInfoEvent")
 
+        min_datetime = get_ion_ts()
+
         for i in xrange(10):
-            event_publisher_1.publish_event(origin='my_special_find_events_origin', ts_created = i)
-            event_publisher_2.publish_event(origin='another_origin', ts_created = i)
+            event_publisher_1.publish_event(origin='my_special_find_events_origin', ts_created = get_ion_ts())
+            event_publisher_2.publish_event(origin='another_origin', ts_created = get_ion_ts())
+
+        max_datetime = get_ion_ts()
 
         def poller():
-            events = self.unsc.find_events(origin='my_special_find_events_origin', type = 'PlatformEvent', min_datetime= 4, max_datetime=7)
+            events = self.unsc.find_events(origin='my_special_find_events_origin', type = 'PlatformEvent', min_datetime= min_datetime, max_datetime=max_datetime)
             return len(events) >= 4
 
         success = self.event_poll(poller, 10)
@@ -1529,13 +1533,17 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         event_publisher_1 = EventPublisher("PlatformEvent")
         event_publisher_2 = EventPublisher("ReloadUserInfoEvent")
 
+        min_time = get_ion_ts()
+
         for i in xrange(10):
-            event_publisher_1.publish_event(origin='Some_Resource_Agent_ID1', ts_created = i)
-            event_publisher_2.publish_event(origin='Some_Resource_Agent_ID2', ts_created = i)
+            event_publisher_1.publish_event(origin='Some_Resource_Agent_ID1', ts_created = get_ion_ts())
+            event_publisher_2.publish_event(origin='Some_Resource_Agent_ID2', ts_created = get_ion_ts())
+
+        max_time = get_ion_ts()
 
         # allow elastic search to populate the indexes. This gives enough time for the reload of user_info
         def poller():
-            events = self.unsc.find_events_extended(origin='Some_Resource_Agent_ID1', min_time=4, max_time=7)
+            events = self.unsc.find_events_extended(origin='Some_Resource_Agent_ID1', min_time=min_time, max_time=max_time)
             return len(events) >= 4
 
         success = self.event_poll(poller, 10)
@@ -1618,8 +1626,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         sub_type= 'sub_type_1'
         event_attrs = {'status': 'OK'}
 
-#        log.debug("event_attrs: %s", event_attrs)
-
         # create async result to wait on in test
         ar = gevent.event.AsyncResult()
 
@@ -1695,8 +1701,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         def publish_events():
             for i in xrange(3):
-                t = now()
-                t = UserNotificationIntTest.makeEpochTime(t)
+                t = get_ion_ts()
 
                 event_publisher.publish_event( ts_created= t ,
                     origin="instrument_1",

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1684,16 +1684,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         self.unsc.set_process_batch_key(process_batch_key = newkey)
 
         #--------------------------------------------------------------------------------
-        # Set up a time for the scheduler to trigger timer events
-        #--------------------------------------------------------------------------------
-        # Trigger the timer event 10 seconds later from now
-#        time_now = datetime.utcnow() + timedelta(seconds=15)
-#        times_of_day =[{'hour': str(time_now.hour),'minute' : str(time_now.minute), 'second':str(time_now.second) }]
-
-        times_of_day =[{'hour': '0','minute' : '0', 'second': '0' }]
-
-
-        #--------------------------------------------------------------------------------
         # Publish the events that the user will later be notified about
         #--------------------------------------------------------------------------------
         event_publisher = EventPublisher()
@@ -1768,10 +1758,19 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------
         # Set up the scheduler to publish daily events that should kick off process_batch()
         #--------------------------------------------------------------------------------
+
+        # Set up a time for the scheduler to trigger timer events
+        # Trigger the timer event 15 seconds later from now
+        time_now = datetime.utcnow() + timedelta(seconds=15)
+        times_of_day =[{'hour': str(time_now.hour),'minute' : str(time_now.minute), 'second':str(time_now.second) }]
+
         sid = self.ssclient.create_time_of_day_timer(   times_of_day=times_of_day,
-#            expires=get_ion_ts(),
+            expires=time.time()+25200+60,
             event_origin= newkey,
             event_subtype="")
+
+        log.debug("created the timer id: %s", sid)
+
         def cleanup_timer(scheduler, schedule_id):
             """
             Do a friendly cancel of the scheduled event.

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -243,7 +243,7 @@ class UserNotificationTest(PyonTestCase):
 
         self.mock_rr_client.read.assert_called_once_with(notification_id, '')
 
-        notification_request.temporal_bounds.end_datetime = self.user_notification.makeEpochTime(now())
+        notification_request.temporal_bounds.end_datetime = get_ion_ts()
         self.mock_rr_client.update.assert_called_once_with(notification_request)
 
 @attr('INT', group='dm')
@@ -1818,21 +1818,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         self.assertEquals(len(events_for_message), self.number_event_published)
         self.assertEquals(times, times_of_events_published)
         self.assertEquals(origins_of_events, Set(['instrument_1', 'instrument_2']))
-
-    @staticmethod
-    def makeEpochTime(date_time):
-        """
-        provides the seconds since epoch give a python datetime object.
-
-        @param date_time: Python datetime object
-        @return: seconds_since_epoch:: int
-        """
-        date_time = date_time.isoformat().split('.')[0].replace('T',' ')
-        #'2009-07-04 18:30:47'
-        pattern = '%Y-%m-%d %H:%M:%S'
-        seconds_since_epoch = int(time.mktime(time.strptime(date_time, pattern)))
-
-        return seconds_since_epoch
 
     @attr('LOCOINT')
     @unittest.skipIf(not use_es, 'No ElasticSearch')

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1687,8 +1687,11 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Set up a time for the scheduler to trigger timer events
         #--------------------------------------------------------------------------------
         # Trigger the timer event 10 seconds later from now
-        time_now = datetime.utcnow() + timedelta(seconds=15)
-        times_of_day =[{'hour': str(time_now.hour),'minute' : str(time_now.minute), 'second':str(time_now.second) }]
+#        time_now = datetime.utcnow() + timedelta(seconds=15)
+#        times_of_day =[{'hour': str(time_now.hour),'minute' : str(time_now.minute), 'second':str(time_now.second) }]
+
+        times_of_day =[{'hour': '0','minute' : '0', 'second': '0' }]
+
 
         #--------------------------------------------------------------------------------
         # Publish the events that the user will later be notified about
@@ -1766,7 +1769,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Set up the scheduler to publish daily events that should kick off process_batch()
         #--------------------------------------------------------------------------------
         sid = self.ssclient.create_time_of_day_timer(   times_of_day=times_of_day,
-            expires=time.time()+25200+60,
+#            expires=get_ion_ts(),
             event_origin= newkey,
             event_subtype="")
         def cleanup_timer(scheduler, schedule_id):
@@ -1915,8 +1918,9 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         def publish_events():
             x = 0
             for i in xrange(10):
-                event_publisher_1.publish_event(origin='my_unique_test_recent_events_origin', ts_created = i)
-                event_publisher_2.publish_event(origin='Another_recent_events_origin', ts_created = i)
+                t = get_ion_ts()
+                event_publisher_1.publish_event(origin='my_unique_test_recent_events_origin', ts_created = t)
+                event_publisher_2.publish_event(origin='Another_recent_events_origin', ts_created = t)
                 x += 1
             self.event.set()
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -537,17 +537,41 @@ class UserNotificationService(BaseUserNotificationService):
 
         return events
 
-    def publish_event(self, event=None):
+    def publish_event_object(self, event=None):
         """
-        Publish a general event at a certain time using the UNS
+        This service operation would publish the given event from an event object.
 
-        @param event Event
+        @param event    !Event
+        @retval event   !Event
+        """
+        event_object = self.event_publisher.publish_event_object(event_object=event)
+        log.info("The publish_event_obj(event) method of UNS was used to publish the event: %s", event_object )
+
+    def publish_event(self, event_type='', origin='', origin_type='', sub_type='', description='', event_attrs=None):
+        """
+        This service operation assembles a new Event object based on event_type 
+        (e.g. via the pyon Event publisher) with optional additional attributes from a event_attrs
+        dict of arbitrary attributes.
+        
+        
+        @param event_type   str
+        @param origin       str
+        @param origin_type  str
+        @param sub_type     str
+        @param description  str
+        @param event_attrs  str
+        @retval event       !Event
         """
 
-        self.event_publisher.publish_event( event_msg = event,
-            origin=event.origin,
-            event_type = event.type_)
-        log.info("The publish_event() method of UNS was used to publish an event.")
+        event = self.event_publisher.publish_event(
+            event_type = event_type,
+            origin = origin,
+            origin_type = origin_type,
+            sub_type = sub_type,
+            description = description,
+            event_attrs = event_attrs
+            )
+        log.info("The publish_event() method of UNS was used to publish an event: %s", event)
 
     def get_recent_events(self, resource_id='', limit = 100):
         """

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -545,7 +545,7 @@ class UserNotificationService(BaseUserNotificationService):
         @retval event   !Event
         """
         event = self.event_publisher.publish_event_object(event_object=event)
-        log.info("The publish_event_obj(event) method of UNS was used to publish the event: %s", event )
+        log.info("The publish_event_object(event) method of UNS was used to publish the event: %s", event )
 
         return event
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -544,8 +544,10 @@ class UserNotificationService(BaseUserNotificationService):
         @param event    !Event
         @retval event   !Event
         """
-        event_object = self.event_publisher.publish_event_object(event_object=event)
-        log.info("The publish_event_obj(event) method of UNS was used to publish the event: %s", event_object )
+        event = self.event_publisher.publish_event_object(event_object=event)
+        log.info("The publish_event_obj(event) method of UNS was used to publish the event: %s", event )
+
+        return event
 
     def publish_event(self, event_type='', origin='', origin_type='', sub_type='', description='', event_attrs=None):
         """
@@ -559,7 +561,7 @@ class UserNotificationService(BaseUserNotificationService):
         @param origin_type  str
         @param sub_type     str
         @param description  str
-        @param event_attrs  str
+        @param event_attrs  dict
         @retval event       !Event
         """
 
@@ -569,9 +571,11 @@ class UserNotificationService(BaseUserNotificationService):
             origin_type = origin_type,
             sub_type = sub_type,
             description = description,
-            event_attrs = event_attrs
+            **event_attrs
             )
         log.info("The publish_event() method of UNS was used to publish an event: %s", event)
+
+        return event
 
     def get_recent_events(self, resource_id='', limit = 100):
         """

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -265,7 +265,7 @@ class UserNotificationService(BaseUserNotificationService):
 
             # since the notification has not been registered yet, register it and get the id
             notification.temporal_bounds = TemporalBounds()
-            notification.temporal_bounds.start_datetime = self.makeEpochTime(self.__now())
+            notification.temporal_bounds.start_datetime = get_ion_ts()
             notification.temporal_bounds.end_datetime = ''
 
             notification_id, _ = self.clients.resource_registry.create(notification)
@@ -396,7 +396,7 @@ class UserNotificationService(BaseUserNotificationService):
         # Update the resource registry
         #-------------------------------------------------------------------------------------------------------------------
 
-        notification_request.temporal_bounds.end_datetime = self.makeEpochTime(self.__now())
+        notification_request.temporal_bounds.end_datetime = get_ion_ts()
 
         self.clients.resource_registry.update(notification_request)
 
@@ -590,7 +590,7 @@ class UserNotificationService(BaseUserNotificationService):
         @retval events list of Event objects
         """
 
-        now = self.makeEpochTime(datetime.utcnow())
+        now = get_ion_ts()
         events = self.find_events(origin=resource_id,limit=limit, max_datetime=now, descending=True)
 
         ret = IonObject(OT.ComputedListValue)
@@ -671,22 +671,6 @@ class UserNotificationService(BaseUserNotificationService):
             pids.append(pid)
 
         return pids
-
-    @staticmethod
-    def makeEpochTime(date_time):
-        """
-        provides the seconds since epoch give a python datetime object.
-
-        @param date_time Python datetime object
-        @retval seconds_since_epoch int
-        """
-        date_time = date_time.isoformat().split('.')[0].replace('T',' ')
-        #'2009-07-04 18:30:47'
-        pattern = '%Y-%m-%d %H:%M:%S'
-        seconds_since_epoch = int(time.mktime(time.strptime(date_time, pattern)))
-
-        return seconds_since_epoch
-
 
     def process_batch(self, start_time = '', end_time = ''):
         """

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -10,6 +10,7 @@
 from pyon.core.exception import BadRequest, IonException, NotFound
 from pyon.core.bootstrap import CFG
 from pyon.util.log import log
+from pyon.util.containers import get_ion_ts
 from pyon.public import RT, PRED, get_sys_name, Container, OT, IonObject
 from pyon.event.event import EventPublisher, EventSubscriber
 from interface.services.dm.idiscovery_service import DiscoveryServiceClient
@@ -145,7 +146,7 @@ class UserNotificationService(BaseUserNotificationService):
         self.event_publisher = EventPublisher()
         self.datastore = self.container.datastore_manager.get_datastore('events')
 
-        self.start_time = UserNotificationService.makeEpochTime(self.__now())
+        self.start_time = get_ion_ts()
 
         #------------------------------------------------------------------------------------
         # Create an event subscriber for Reload User Info events
@@ -212,7 +213,9 @@ class UserNotificationService(BaseUserNotificationService):
         """
 
         def process(event_msg, headers):
-            self.end_time = UserNotificationService.makeEpochTime(self.__now())
+            self.end_time = get_ion_ts()
+
+            log.debug("process_batch being called with start_time = %s, end_time = %s", self.start_time, self.end_time)
 
             # run the process_batch() method
             self.process_batch(start_time=self.start_time, end_time=self.end_time)


### PR DESCRIPTION
- Refactors according to Michael and Maurice's comments in the email thread regarding the publish_event() and publish_event_object() methods of UNS
- get_ion_ts() is now used throughout UNS
