### PR TITLE
Delay coverage creation

### DIFF
--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -896,8 +896,7 @@ class TestExternalDatasetAgent_Dummy(ExternalDatasetAgentTestBase, IonIntegratio
             spatial_domain=sdom)
 
         dproduct_id = dpms_cli.create_data_product(data_product=dprod,
-            stream_definition_id=streamdef_id,
-            parameter_dictionary=pdict_id)
+            stream_definition_id=streamdef_id)
 
         dams_cli.assign_data_product(input_resource_id=ds_id, data_product_id=dproduct_id)  # , create_stream=True)
 

--- a/ion/agents/data/test/test_external_dataset_agent_netcdf.py
+++ b/ion/agents/data/test/test_external_dataset_agent_netcdf.py
@@ -153,8 +153,7 @@ class TestExternalDatasetAgent_Netcdf(ExternalDatasetAgentTestBase,
 
         # Generate the data product and associate it to the ExternalDataset
         dproduct_id = dpms_cli.create_data_product(data_product=dprod,
-            stream_definition_id=streamdef_id,
-            parameter_dictionary=pdict_id)
+            stream_definition_id=streamdef_id)
 
         dams_cli.assign_data_product(input_resource_id=ds_id, data_product_id=dproduct_id)
 

--- a/ion/agents/data/test/test_external_dataset_agent_ruv.py
+++ b/ion/agents/data/test/test_external_dataset_agent_ruv.py
@@ -132,8 +132,7 @@ class TestExternalDatasetAgent_Ruv(ExternalDatasetAgentTestBase, IonIntegrationT
 
         # Generate the data product and associate it to the ExternalDataset
         dproduct_id = dpms_cli.create_data_product(data_product=dprod,
-            stream_definition_id=streamdef_id,
-            parameter_dictionary=pdict_id)
+            stream_definition_id=streamdef_id)
 
         dams_cli.assign_data_product(input_resource_id=ds_id, data_product_id=dproduct_id)
 

--- a/ion/agents/data/test/test_external_dataset_agent_slocum.py
+++ b/ion/agents/data/test/test_external_dataset_agent_slocum.py
@@ -183,8 +183,7 @@ class TestExternalDatasetAgent_Slocum(ExternalDatasetAgentTestBase,
             spatial_domain=sdom)
 
         dproduct_id = dpms_cli.create_data_product(data_product=dprod,
-            stream_definition_id=streamdef_id,
-            parameter_dictionary=pdict_id)
+            stream_definition_id=streamdef_id)
 
         dams_cli.assign_data_product(input_resource_id=ds_id, data_product_id=dproduct_id)
 

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -382,8 +382,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
                            spatial_domain = sdom)
 
         data_product_id2 = self.DP.create_data_product(data_product=dp_obj,
-                                                       stream_definition_id=raw_stream_def_id,
-                                                       parameter_dictionary=rpdict_id)
+                                                       stream_definition_id=raw_stream_def_id)
         log.debug( 'new dp_id = %s', str(data_product_id2))
 
         self.DAMS.assign_data_product(input_resource_id=instDevice_id, data_product_id=data_product_id2)

--- a/ion/services/sa/product/data_product_management_service.py
+++ b/ion/services/sa/product/data_product_management_service.py
@@ -34,7 +34,7 @@ class DataProductManagementService(BaseDataProductManagementService):
         self.data_product   = DataProductImpl(self.clients)
 
 
-    def create_data_product(self, data_product=None, stream_definition_id='', parameter_dictionary=None, exchange_point=''):
+    def create_data_product(self, data_product=None, stream_definition_id='', exchange_point=''):
         """
         @param      data_product IonObject which defines the general data product resource
         @param      source_resource_id IonObject id which defines the source for the data
@@ -49,7 +49,7 @@ class DataProductManagementService(BaseDataProductManagementService):
         # If the stream definition has a parameter dictionary, use that
         validate_is_not_none(stream_definition_id, 'A stream definition id must be passed to register a data product')
         stream_def_obj = self.clients.pubsub_management.read_stream_definition(stream_definition_id) # Validates and checks for param_dict
-        parameter_dictionary = stream_def_obj.parameter_dictionary or parameter_dictionary
+        parameter_dictionary = stream_def_obj.parameter_dictionary 
         validate_is_not_none(parameter_dictionary , 'A parameter dictionary must be passed to register a data product')
         validate_is_not_none(data_product, 'A data product (ion object) must be passed to register a data product')
         exchange_point = exchange_point or 'science_data'

--- a/ion/services/sa/product/test/test_data_product_management_service.py
+++ b/ion/services/sa/product/test/test_data_product_management_service.py
@@ -84,8 +84,7 @@ class TestDataProductManagementServiceUnit(PyonTestCase):
 
         # test call
         dp_id = self.data_product_management_service.create_data_product(data_product=dp_obj,
-                stream_definition_id='a stream def id',
-                parameter_dictionary=parameter_dictionary)
+                stream_definition_id='a stream def id')
 
 
 


### PR DESCRIPTION
- DataProduct's only persist a Coverage object to the file system in the DEPLOY/AVAILABLE state. 
- Computed attributes are updated to reflect new queries.
- DataProductManagement's `create_data_product` no longer accepts a raw parameter dictionary as a parameter.
