### PR TITLE
Fix OOIION-724. Harden Event Persister

### DIFF
--- a/ion/processes/event/event_persister.py
+++ b/ion/processes/event/event_persister.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Process that subscribes to ALL events and persists them efficiently into the events datastore"""
+"""Process that subscribes to ALL events and persists them efficiently in bulk into the events datastore"""
 
 from pyon.core import bootstrap
 from pyon.event.event import EventSubscriber
@@ -11,22 +11,17 @@ from gevent.event import Event
 from pyon.public import log
 
 
-"""
-TODO:
-- How fast can this receive event messages?
-"""
-
-
 class EventPersister(StandaloneProcess):
 
     def on_init(self):
         # Time in between event persists
-        self.persist_interval = 1.0
+        self.persist_interval = float(self.CFG.get_safe("event_persist_interval", 1.0))
 
-        # Holds received events FIFO
+        # Holds received events FIFO in syncronized queue
         self.event_queue = Queue()
 
-        # Temporarily holds list of events to persist while datastore operation not yet completed
+        # Temporarily holds list of events to persist while datastore operation are not yet completed
+        # This is where events to persist will remain if datastore operation fails occasionally.
         self.events_to_persist = None
 
         # bookkeeping for timeout greenlet
@@ -39,7 +34,7 @@ class EventPersister(StandaloneProcess):
     def on_start(self):
         # Persister thread
         self._persist_greenlet = spawn(self._trigger_func, self.persist_interval)
-        log.debug('Publisher Greenlet started in "%s"', self.__class__.__name__)
+        log.debug('EventPersister timer greenlet started in "%s" (interval %s)', self.__class__.__name__, self.persist_interval)
 
         # Event subscription
         self.event_sub = EventSubscriber(pattern=EventSubscriber.ALL_EVENTS,
@@ -80,7 +75,7 @@ class EventPersister(StandaloneProcess):
             except Exception as ex:
                 # Note: Persisting events may fail occasionally during test runs (when the "events" datastore is force
                 # deleted and recreated). We'll log and keep retrying forever.
-                log.exception("Failed to persist %s received events" % len(self.events_to_persist))
+                log.exception("Failed to persist %s received events. Will retry next cycle" % len(self.events_to_persist))
                 return False
 
     def _persist_events(self, event_list):


### PR DESCRIPTION
This PR makes the event_persister process retry persisting any events that previously failed persisting, before taking new events off the queue. This is needed in testing, because the "events" datastore gets dropped and recreated for each new test.

Also, the event_persist_interval is now configurable when the event_persister is spawned.

And some better log statements and comment improvements.
