### PR TITLE
Upate ooi preload

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -998,6 +998,8 @@ class IONLoader(ImmediateProcess):
             support_bulk=True)
 
     def _load_InstrumentModel_OOI(self):
+        # Create one InstrumentModel per entry in subseries.
+        # Copy down family, class, series and makemodel attributes
         ooi_objs = self.ooi_loader.get_type_assets("subseries")
 
         for ooi_id, ooi_obj in ooi_objs.iteritems():
@@ -1056,6 +1058,7 @@ class IONLoader(ImmediateProcess):
             fakerow = {}
             fakerow[self.COL_ID] = ooi_id
             fakerow['obs/name'] = ooi_obj['name']
+            fakerow['obs/description'] = "Array: %s" % ooi_id
             fakerow['obs/alt_ids'] = "['OOI:" + ooi_id + "']"
             fakerow['constraint_ids'] = ''
             fakerow['coordinate_system'] = 'OOI_SUBMERGED_CS'
@@ -1089,11 +1092,13 @@ class IONLoader(ImmediateProcess):
                     headers=headers)
 
     def _load_Subsite_OOI(self):
+        # (1) Create Subsite per OOI site
         ooi_objs = self.ooi_loader.get_type_assets("site")
         for ooi_id, ooi_obj in ooi_objs.iteritems():
             fakerow = {}
             fakerow[self.COL_ID] = ooi_id
             fakerow['site/name'] = ooi_obj['name']
+            fakerow['site/description'] = "Site: %s" % ooi_id
             fakerow['site/alt_ids'] = "['OOI:" + ooi_id + "']"
             fakerow['constraint_ids'] = ''
             fakerow['coordinate_system'] = 'OOI_SUBMERGED_CS'
@@ -1105,6 +1110,7 @@ class IONLoader(ImmediateProcess):
 
             self._load_Subsite(fakerow)
 
+        # (2) Create child Subsite per OOI subsite
         ooi_objs = self.ooi_loader.get_type_assets("subsite")
         for ooi_id, ooi_obj in ooi_objs.iteritems():
             constrow = {}
@@ -1125,6 +1131,7 @@ class IONLoader(ImmediateProcess):
             fakerow = {}
             fakerow[self.COL_ID] = ooi_id
             fakerow['site/name'] = ooi_obj['name']
+            fakerow['site/description'] = "Subsite: %s" % ooi_id
             fakerow['site/alt_ids'] = "['OOI:" + ooi_id + "']"
             fakerow['constraint_ids'] = const_id1
             fakerow['coordinate_system'] = 'OOI_SUBMERGED_CS'
@@ -1196,8 +1203,10 @@ class IONLoader(ImmediateProcess):
             fakerow['coordinate_system'] = 'OOI_SUBMERGED_CS'
             if ooi_obj.get('is_platform', False):
                 fakerow['parent_site_id'] = ooi_id[:8]
+                fakerow['ps/description'] = "Node (platform): %s" % ooi_id
             else:
                 fakerow['parent_site_id'] = ooi_obj.get('platform_id', '')
+                fakerow['ps/description'] = "Node (child): %s" % ooi_id
             fakerow['platform_model_ids'] = ooi_id[9:11] + "_PM"
             fakerow['org_ids'] = self._get_org_ids([ooi_id[:2]])
 
@@ -1253,6 +1262,8 @@ class IONLoader(ImmediateProcess):
 
     def _load_InstrumentSite_OOI(self):
         ooi_objs = self.ooi_loader.get_type_assets("instrument")
+        nodes = self.ooi_loader.get_type_assets("node")
+        iclass = self.ooi_loader.get_type_assets("class")
 
         for ooi_id, ooi_obj in ooi_objs.iteritems():
             constrow = {}
@@ -1270,9 +1281,11 @@ class IONLoader(ImmediateProcess):
                 constrow['bottom'] = ooi_obj['depth_port_max'] or '0.0'
                 self._load_Constraint(constrow)
 
+            ooi_rd = OOIReferenceDesignator(ooi_id)
             fakerow = {}
             fakerow[self.COL_ID] = ooi_id
-            fakerow['is/name'] = ooi_id
+            fakerow['id/name'] = "%s on %s" % (iclass[ooi_rd.inst_class]['Class_Name'], nodes[ooi_id[:14]]['name'])
+            fakerow['is/description'] = "Instrument: %s" % ooi_id
             fakerow['is/alt_ids'] = "['OOI:" + ooi_id + "']"
             fakerow['constraint_ids'] = const_id1
             fakerow['coordinate_system'] = 'OOI_SUBMERGED_CS'
@@ -1425,14 +1438,15 @@ Reason: %s
         self._resource_advance_lcs(row, res_id, "PlatformDevice")
 
     def _load_PlatformDevice_OOI(self):
-        ooi_objs = self.ooi_loader.get_type_assets("nodetype")
+        ooi_objs = self.ooi_loader.get_type_assets("node")
 
         for ooi_id, ooi_obj in ooi_objs.iteritems():
             fakerow = {}
             fakerow[self.COL_ID] = ooi_id + "_PD"
-            fakerow['pd/name'] = "%s (%s)" % (ooi_obj.get('name', ''), ooi_id)
+            fakerow['pd/name'] = "%s" % ooi_obj.get('name', '')
+            fakerow['pd/description'] = "Platform %s device #01" % ooi_id
             fakerow['org_ids'] = self._get_org_ids(ooi_obj.get('array_list', None))
-            fakerow['platform_model_id'] = ooi_id + "_PM"
+            fakerow['platform_model_id'] = ooi_id[9:11] + "_PM"
             fakerow['contact_ids'] = ''
 
             if not self._match_filter(ooi_obj.get('array_list', None)):
@@ -1482,15 +1496,26 @@ Reason: %s
 
     def _load_InstrumentDevice_OOI(self):
         ooi_objs = self.ooi_loader.get_type_assets("instrument")
+        nodes = self.ooi_loader.get_type_assets("node")
+        iclass = self.ooi_loader.get_type_assets("class")
 
         for ooi_id, ooi_obj in ooi_objs.iteritems():
+            node_id = ooi_id[:14]
+            node_obj = nodes[node_id]
+            if not node_obj.get('is_platform', False):
+                node_id = node_obj.get('platform_id')
+                node_obj = nodes[node_id]
+                if not node_obj.get('is_platform', False):
+                    log.warn("Node %s is not a platform!!" % node_id)
+
+            ooi_rd = OOIReferenceDesignator(ooi_id)
             fakerow = {}
             fakerow[self.COL_ID] = ooi_id + "_ID"
-            fakerow['id/name'] = ooi_id
+            fakerow['id/name'] = "%s on %s" % (iclass[ooi_rd.inst_class]['Class_Name'], nodes[ooi_id[:14]]['name'])
+            fakerow['id/description'] = "Instrument %s device #01" % ooi_id
             fakerow['org_ids'] = self._get_org_ids([ooi_id[:2]])
-            ooi_rd = OOIReferenceDesignator(ooi_id)
             fakerow['instrument_model_id'] = ooi_rd.subseries_rd
-            fakerow['platform_device_id'] = ooi_rd.node_type + "_PD"
+            fakerow['platform_device_id'] = node_id + "_PD"
             fakerow['id/reference_urls'] = ''
             fakerow['contact_ids'] = ''
 
@@ -1565,7 +1590,7 @@ Reason: %s
         self._resource_advance_lcs(row, res_id, "InstrumentAgent")
 
     def _load_InstrumentAgent_OOI(self):
-        ooi_objs = self.ooi_loader.get_type_assets("instrument")
+        ooi_objs = self.ooi_loader.get_type_assets("subseries")
 
         for ooi_id, ooi_obj in ooi_objs.iteritems():
             fakerow = {}

--- a/ion/processes/bootstrap/ooi_loader.py
+++ b/ion/processes/bootstrap/ooi_loader.py
@@ -53,8 +53,9 @@ class OOILoader(object):
                        # Tabs from the mapping spreadsheet
                        'Arrays',
                        'Sites',
+                       'Subsites',
                        'Nodes',
-                       'Platforms',
+                       #'Platforms',
                        'NodeTypes',
                        'PlatformAgentTypes'
                      ]
@@ -112,6 +113,8 @@ class OOILoader(object):
 
         for ot, oo in self.ooi_objects.iteritems():
             log.info("Type %s has %s entries", ot, len(oo))
+            #import pprint
+            #pprint.pprint(oo)
             #log.debug("Type %s has %s attributes", ot, self.ooi_obj_attrs[ot])
             #print ot
             #print "\n".join(sorted(list(self.ooi_obj_attrs[ot])))
@@ -356,12 +359,19 @@ class OOILoader(object):
 
     def _parse_Sites(self, row):
         ooi_rd = row['Reference ID']
-        name = "%s (%s)" % (row['Name'], ooi_rd[4:8])
+        name = row['Full Name']
+        self._add_object_attribute('site',
+            ooi_rd, 'name', name, change_ok=True)
+
+    def _parse_Subsites(self, row):
+        ooi_rd = row['Reference ID']
+        name = row['Full Name']
         self._add_object_attribute('subsite',
             ooi_rd, 'name', name, change_ok=True)
 
     def _parse_Nodes(self, row):
         ooi_rd = row['Reference ID']
+        name=row['Full Name']
         node_entry = dict(
             parent_id=row['Parent Reference ID'],
             platform_id=row['Platform Reference ID'],
@@ -371,19 +381,8 @@ class OOILoader(object):
         )
         self._add_object_attribute('node',
             ooi_rd, None, None, **node_entry)
-
-    def _parse_Platforms(self, row):
-        ooi_rd = row['Reference ID']
-        node_entry = dict(
-            name=row['Name'],
-            has_nodes=row['Marine Reference ID'] == row['Site Reference ID'],
-            deployment_date=row['Deployment Date'],
-            controller_type=row['Controller Type'],
-            power_configuration=row['Power Configuration'],
-            terrestrial_link=row['Terrestial Link'],
-        )
         self._add_object_attribute('node',
-            ooi_rd, None, None, change_ok=True, **node_entry)
+            ooi_rd, 'name', name, change_ok=True)
 
         # Determine on which arrays the nodetype is used
         self._add_object_attribute('nodetype',


### PR DESCRIPTION
This updates the OOI asset loader part of preload to reflect latest SAF definitions.
This also corrects an error defining platform devices and generally assigns better names and descriptions to generated resources.
