### PR TITLE
Granule time

### DIFF
--- a/ion/services/dm/utility/granule/record_dictionary.py
+++ b/ion/services/dm/utility/granule/record_dictionary.py
@@ -49,6 +49,7 @@ class RecordDictionaryTool(object):
     _shp         = None
     _locator     = None
     _stream_def  = None
+    _creation_timestamp = None
     _dirty_shape = False
 
     def __init__(self,param_dictionary=None, stream_definition_id='', locator=None):
@@ -91,6 +92,9 @@ class RecordDictionaryTool(object):
        
         if g.domain:
             instance._shp = (g.domain[0],)
+
+        if g.creation_timestamp:
+            instance._creation_timestamp = g.creation_timestamp
         
         for k,v in g.record_dictionary.iteritems():
             key = instance._pdict.key_from_ord(k)

--- a/ion/services/dm/utility/granule/record_dictionary.py
+++ b/ion/services/dm/utility/granule/record_dictionary.py
@@ -24,6 +24,7 @@ from coverage_model.parameter_values import AbstractParameterValue, ConstantValu
 
 import numpy as np
 import msgpack
+import time
 
 class RecordDictionaryTool(object):
     """
@@ -118,6 +119,7 @@ class RecordDictionaryTool(object):
         granule.domain = self.domain.shape
         granule.data_producer_id=data_producer_id
         granule.provider_metadata_update=provider_metadata_update
+        granule.creation_timestamp = time.time()
         return granule
 
 

--- a/ion/services/dm/utility/test/test_granule.py
+++ b/ion/services/dm/utility/test/test_granule.py
@@ -49,6 +49,7 @@ class RecordDictionaryIntegrationTest(IonIntegrationTestCase):
         self.assertEquals(rdt, self.rdt)
         self.assertEquals(m.data_producer_id, self.data_producer_id)
         self.assertEquals(m.provider_metadata_update, self.provider_metadata_update)
+        self.assertNotEqual(m.creation_timestamp, None)
         self.event.set()
 
 


### PR DESCRIPTION
Adds creation_timestamp and assert to to_granule and load_from_granule in RecordDictionaryTool. 
