### PR TITLE
Enforcing Jamie's suggestion: Checking to see if increasing timeout passes the test

### DIFF
--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -386,10 +386,11 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
             for evt in recent_events:
                 log.debug("Got an event with event_state: %s. While ProcessStateEnum.RUNNING would be: %s", evt.state, ProcessStateEnum.RUNNING)
                 if evt.state == ProcessStateEnum.RUNNING:
+                    log.debug("Caught the event here: %s", evt)
                     return True
             return False
 
-        poll(data_process_running, self.event_repo, data_process.process_id)
+        poll(data_process_running, self.event_repo, data_process.process_id, timeout = 60)
 
         #-------------------------------
         # Retrieve a list of all data process defintions in RR and validate that the DPD is listed


### PR DESCRIPTION
- Apart from increasing the timeout to 60, added a good log debug that eliminates doubts regarding whether the correct "process running" event gets caught during the test.
