### PR TITLE
Adds input validation and fill_value to rdt

### DIFF
--- a/ion/processes/data/replay/replay_process.py
+++ b/ion/processes/data/replay/replay_process.py
@@ -242,7 +242,9 @@ class ReplayProcess(BaseReplayProcess):
             outgoing = RecordDictionaryTool(stream_definition_id=self.stream_def_id)
             fields = self.parameters or outgoing.fields
             for field in fields:
-                outgoing[field] = rdt[field][(i*self.publish_limit) : ((i+1)*self.publish_limit)]
+                v = rdt[field]
+                if v is not None:
+                    outgoing[field] = v[(i*self.publish_limit) : ((i+1)*self.publish_limit)]
             yield outgoing
         coverage.close(timeout=5)
         return 

--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -398,6 +398,7 @@ class TestDMEnd2End(IonIntegrationTestCase):
         rdt['time'] = np.arange(10)
         rdt['temp'] = np.random.randn(10) * 10 + 30
         rdt['conductivity'] = np.random.randn(10) * 2 + 10
+        rdt['pressure'] = np.random.randn(10) * 1 + 12
 
         publisher = StandaloneStreamPublisher(ctd_stream_id, route)
         publisher.publish(rdt.to_granule())

--- a/ion/services/dm/utility/granule/record_dictionary.py
+++ b/ion/services/dm/utility/granule/record_dictionary.py
@@ -144,7 +144,23 @@ class RecordDictionaryTool(object):
     def temporal_parameter(self):
         return self._pdict.temporal_parameter_name
 
+    def fill_value(self,name):
+        return self._pdict.get_context(name).fill_value
+
+    def _replace_hook(self, name,vals):
+        nparray = np.array(vals)
+        np.place(nparray,nparray==np.array(None),self.fill_value(name))
+        try:
+            if (nparray==np.array(self.fill_value(name))).all():
+                return None
+        except AttributeError:
+            return nparray
+        return nparray
+
     def __setitem__(self, name, vals):
+        return self._set(name, self._replace_hook(name,vals))
+
+    def _set(self, name, vals):
         """
         Set a parameter
         """

--- a/ion/services/dm/utility/test/test_granule.py
+++ b/ion/services/dm/utility/test/test_granule.py
@@ -90,6 +90,14 @@ class RecordDictionaryIntegrationTest(IonIntegrationTestCase):
         self.pubsub_management.deactivate_subscription(subscription_id)
         self.pubsub_management.delete_subscription(subscription_id)
 
+        rdt = RecordDictionaryTool(stream_definition_id=stream_def_id)
+        rdt['time'] = np.array([None,None,None])
+        self.assertTrue(rdt['time'] is None)
+        
+        rdt['time'] = np.array([None, 1, 2])
+        self.assertEquals(rdt['time'][0], rdt.fill_value('time'))
+
+
     @unittest.skip('TODO: add support back for appending granules')
     def test_granule_append(self):
         pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)


### PR DESCRIPTION
Input vectors into the record dictionary tool will replace None with an
appropriate fill value for the specified parameter.
RecordDictionaryTool now as a fill_value method to determine the fill
value for a specified parameter.
