### PR TITLE
Fixes test_replay_with_parameters

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -9,7 +9,7 @@ from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTo
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
 from pyon.core.exception import CorruptionError
 from pyon.event.event import handle_stream_exception, EventPublisher
-from pyon.public import log, RT, PRED, CFG
+from pyon.public import log, RT, PRED, CFG, OT
 from ion.services.dm.inventory.dataset_management_service import DatasetManagementService
 from interface.objects import Granule
 from ion.core.process.transform import TransformStreamListener
@@ -33,7 +33,7 @@ class ScienceGranuleIngestionWorker(TransformStreamListener):
         self._bad_coverages = {}
     def on_start(self): #pragma no cover
         super(ScienceGranuleIngestionWorker,self).on_start()
-        self.event_publisher = EventPublisher('DatasetModified')
+        self.event_publisher = EventPublisher(OT.DatasetModified)
 
 
     def on_quit(self): #pragma no cover

--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -496,6 +496,8 @@ class TestDMEnd2End(IonIntegrationTestCase):
         es = EventSubscriber(event_type=OT.DatasetModified, callback=cb, origin=dataset_id)
         es.start()
 
+        self.addCleanup(es.stop)
+
         self.publish_fake_data(stream_id, route)
 
         self.assertTrue(dataset_modified.wait(30))


### PR DESCRIPTION
The test was rewritten to use a deterministic push/pull pattern for
verifying the retrieve data.
