### PR TITLE
UNS' find_events() now uses the container's event_repository's find_events() 

### DIFF
--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -1571,6 +1571,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         def poller():
             events = self.unsc.find_events(origin='my_special_find_events_origin', type = 'PlatformEvent', min_datetime= min_datetime, max_datetime=max_datetime)
+            log.debug("(UNS) got events: %s", events)
             return len(events) >= 4
 
         success = self.event_poll(poller, 10)

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -761,7 +761,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
                         proc1.q.queue.clear()
                         return reloaded_user_info, reloaded_reverse_user_info
 
-        reloaded_user_info,  reloaded_reverse_user_info= self.poll(9, found_user_info_dicts, processes, 3)
+        reloaded_user_info,  reloaded_reverse_user_info= self.poll(20, found_user_info_dicts, processes, 3)
         notification_id_2 = self.unsc.create_notification(notification=notification_request_2, user_id=user_id)
 
         self.assertIsNotNone(reloaded_user_info)
@@ -793,7 +793,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Create another notification
         #--------------------------------------------------------------------------------------
 
-        reloaded_user_info,  reloaded_reverse_user_info= self.poll(9, found_user_info_dicts, processes, 1)
+        reloaded_user_info,  reloaded_reverse_user_info= self.poll(20, found_user_info_dicts, processes, 1)
 
         notification_request_2 = self.rrc.read(notification_id_2)
 

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -12,7 +12,7 @@ from pyon.core.bootstrap import CFG
 from pyon.util.log import log
 from pyon.util.containers import get_ion_ts
 from pyon.public import RT, PRED, get_sys_name, Container, OT, IonObject
-from pyon.event.event import EventPublisher, EventSubscriber, EventRepository
+from pyon.event.event import EventPublisher, EventSubscriber
 from interface.services.dm.idiscovery_service import DiscoveryServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
@@ -142,7 +142,6 @@ class UserNotificationService(BaseUserNotificationService):
         self.process_dispatcher = ProcessDispatcherServiceClient()
         self.event_publisher = EventPublisher()
         self.datastore = self.container.datastore_manager.get_datastore('events')
-        self.event_repo = EventRepository()
 
         self.start_time = get_ion_ts()
 
@@ -456,7 +455,7 @@ class UserNotificationService(BaseUserNotificationService):
         @throws NotFound    object with specified parameters does not exist
         """
 
-        event_tuples = self.event_repo.find_events(event_type=type, origin=origin, start_ts=min_datetime, end_ts=max_datetime, limit=limit, descending=descending)
+        event_tuples = self.container.event_repository.find_events(event_type=type, origin=origin, start_ts=min_datetime, end_ts=max_datetime, limit=limit, descending=descending)
 
         events = [item[2] for item in event_tuples]
         log.debug("(find_events) UNS found the following relevant events: %s", events)

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -456,8 +456,9 @@ class UserNotificationService(BaseUserNotificationService):
         @throws NotFound    object with specified parameters does not exist
         """
 
-        events = self.event_repo.find_events(event_type=type, origin=origin, start_ts=min_datetime, end_ts=max_datetime, limit=limit, descending=descending)
+        event_tuples = self.event_repo.find_events(event_type=type, origin=origin, start_ts=min_datetime, end_ts=max_datetime, limit=limit, descending=descending)
 
+        events = [item[2] for item in event_tuples]
         log.debug("(find_events) UNS found the following relevant events: %s", events)
 
         return events

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -12,7 +12,7 @@ from pyon.core.bootstrap import CFG
 from pyon.util.log import log
 from pyon.util.containers import get_ion_ts
 from pyon.public import RT, PRED, get_sys_name, Container, OT, IonObject
-from pyon.event.event import EventPublisher, EventSubscriber
+from pyon.event.event import EventPublisher, EventSubscriber, EventRepository
 from interface.services.dm.idiscovery_service import DiscoveryServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
@@ -111,9 +111,6 @@ class UserNotificationService(BaseUserNotificationService):
         # Get the event Repository
         #---------------------------------------------------------------------------------------------------
 
-        self.event_repo = self.container.instance.event_repository
-
-
 #        self.ION_NOTIFICATION_EMAIL_ADDRESS = 'data_alerts@oceanobservatories.org'
         self.ION_NOTIFICATION_EMAIL_ADDRESS = CFG.get_safe('server.smtp.sender')
 
@@ -145,6 +142,7 @@ class UserNotificationService(BaseUserNotificationService):
         self.process_dispatcher = ProcessDispatcherServiceClient()
         self.event_publisher = EventPublisher()
         self.datastore = self.container.datastore_manager.get_datastore('events')
+        self.event_repo = EventRepository()
 
         self.start_time = get_ion_ts()
 
@@ -458,42 +456,9 @@ class UserNotificationService(BaseUserNotificationService):
         @throws NotFound    object with specified parameters does not exist
         """
 
-        # The reason for the if-else below is that couchdb query_view does not support passing in Null or -1 for limit
-        # If the opreator does not want to set a limit for the search results in find_events, and does not therefore
-        # provide a limit, one has to just omit it from the opts dictionary and pass that into the query_view() method.
-        # Passing a null or negative for the limit to query view through opts results in a ServerError so we cannot do that.
-        if limit > -1:
-            opts = dict(
-                startkey = [origin, type or 0, min_datetime or 0],
-                endkey   = [origin, type or {}, max_datetime or {}],
-                descending = descending,
-                limit = limit,
-                include_docs = True
-            )
-
-        else:
-            opts = dict(
-                startkey = [origin, type or 0, min_datetime or 0],
-                endkey   = [origin, type or {}, max_datetime or {}],
-                descending = descending,
-                include_docs = True
-            )
-        if descending:
-            t = opts['startkey']
-            opts['startkey'] = opts['endkey']
-            opts['endkey'] = t
-
-        results = self.datastore.query_view('event/by_origintype',opts=opts)
-
-        events = []
-        for res in results:
-            event_obj = res['doc']
-            events.append(event_obj)
+        events = self.event_repo.find_events(event_type=type, origin=origin, start_ts=min_datetime, end_ts=max_datetime, limit=limit, descending=descending)
 
         log.debug("(find_events) UNS found the following relevant events: %s", events)
-
-        if limit > 0:
-            return events[:limit]
 
         return events
 


### PR DESCRIPTION
- Did the refactor: UNS' find_events() now uses the container's event_repository's find_events() 
- Made a test that was sporadically failing more robust by increasing the number of polling tries.
