### PR TITLE
skipping test because Host requires file-system access to coverage

### DIFF
--- a/ion/processes/data/registration/test/test_registration_process.py
+++ b/ion/processes/data/registration/test/test_registration_process.py
@@ -27,6 +27,8 @@ class RegistrationProcessTest(IonIntegrationTestCase):
         self.rp = RegistrationProcess()
         self.rp.on_start()
             
+    @attr('LOCOINT')
+    @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Host requires file-system access to coverage files, CEI mode does not support.')
     def test_get_dataset_to_xml(self):
         dataset_id = self._make_dataset()
         coverage_path = DatasetManagementService()._get_coverage_path(dataset_id)


### PR DESCRIPTION
Part of [OOIION-715](https://jira.oceanobservatories.org/tasks/browse/OOIION-715)
