### PR TITLE
OOIION-718: raise proper errors, properly test for failing activate_deployment cases

### DIFF
--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -774,6 +774,8 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
             possible_sites = [s for s in site_models.keys()
                               if device_model in site_models[s]]
                                     #and self.streamdef_of_site(s) in self.streamdefs_of_device(device_id)]
+            if not possible_sites:
+                raise BadRequest("No sites were found in the deployment")
             problem.addVariable("device_%s" % device_id, possible_sites)
 
         # add the constraint that all the variables have to pick their own site
@@ -793,7 +795,7 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
 
         if 1 > len(solutions):
             raise BadRequest("The set of devices could not be mapped to the set of sites, based on matching " +
-                             "model and streamdefs")
+                             "models") # and streamdefs")
         elif 1 < len(solutions):
             log.warn("Found %d possible ways to map device and site, but just picking the first one", len(solutions))
             log.warn("Here is the %s of all of them:", type(solutions).__name__)


### PR DESCRIPTION
ValueError was being raised when there were 0 sites associated with the deployment.  That case has been detected, and BadRequest with an informative error message is the new behavior.

4 new int tests have been added to verify proper error raising.
