### PR TITLE
Support creating resource attachments in service gateway

### DIFF
--- a/ion/services/coi/service_gateway_service.py
+++ b/ion/services/coi/service_gateway_service.py
@@ -629,7 +629,7 @@ def get_attachment(attachment_id):
 def create_attachment():
 
     try:
-        resource_id        = str(request.form['resource_id'])       # unicode coming in
+        resource_id        = str(request.form.get('resource_id', ''))       # unicode coming in
         fil                = request.files['file']
         content            = fil.read()
 
@@ -641,7 +641,7 @@ def create_attachment():
                                         content=content)
 
         rr_client = ResourceRegistryServiceProcessClient(node=Container.instance.node, process=service_gateway_instance)
-        ret = rr_client.create_attachment(resource_id, attachment=attachment)
+        ret = rr_client.create_attachment(resource_id=resource_id, attachment=attachment)
 
         ret_obj = {'attachment_id': ret}
 

--- a/ion/services/coi/service_gateway_service.py
+++ b/ion/services/coi/service_gateway_service.py
@@ -174,7 +174,7 @@ def custom_403(error):
 def is_trusted_request():
 
     if request.remote_addr is not None:
-        log.debug("Request from: " + request.remote_addr)
+        log.debug("%s from: %s: %s", request.method, request.remote_addr, request.url)
 
     if not service_gateway_instance.is_trusted_address(request.remote_addr):
         abort(403)

--- a/ion/services/coi/service_gateway_service.py
+++ b/ion/services/coi/service_gateway_service.py
@@ -524,7 +524,7 @@ def convert_unicode(data):
         return str(data)
     elif isinstance(data, collections.Mapping):
         return dict(map(convert_unicode, data.iteritems()))
-    elif isinstance(data, collections.Iterable):
+    elif isinstance(data, collections.Iterable): # @TODO: passing in a dictionary with strings in it will infinite loop here
         return type(data)(map(convert_unicode, data))
     else:
         return data
@@ -629,15 +629,15 @@ def get_attachment(attachment_id):
 def create_attachment():
 
     try:
-        resource_id        = str(request.form.get('resource_id', ''))       # unicode coming in
+        resource_id        = convert_unicode(request.form.get('resource_id', ''))
         fil                = request.files['file']
         content            = fil.read()
 
         # build attachment
-        attachment         = Attachment(name=request.form['attachment_name'],
-                                        description=request.form['attachment_description'],
-                                        attachment_type=int(request.form['attachment_type']),       # this is unicode coming in
-                                        content_type=request.form['attachment_content_type'],
+        attachment         = Attachment(name=convert_unicode(request.form['attachment_name']),
+                                        description=convert_unicode(request.form['attachment_description']),
+                                        attachment_type=int(request.form['attachment_type']),
+                                        content_type=convert_unicode(request.form['attachment_content_type']),
                                         content=content)
 
         rr_client = ResourceRegistryServiceProcessClient(node=Container.instance.node, process=service_gateway_instance)


### PR DESCRIPTION
This custom route (POST to `/ion-service/attachment`) mirrors the GET side of getting an attachment.

Also adds a change to logging of incoming requests for more debuggability.
