### PR TITLE
Added autosample_duration to InstrumentDeviceComputedAttributes for use in InstrumentDeviceExtension

### DIFF
--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1932,8 +1932,33 @@ class InstrumentManagementService(BaseInstrumentManagementService):
         return ret
 
     def get_autosample_duration(self, instrument_device_id):
+        log.debug("came here to run this method: %s", instrument_device_id)
         ia_client, ret = self.obtain_agent_calculation(instrument_device_id, OT.ComputedIntValue)
+
+        log.debug("got the instrument agent client: %s", ia_client)
+
         if ia_client:
+            # Calculate the value to put in
+
+            # Find events in the event repo that were published when changes of state occurred for the instrument
+            # The Instrument Agent publishes events of a particular type and origin_type. So we query the events db for those.
+            event_tuples = self.container.event_repository.find_events(origin=instrument_device_id, event_type='ResourceAgentResourceStateEvent', origin_type= 'InstrumentDevice')
+
+            log.debug("got the event tuples here: %s", event_tuples)
+
+            recent_events = [tuple[2] for tuple in event_tuples]
+
+            ts_acquire_sample = None
+            for evt in recent_events:
+                log.debug("Got an event with event_state: %s", evt.state)
+                if evt.state == DriverState.ACQUIRE_SAMPLE:
+                    ts_acquire_sample = evt.ts_created
+
+
+
+
+
+
             ret.value = 0 #todo: use ia_client
         return ret
 

--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -7,7 +7,7 @@ __author__ = 'Maurice Manning, Ian Katz, Michael Meisinger'
 import os
 import pwd
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 import time
 import tempfile
 
@@ -1965,8 +1965,21 @@ class InstrumentManagementService(BaseInstrumentManagementService):
         return ret
 
 
-    # def get_uptime(self, device_id): - common to both instrument and platform, see below
+#    def get_uptime(self, device_id): - common to both instrument and platform, see below
 
+    def get_uptime(self, device_id):
+        """
+        @Tim: Lets just consider this value how long the agent has been in Auto-sample mode.
+        If someone take it out of auto-sample, but leaves the drover up, the clock resets the next time
+        its in Auto-sample mode again.
+        """
+        #@todo: The uptime and autosample_duration attributes as defined in email threads appear to be duplicates except
+        # todo(contd): that the autosample duration is an attribute with an int value while the uptime is one with a string value
+        ret = self.get_autosample_duration(device_id)
+        sec = timedelta(seconds = ret.value)
+        d = datetime(1,1,1) + sec
+
+        return "%s days, %s hours, %s minutes" %(d.day-1, d.hour, d.minute)
 
     #functions for INSTRUMENT computed attributes -- currently bogus values returned
 
@@ -2048,14 +2061,6 @@ class InstrumentManagementService(BaseInstrumentManagementService):
 
         return extended_platform
 
-    # The actual initiation of the deployment, calculated from when the deployment was activated
-    def get_uptime(self, device_id):
-        #used by both instrument device, platform device
-#        ia_client, ret = self.obtain_agent_calculation(instrument_device_id, OT.ComputedFloatValue)
-#        if ia_client:
-#            ret.value = 45.5 #todo: use ia_client
-#        return ret
-        return "0 days, 0 hours, 0 minutes"
 
     def get_data_product_parameters_set(self, resource_id=''):
         # return the set of data product with the processing_level_code as the key to identify

--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1856,6 +1856,12 @@ class InstrumentManagementService(BaseInstrumentManagementService):
             ret.value = 0 #todo: use ia_client
         return ret
 
+    def get_autosample_duration(self, instrument_device_id):
+        ia_client, ret = self.obtain_agent_calculation(instrument_device_id, OT.ComputedIntValue)
+        if ia_client:
+            ret.value = 0 #todo: use ia_client
+        return ret
+
 
     # def get_uptime(self, device_id): - common to both instrument and platform, see below
 

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -21,7 +21,7 @@ from interface.services.dm.ipubsub_management_service import PubsubManagementSer
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.objects import ComputedValueAvailability, ProcessDefinition, ProcessStateEnum, StatusType, StreamConfiguration
-from interface.objects import ComputedIntValue, ComputedFloatValue
+from interface.objects import ComputedIntValue, ComputedFloatValue, ComputedStringValue
 
 from pyon.public import RT, PRED, CFG
 from nose.plugins.attrib import attr
@@ -162,6 +162,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         self.assertIsInstance(extended_instrument.computed.autosample_duration, ComputedIntValue)
         self.assertIsInstance(extended_instrument.computed.last_data_received_datetime, ComputedFloatValue)
         self.assertIsInstance(extended_instrument.computed.last_calibration_datetime, ComputedFloatValue)
+        self.assertIsInstance(extended_instrument.computed.uptime, ComputedStringValue)
 
         self.assertIsInstance(extended_instrument.computed.power_status_roll_up, ComputedIntValue)
         self.assertIsInstance(extended_instrument.computed.communications_status_roll_up, ComputedIntValue)

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -21,6 +21,7 @@ from interface.services.dm.ipubsub_management_service import PubsubManagementSer
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.objects import ComputedValueAvailability, ProcessDefinition, ProcessStateEnum, StatusType, StreamConfiguration
+from interface.objects import ComputedIntValue, ComputedFloatValue
 
 from pyon.public import RT, PRED, CFG
 from nose.plugins.attrib import attr
@@ -156,6 +157,18 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         self.assertEqual(len(extended_instrument.owners), 2)
         self.assertEqual(extended_instrument.instrument_model._id, instrument_model_id)
 
+        # Verify that computed attributes exist for the extended instrument
+        self.assertIsInstance(extended_instrument.computed.firmware_version, ComputedFloatValue)
+        self.assertIsInstance(extended_instrument.computed.autosample_duration, ComputedIntValue)
+        self.assertIsInstance(extended_instrument.computed.last_data_received_datetime, ComputedFloatValue)
+        self.assertIsInstance(extended_instrument.computed.last_calibration_datetime, ComputedFloatValue)
+
+        self.assertIsInstance(extended_instrument.computed.power_status_roll_up, ComputedIntValue)
+        self.assertIsInstance(extended_instrument.computed.communications_status_roll_up, ComputedIntValue)
+        self.assertIsInstance(extended_instrument.computed.data_status_roll_up, ComputedIntValue)
+        self.assertIsInstance(extended_instrument.computed.location_status_roll_up, ComputedIntValue)
+
+        log.debug("extended_instrument.computed: %s", extended_instrument.computed)
 
         #check model
         inst_model_obj = self.RR.read(instrument_model_id)

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -595,6 +595,7 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         extended_instrument = self.imsclient.get_instrument_device_extension(instrument_device_id=instDevice_id, user_id=user_id_2)
         log.debug( "For user_2: extended_instrument %s", str(extended_instrument) )
+        log.debug( "For user_2: extended_instrument.computed: %s", str(extended_instrument.computed) )
         log.debug( "For user_2: extended_instrument computed user_notification_requests %s", extended_instrument.computed.user_notification_requests.value)
 
         self.assertEqual( 1, len(extended_instrument.computed.user_notification_requests.value) )

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -38,7 +38,7 @@ from ion.services.dm.utility.granule_utils import RecordDictionaryTool
 from interface.objects import Granule, DeviceStatusType, DeviceCommsType, StatusType, StreamConfiguration
 from interface.objects import AgentCommand, ProcessDefinition, ProcessStateEnum
 from interface.objects import UserInfo, NotificationRequest
-from interface.objects import ComputedIntValue, ComputedFloatValue
+from interface.objects import ComputedIntValue, ComputedFloatValue, ComputedStringValue
 from ion.processes.bootstrap.index_bootstrap import STD_INDEXES
 from nose.plugins.attrib import attr
 import gevent
@@ -213,6 +213,7 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         self.assertIsInstance(extended_instrument.computed.autosample_duration, ComputedIntValue)
         self.assertIsInstance(extended_instrument.computed.last_data_received_datetime, ComputedFloatValue)
         self.assertIsInstance(extended_instrument.computed.last_calibration_datetime, ComputedFloatValue)
+        self.assertIsInstance(extended_instrument.computed.uptime, ComputedStringValue)
 
         self.assertIsInstance(extended_instrument.computed.power_status_roll_up, ComputedIntValue)
         self.assertIsInstance(extended_instrument.computed.communications_status_roll_up, ComputedIntValue)

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -38,7 +38,7 @@ from ion.services.dm.utility.granule_utils import RecordDictionaryTool
 from interface.objects import Granule, DeviceStatusType, DeviceCommsType, StatusType, StreamConfiguration
 from interface.objects import AgentCommand, ProcessDefinition, ProcessStateEnum
 from interface.objects import UserInfo, NotificationRequest
-
+from interface.objects import ComputedIntValue, ComputedFloatValue
 from ion.processes.bootstrap.index_bootstrap import STD_INDEXES
 from nose.plugins.attrib import attr
 import gevent

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -206,6 +206,20 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         datastore = self.container.datastore_manager.get_datastore(datastore_name, DataStore.DS_PROFILE.SCIDATA)
         return datastore
 
+    def check_computed_attributes_of_extended_instrument(self, extended_instrument):
+
+        # Verify that computed attributes exist for the extended instrument
+        self.assertIsInstance(extended_instrument.computed.firmware_version, ComputedFloatValue)
+        self.assertIsInstance(extended_instrument.computed.autosample_duration, ComputedIntValue)
+        self.assertIsInstance(extended_instrument.computed.last_data_received_datetime, ComputedFloatValue)
+        self.assertIsInstance(extended_instrument.computed.last_calibration_datetime, ComputedFloatValue)
+
+        self.assertIsInstance(extended_instrument.computed.power_status_roll_up, ComputedIntValue)
+        self.assertIsInstance(extended_instrument.computed.communications_status_roll_up, ComputedIntValue)
+        self.assertIsInstance(extended_instrument.computed.data_status_roll_up, ComputedIntValue)
+        self.assertIsInstance(extended_instrument.computed.location_status_roll_up, ComputedIntValue)
+
+
 
     @attr('LOCOINT')
     @unittest.skipIf(not use_es, 'No ElasticSearch')
@@ -516,6 +530,10 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         self.assertEqual( 1, len(extended_instrument.computed.user_notification_requests.value) )
 
+        # Verify that computed attributes exist for the extended instrument
+        self.check_computed_attributes_of_extended_instrument(extended_instrument)
+
+        # Verify the computed attribute for user notification requests
         notifications = extended_instrument.computed.user_notification_requests.value
         notification = notifications[0]
         self.assertEqual(notification.origin, instDevice_id)
@@ -582,6 +600,8 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         log.debug( "For user_2: extended_instrument computed user_notification_requests %s", extended_instrument.computed.user_notification_requests.value)
 
         self.assertEqual( 1, len(extended_instrument.computed.user_notification_requests.value) )
+
+        self.check_computed_attributes_of_extended_instrument(extended_instrument)
 
         notifications = extended_instrument.computed.user_notification_requests.value
         notification = notifications[0]


### PR DESCRIPTION
- Bumps ion defs
- Implements get_autosample_duration() and get_uptime(). These values are filled after querying the events db.
- Basic integration test code added to check that the autosample_duration and uptime attributes are indeed getting computed and added to the extended resource for instrument device (InstrumentDeviceExtension) and that they are of the correct type.
