### PR TITLE
Adds Ctdbp transforms for pathfinder

### DIFF
--- a/ion/processes/data/transforms/ctd/test/test_ctd_transforms.py
+++ b/ion/processes/data/transforms/ctd/test/test_ctd_transforms.py
@@ -45,9 +45,6 @@ class TestCtdTransforms(IonUnitTestCase):
         # This test does not start a container so we have to hack creating a FileSystem singleton instance
 #        FileSystem(DotDict())
 
-        self.px_ctd = SimpleCtdPublisher()
-        self.px_ctd.last_time = 0
-
         self.tx_L0 = ctd_L0_all()
         self.tx_L0.streams = defaultdict(Mock)
         self.tx_L0.cond_publisher = Mock()
@@ -273,7 +270,6 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
         pub = StandaloneStreamPublisher('stream_id', stream_route)
 
         # Build a packet that can be published
-        self.px_ctd = SimpleCtdPublisher()
         publish_granule = self._get_new_ctd_packet(stream_definition_id=stream_def_id, length = 5)
 
         # Publish the packet
@@ -365,7 +361,6 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
         pub = StandaloneStreamPublisher('stream_id', stream_route)
 
         # Build a packet that can be published
-        self.px_ctd = SimpleCtdPublisher()
         publish_granule = self._get_new_ctd_packet(stream_definition_id=stream_def_id, length = 5)
 
         # Publish the packet
@@ -559,7 +554,6 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
         pub = StandaloneStreamPublisher('stream_id', stream_route)
 
         # Build a packet that can be published
-        self.px_ctd = SimpleCtdPublisher()
         publish_granule = self._get_new_ctd_packet(stream_definition_id=stream_def_id, length = 5)
 
         # Publish the packet
@@ -647,7 +641,6 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
         pub = StandaloneStreamPublisher('stream_id', stream_route)
 
         # Build a packet that can be published
-        self.px_ctd = SimpleCtdPublisher()
         publish_granule = self._get_new_ctd_packet(stream_definition_id=stream_def_id, length = 5)
 
         # Publish the packet
@@ -735,7 +728,6 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
         pub = StandaloneStreamPublisher('stream_id', stream_route)
 
         # Build a packet that can be published
-        self.px_ctd = SimpleCtdPublisher()
         publish_granule = self._get_new_ctd_packet(stream_definition_id=stream_def_id, length = 5)
 
         # Publish the packet
@@ -821,7 +813,6 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
         pub = StandaloneStreamPublisher('stream_id', stream_route)
 
         # Build a packet that can be published
-        self.px_ctd = SimpleCtdPublisher()
         publish_granule = self._get_new_ctd_packet(stream_definition_id=stream_def_id, length = 5)
 
         # Publish the packet
@@ -926,7 +917,6 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
 #        pub = StandaloneStreamPublisher('stream_id', stream_route)
 #
 #        # Build a packet that can be published
-#        self.px_ctd = SimpleCtdPublisher()
 #        publish_granule = self._get_new_ctd_packet(stream_definition_id=stream_def_id, length = 5)
 #
 #        # Publish the packet
@@ -1016,7 +1006,6 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
 #        pub = StandaloneStreamPublisher('stream_id', stream_route)
 #
 #        # Build a packet that can be published
-#        self.px_ctd = SimpleCtdPublisher()
 #        publish_granule = self._get_new_ctd_packet(stream_definition_id=stream_def_id, length = 5)
 #
 #        # Publish the packet

--- a/ion/processes/data/transforms/ctdbp/__init__.py
+++ b/ion/processes/data/transforms/ctdbp/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'SChatterjee'

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
@@ -67,14 +67,12 @@ class ctdbp_L0_algorithm(MultiGranuleTransformFunction):
             pressure = rdt['pressure']
             temperature = rdt['temp']
 
-            result = {}
-
             # build the granule for conductivity, temperature and pressure
-            result['L0_stream'] = ctdbp_L0_algorithm._build_granule(stream_definition_id= params['L0_stream'],
+            granule = ctdbp_L0_algorithm._build_granule(stream_definition_id= params['L0_stream'],
                 field_names= ['conductivity', 'pressure', 'temp'], # these are the field names for the output record dictionary
                 values= [conductivity, temperature, pressure])
 
-            result_list.append(result)
+            result_list.append(granule)
 
         return result_list
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
@@ -47,7 +47,7 @@ class CTDBP_L0_all(TransformDataProcess):
             return
         granules = ctdbp_L0_algorithm.execute([packet], params=self.params)
         for granule in granules:
-            self.L0_stream.publish(msg=granule['L0_stream'])
+            self.L0_stream.publish(msg=granule)
 
 class ctdbp_L0_algorithm(MultiGranuleTransformFunction):
 
@@ -65,12 +65,13 @@ class ctdbp_L0_algorithm(MultiGranuleTransformFunction):
 
             conductivity = rdt['conductivity']
             pressure = rdt['pressure']
-            temperature = rdt['temp']
+            temperature = rdt['temperature']
+            time = rdt['time']
 
             # build the granule for conductivity, temperature and pressure
             granule = ctdbp_L0_algorithm._build_granule(stream_definition_id= params['L0_stream'],
-                field_names= ['conductivity', 'pressure', 'temp'], # these are the field names for the output record dictionary
-                values= [conductivity, temperature, pressure])
+                field_names= ['conductivity', 'pressure', 'temperature', 'time'], # these are the field names for the output record dictionary
+                values= [conductivity, temperature, pressure, time])
 
             result_list.append(granule)
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
@@ -1,7 +1,7 @@
 '''
 @author Swarbhanu Chatterjee
 @file ion/processes/data/transforms/ctdbp/ctdbp_L0.py
-@description Transforms CTD parsed data into L0 streams
+@description Transforms incoming CTD parsed data into L0 products to send out through the L0 stream
 '''
 
 from ion.core.process.transform import TransformDataProcess
@@ -65,7 +65,7 @@ class ctdbp_L0_algorithm(MultiGranuleTransformFunction):
 
             # build the granule for conductivity, temperature and pressure
             result['L0_stream'] = ctdbp_L0_algorithm._build_granule(stream_definition_id= params['L0_stream'],
-                field_names= ['conductivity', 'temp', 'pressure'],
+                field_names= ['CONDWAT_L0', 'TEMPWAT_L0', 'PRESWAT_L0'], # these are the field names for the output record dictionary
                 time=time,
                 values= [conductivity, temperature, pressure])
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
@@ -1,0 +1,102 @@
+'''
+@author Swarbhanu Chatterjee
+@file ion/processes/data/transforms/ctdbp/ctdbp_L0.py
+@description Transforms CTD parsed data into L0 streams
+'''
+
+from ion.core.process.transform import TransformDataProcess
+from pyon.core.exception import BadRequest
+
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.core.function.transform_function import MultiGranuleTransformFunction
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
+
+class CTDBP_L0_all(TransformDataProcess):
+    """
+    L0 listens to the parsed and just pulls C, T, & Pressure from the parsed and puts it onto the L0 stream.
+    """
+    output_bindings = ['L0_stream']
+    def on_start(self):
+        super(CTDBP_L0_all, self).on_start()
+
+        if not self.CFG.process.publish_streams.has_key('L0_stream'):
+            raise BadRequest("For CTD transforms, please send the stream_id for the L0_stream using "
+                             "a special keyword (L0_stream)")
+        self.L0_stream = self.CFG.process.publish_streams.L0_stream
+
+        pubsub = PubsubManagementServiceProcessClient(process=self)
+        self.stream_def_L0 = pubsub.read_stream_definition(stream_id=self.L0_stream)
+
+        self.params = {}
+        self.params['L0_stream'] = self.stream_def_L0._id
+
+    def recv_packet(self, packet,stream_route, stream_id):
+        """Processes incoming data!!!!
+            @param packet granule
+            @param stream_route StreamRoute
+            @param stream_id str
+        """
+        if packet == {}:
+            return
+        granules = ctd_L0_algorithm.execute([packet], params=self.params)
+        for granule in granules:
+            self.conductivity.publish(msg = granule['conductivity'])
+            self.temperature.publish(msg = granule['temp'])
+            self.pressure.publish(msg = granule['pressure'])
+
+class ctd_L0_algorithm(MultiGranuleTransformFunction):
+
+    @staticmethod
+    @MultiGranuleTransformFunction.validate_inputs
+    def execute(input=None, context=None, config=None, params=None, state=None):
+        '''
+        @param input granule
+        @retval result_list list of dictionaries containing granules as values
+        '''
+
+        result_list = []
+        for x in input:
+            rdt = RecordDictionaryTool.load_from_granule(x)
+
+            conductivity = rdt['conductivity']
+            pressure = rdt['pressure']
+            temperature = rdt['temp']
+            time = rdt['time']
+
+            result = {}
+
+            # build the granules for conductivity, temperature and pressure
+            result['conductivity'] = ctd_L0_algorithm._build_granule(   stream_definition_id= params['conductivity'],
+                field_name= 'conductivity',
+                time=time,
+                value= conductivity)
+
+            result['temp'] = ctd_L0_algorithm._build_granule(stream_definition_id= params['temperature'],
+                field_name= 'temp',
+                time=time,
+                value= temperature)
+
+            result['pressure'] = ctd_L0_algorithm._build_granule(stream_definition_id= params['pressure'],
+                field_name= 'pressure',
+                time=time,
+                value= pressure)
+
+            result_list.append(result)
+
+        return result_list
+
+    @staticmethod
+    def _build_granule(stream_definition_id=None, field_name='', value=None, time=None):
+        '''
+        @param param_dictionary ParameterDictionary
+        @param field_name str
+        @param value numpy.array
+
+        @retval Granule
+        '''
+        root_rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
+        root_rdt[field_name] = value
+        root_rdt['time'] = time
+
+        return root_rdt.to_granule()
+

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
@@ -67,11 +67,13 @@ class ctdbp_L0_algorithm(MultiGranuleTransformFunction):
             pressure = rdt['pressure']
             temperature = rdt['temperature']
             time = rdt['time']
+            lat = rdt['lat']
+            lon = rdt['lon']
 
             # build the granule for conductivity, temperature and pressure
             granule = ctdbp_L0_algorithm._build_granule(stream_definition_id= params['L0_stream'],
-                field_names= ['conductivity', 'pressure', 'temperature', 'time'], # these are the field names for the output record dictionary
-                values= [conductivity, temperature, pressure, time])
+                field_names= ['conductivity', 'pressure', 'temperature', 'time', 'lat', 'lon'], # these are the field names for the output record dictionary
+                values= [conductivity, temperature, pressure, time, lat, lon])
 
             result_list.append(granule)
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
@@ -54,10 +54,10 @@ class ctdbp_L0_algorithm(MultiGranuleTransformFunction):
     @staticmethod
     @MultiGranuleTransformFunction.validate_inputs
     def execute(input=None, context=None, config=None, params=None, state=None):
-        '''
+        """
         @param input granule
         @retval result_list list of dictionaries containing granules as values
-        '''
+        """
 
         result_list = []
         for x in input:
@@ -80,7 +80,7 @@ class ctdbp_L0_algorithm(MultiGranuleTransformFunction):
 
     @staticmethod
     def _build_granule(stream_definition_id=None, field_names=None, values=None):
-        '''
+        """
         Builds a granule with values corresponding only to the params specified in the field names
 
         @param param_dictionary ParameterDictionary
@@ -88,7 +88,7 @@ class ctdbp_L0_algorithm(MultiGranuleTransformFunction):
         @param value numpy.array
 
         @retval Granule
-        '''
+        """
         root_rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
         zipped = zip(field_names, values)
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L0.py
@@ -23,12 +23,12 @@ class CTDBP_L0_all(TransformDataProcess):
         if not self.CFG.process.publish_streams.has_key('L0_stream'):
             raise BadRequest("For CTD transforms, please send the stream_id for the L0_stream using "
                              "a special keyword (L0_stream)")
-        self.L0_stream = self.CFG.process.publish_streams.L0_stream
+        self.L0_stream_id = self.CFG.process.publish_streams.L0_stream
 
-        log.debug("the output stream: %s", self.L0_stream)
+        log.debug("the output stream: %s", self.L0_stream_id)
 
         pubsub = PubsubManagementServiceProcessClient(process=self)
-        self.stream_def_L0 = pubsub.read_stream_definition(stream_id=self.L0_stream)
+        self.stream_def_L0 = pubsub.read_stream_definition(stream_id=self.L0_stream_id)
 
         self.params = {'L0_stream' : self.stream_def_L0._id }
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -88,16 +88,16 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
         # Set the conductivity values for the output granule
         # Note that since the conductivity caculation depends on whether TEMPWAT_L1, PRESWAT_L1 have been calculated, we need to do this last
-        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_conductivity(   out_rdt = out_rdt,
-                                                                        cond_calibration_coeffs = cond_calibration_coeffs,
-                                                                        TEMPWAT_L1 = TEMPWAT_L1,
-                                                                        PRESWAT_L1 = PRESWAT_L1)
+        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_conductivity(   input_rdt = rdt,
+                                                                        out_rdt = out_rdt,
+                                                                        cond_calibration_coeffs = cond_calibration_coeffs
+        )
 
         # build the granule for the L1 stream
         return out_rdt.to_granule()
 
     @staticmethod
-    def calculate_conductivity(input_rdt = None, out_rdt = None, cond_calibration_coeffs = None, TEMPWAT_L1=None, PRESWAT_L1=None):
+    def calculate_conductivity(input_rdt = None, out_rdt = None, cond_calibration_coeffs = None):
         """
         Dependencies: conductivity calibration coefficients, TEMPWAT_L1, PRESWAT_L1
         """
@@ -105,6 +105,9 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         log.debug("L1 transform applying conductivity algorithm")
 
         CONDWAT_L0 = input_rdt['conductivity']
+        TEMPWAT_L1 = out_rdt['temperature']
+        PRESWAT_L1 = out_rdt['pressure']
+
 
         #------------  CALIBRATION COEFFICIENTS FOR CONDUCTIVITY  --------------
         g = cond_calibration_coeffs['g']
@@ -182,7 +185,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         log.debug("L1 transform applying pressure algorithm")
 
         PRESWAT_L0 = input_rdt['pressure']
-        TEMPWAT_L0 = rdt['temperature']
+        TEMPWAT_L0 = input_rdt['temperature']
 
         #------------  CALIBRATION COEFFICIENTS FOR TEMPERATURE  --------------
         PTEMPA0 = pres_calibration_coeffs['PTEMPA0']
@@ -197,7 +200,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         PTCB1 = pres_calibration_coeffs['PTCB1']
         PTCB2 = pres_calibration_coeffs['PTCB2']
 
-        PA0 = pres_calibration_coeffs['PA0']
+        PA0 = pres_calibration_coeffs['PTCB0']
         PA1 = pres_calibration_coeffs['PA1']
         PA2 = pres_calibration_coeffs['PA2']
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -82,8 +82,8 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
                                                                         temp_calibration_coeffs= temp_calibration_coeffs )
 
         # Set the pressure values for the output granule
-        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_pressure(   out_rdt = out_rdt,
-                                                                    TEMPWAT_L0 = rdt['temperature'],
+        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_pressure(   input_rdt= rdt,
+                                                                    out_rdt = out_rdt,
                                                                     pres_calibration_coeffs= pres_calibration_coeffs)
 
         # Set the conductivity values for the output granule
@@ -120,7 +120,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
         #------------  Computation -------------------------------------
         freq = (CONDWAT_L0 / 256) / 1000
-        CONDWAT_L1 = (g + h * freq^2 + I * freq^3 + j * freq^4) / (1 + CTcor * TEMPWAT_L1 + CPcor * PRESWAT_L1)
+        CONDWAT_L1 = (g + h * freq**2 + I * freq**3 + j * freq**4) / (1 + CTcor * TEMPWAT_L1 + CPcor * PRESWAT_L1)
 
 
         #------------  Update the output record dictionary with the values -------
@@ -174,7 +174,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         return out_rdt
 
     @staticmethod
-    def calculate_pressure(input_rdt = None, out_rdt = None, TEMPWAT_L0 = None, pres_calibration_coeffs = None):
+    def calculate_pressure(input_rdt = None, out_rdt = None, pres_calibration_coeffs = None):
         """
             Dependencies: TEMPWAT_L0, PRESWAT_L0, pressure calibration coefficients
         """
@@ -182,6 +182,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         log.debug("L1 transform applying pressure algorithm")
 
         PRESWAT_L0 = input_rdt['pressure']
+        TEMPWAT_L0 = rdt['temperature']
 
         #------------  CALIBRATION COEFFICIENTS FOR TEMPERATURE  --------------
         PTEMPA0 = pres_calibration_coeffs['PTEMPA0']
@@ -209,10 +210,10 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
         #------------  Computation -------------------------------------
         tvolt = TEMPWAT_L0 / 13107
-        temp = PTEMPA0 + PTEMPA1 * tvolt + PTEMPA2 * tvolt^2
-        x = PRESWAT_L0 - PTCA0 - PTCA1 * temp - PTCA2 * temp^2
-        n = x * PTCB0 / (PTCB0 + PTCB1 * temp + PTCB2 * temp^2)
-        absolute_pressure = PA0 + PA1 * n + PA2 * n^2
+        temp = PTEMPA0 + PTEMPA1 * tvolt + PTEMPA2 * tvolt**2
+        x = PRESWAT_L0 - PTCA0 - PTCA1 * temp - PTCA2 * temp**2
+        n = x * PTCB0 / (PTCB0 + PTCB1 * temp + PTCB2 * temp**2)
+        absolute_pressure = PA0 + PA1 * n + PA2 * n**2
         PRESWAT_L1 = (absolute_pressure * 0.689475729) - 10.1325
 
         #------------  Update the output record dictionary with the values ---------

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -1,9 +1,9 @@
 
-'''
+"""
 @author Swarbhanu Chatterjee
 @file ion/processes/data/transforms/ctdbp/ctd_L1.py
 @description Transforms incoming L0 product into L1 product for conductivity, temperature and pressure through the L1 stream
-'''
+"""
 
 from pyon.public import log
 from pyon.core.exception import BadRequest
@@ -16,10 +16,10 @@ from ion.core.function.transform_function import SimpleGranuleTransformFunction
 import numpy as np
 
 class CTDBP_L1_Transform(TransformDataProcess):
-    '''
+    """
     L1 takes the L0 stream and the passed in Calibration Coefficients and performs the appropriate calculations
     to output the L1 values.
-    '''
+    """
     output_bindings = ['L1_stream']
 
     def on_start(self):
@@ -58,9 +58,9 @@ class CTDBP_L1_Transform(TransformDataProcess):
         self.L1_stream.publish(msg=granule)
 
 class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
-    '''
-
-    '''
+    """
+    Compute conductivity, temperature and pressure using the calibration coefficients
+    """
     @staticmethod
     @SimpleGranuleTransformFunction.validate_inputs
     def execute(input=None, context=None, config=None, params=None, state=None):
@@ -95,9 +95,9 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
     @staticmethod
     def calculate_conductivity(input_rdt = None, out_rdt = None, cond_calibration_coeffs = None, TEMPWAT_L1=None, PRESWAT_L1=None):
-        '''
+        """
         Dependencies: conductivity calibration coefficients, TEMPWAT_L1, PRESWAT_L1
-        '''
+        """
 
         log.debug("L1 transform applying conductivity algorithm")
 
@@ -137,9 +137,9 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
     @staticmethod
     def calculate_temperature(input_rdt = None, out_rdt = None, temp_calibration_coeffs = None):
-        '''
+        """
         Dependencies: temperature calibration coefficients
-        '''
+        """
         log.debug("L1 transform applying temperature algorithm")
 
         TEMPWAT_L0 = input_rdt['TEMPWAT_L0']
@@ -172,9 +172,9 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
     @staticmethod
     def calculate_pressure(input_rdt = None, out_rdt = None, TEMPWAT_L0 = None, pres_calibration_coeffs = None):
-        '''
+        """
             Dependencies: TEMPWAT_L0, PRESWAT_L0, pressure calibration coefficients
-        '''
+        """
 
         log.debug("L1 transform applying pressure algorithm")
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -60,6 +60,12 @@ class CTDBP_L1_Transform(TransformDataProcess):
 class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
     """
     Compute conductivity, temperature and pressure using the calibration coefficients
+
+    Reference
+    ---------
+    The calculations below are based on the following spreadsheet document:
+    https://docs.google.com/spreadsheet/ccc?key=0Au7PUzWoCKU4dDRMeVI0RU9yY180Z0Y5U0hyMUZERmc#gid=0
+
     """
     @staticmethod
     @SimpleGranuleTransformFunction.validate_inputs

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -129,7 +129,6 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         #------------  Update the output record dictionary with the values -------
         for key, value in input_rdt.iteritems():
             if key in out_rdt:
-                #todo check this!!!!
                 out_rdt[key] = value[:]
 
         #------------------------------------------------------------------------

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -2,7 +2,7 @@
 '''
 @author Swarbhanu Chatterjee
 @file ion/processes/data/transforms/ctdbp/ctd_L1.py
-@description Transforms CTD parsed data into L1 products for conductivity, temperature and pressure
+@description Transforms incoming L0 product into L1 product for conductivity, temperature and pressure through the L1 stream
 '''
 
 from ion.core.process.transform import TransformDataProcess
@@ -18,19 +18,28 @@ class CTDBP_L1_Transform(TransformDataProcess):
     L1 takes the L0 stream and the passed in Calibration Coefficients and performs the appropriate calculations
     to output the L1 values.
     '''
-    output_bindings = ['conductivity']
+    output_bindings = ['L1_stream']
 
     def on_start(self):
         super(CTDBPL1Transform, self).on_start()
 
+        #  Validate the CFG used to launch the transform has all the required fields
         if not self.CFG.process.publish_streams.has_key('L1_stream'):
-            raise BadRequest("For CTD transforms, please send the stream_id for the L1_stream using "
-                             "a special keyword (L1_stream)")
+            raise BadRequest("For CTDBP transforms, please send the stream_id for the L1_stream using "
+                     "a special keyword (L1_stream)")
+
         self.L1_stream = self.CFG.process.publish_streams.L1_stream
+
+        calibration_coeffs['cond_calibration_coeffs'] = self.CFG.process.calibration_coeffs.cond_calibration_coeffs
+        calibration_coeffs['temp_calibration_coeffs'] = self.CFG.process.calibration_coeffs.temp_calibration_coeffs
+        calibration_coeffs['pres_calibration_coeffs'] = self.CFG.process.calibration_coeffs.pres_calibration_coeffs
 
         # Read the parameter dict from the stream def of the stream
         pubsub = PubsubManagementServiceProcessClient(process=self)
         self.stream_definition = pubsub.read_stream_definition(stream_id=self.L1_stream)
+
+        self.params['stream_def_id'] = self.stream_definition._id
+        self.params['calibration_coeffs'] = calibration_coeffs
 
     def recv_packet(self, packet, stream_route, stream_id):
         """Processes incoming data!!!!
@@ -38,9 +47,8 @@ class CTDBP_L1_Transform(TransformDataProcess):
         if packet == {}:
             return
 
-        granule = CTDBP_L1_ConductivityTransformAlgorithm.execute(packet, params=self.stream_definition._id)
-        self.conductivity.publish(msg=granule)
-
+        granule = CTDBP_L1_TransformAlgorithm.execute(packet, params= self.params)
+        self.L1_stream.publish(msg=granule)
 
 class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
     '''
@@ -50,52 +58,132 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
     @SimpleGranuleTransformFunction.validate_inputs
     def execute(input=None, context=None, config=None, params=None, state=None):
 
-        rdt = RecordDictionaryTool.load_from_granule(input)
-        out_rdt = RecordDictionaryTool(stream_definition_id=params)
+        self.rdt = RecordDictionaryTool.load_from_granule(input)
+        out_rdt = RecordDictionaryTool(stream_definition_id=params['stream_def_id'])
 
-        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_conductivity(rdt, out_rdt)
-        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_temperature(rdt, out_rdt)
-        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_pressure(rdt, out_rdt)
 
-        # build the granule for conductivity
+        # Set the temperature values for the output granule
+        out_rdt = self.calculate_temperature(out_rdt, params['calibration_coeffs']['temp_calibration_coeffs'] )
+
+        # Set the pressure values for the output granule
+        out_rdt = self.calculate_pressure(out_rdt, params['calibration_coeffs']['pres_calibration_coeffs'])
+
+        # Set the conductivity values for the output granule
+        out_rdt = self.calculate_conductivity(out_rdt, params['calibration_coeffs']['cond_calibration_coeffs'])
+
+
+        # build the granule for the L1 stream
         return out_rdt.to_granule()
 
-    @staticmethod
-    def calculate_conductivity(rdt = None, out_rdt = None):
-        conductivity = rdt['conductivity']
-        cond_value = (conductivity / 100000.0) - 0.5
+    def calculate_conductivity(self, out_rdt = None, cond_calibration_coeffs = None):
+        '''
+        Dependencies: conductivity calibration coefficients, TEMPWAT_L1, PRESWAT_L1
+        '''
+        CONDWAT_L0 = self.rdt['CONDWAT_L0']
 
-        for key, value in rdt.iteritems():
+        #------------  CALIBRATION COEFFICIENTS FOR CONDUCTIVITY  --------------
+        g = cond_calibration_coeffs['g']
+        h = cond_calibration_coeffs['h']
+        I = cond_calibration_coeffs['I']
+        j = cond_calibration_coeffs['j']
+        CTcor = cond_calibration_coeffs['CTcor']
+        CPcor = cond_calibration_coeffs['CPcor']
+
+        if not (g and h and I and j and CTcor and CPcor):
+            raise BadRequest("All the conductivity calibration coefficients (g,h,I,j,CTcor, CPcor) were not passed through"
+                             "the config. Example: config.process.calibration_coeffs.cond_calibration_coeffs['g']")
+
+        #------------  Computation -------------------------------------
+        freq = (CONDWAT_L0 / 256) / 1000
+        CONDWAT_L1 = (g + h * freq^2 + I * freq^3 + j * freq^4) / (1 + CTcor * TEMPWAT_L1 + CPcor * PRESWAT_L1)
+
+
+        #------------  Update the output record dictionary with the values -------
+        for key, value in self.rdt.iteritems():
             if key in out_rdt:
+                #todo check this!!!!
                 out_rdt[key] = value[:]
 
+        #------------------------------------------------------------------------
         # Update the conductivity values
-        out_rdt['conductivity'] = cond_value
+        #------------------------------------------------------------------------
+        out_rdt['CONDWAT_L1'] = CONDWAT_L1
 
         return out_rdt
 
-    @staticmethod
-    def calculate_temperature(rdt = None, out_rdt = None):
-        temperature = rdt['temp']
-        temp_value = (temperature / 10000.0) - 10
+    def calculate_temperature(self, out_rdt = None, temp_calibration_coeffs = None):
+        '''
+        Dependencies: temperature calibration coefficients
+        '''
+        TEMPWAT_L0 = self.rdt['TEMPWAT_L0']
 
-        for key, value in rdt.iteritems():
+        #------------  CALIBRATION COEFFICIENTS FOR TEMPERATURE  --------------
+        a0 = cond_calibration_coeffs['a0']
+        a1 = cond_calibration_coeffs['a1']
+        a2 = cond_calibration_coeffs['a2']
+        a3 = cond_calibration_coeffs['a3']
+
+        if not (a0 and a1 and a2 and a3):
+            raise BadRequest("All the temperature calibration coefficients (a0,a1,a2,a3) were not passed through"
+                             "the config. Example: config.process.calibration_coeffs.temp_calibration_coeffs['a0']")
+
+        #------------  Computation -------------------------------------
+        MV = (TEMPWAT_L0 - 524288) / 1.6e+007
+        R = (MV * 2.900e+009 + 1.024e+008) / (2.048e+004 - MV * 2.0e+005)
+        TEMPWAT_L1 = 1 / (a0 + a1 * ln(R) + a2 * ln^2(R) + a3 * ln^3(R)) - 273.15
+
+        #------------  Update the output record dictionary with the values --------------
+        for key, value in self.rdt.iteritems():
             if key in out_rdt:
                 out_rdt[key] = value[:]
 
-        out_rdt['temp'] = temp_value
+        out_rdt['TEMPWAT_L1'] = TEMPWAT_L1
 
         return out_rdt
 
-    @staticmethod
-    def calculate_pressure(rdt = None, out_rdt = None):
-        pressure = rdt['pressure']
-        pres_value = (pressure / 100.0) + 0.5
+    def calculate_pressure(self, out_rdt = None, pres_calibration_coeffs = None):
+        '''
+            Dependencies: TEMPWAT_L0, PRESWAT_L0, pressure calibration coefficients
+        '''
+        PRESWAT_L0 = self.rdt['PRESWAT_L0']
 
-        for key, value in rdt.iteritems():
+        #------------  CALIBRATION COEFFICIENTS FOR TEMPERATURE  --------------
+        PTEMPA0 = cond_calibration_coeffs['PTEMPA0']
+        PTEMPA1 = cond_calibration_coeffs['PTEMPA1']
+        PTEMPA2 = cond_calibration_coeffs['PTEMPA2']
+
+        PTCA0 = cond_calibration_coeffs['PTCA0']
+        PTCA1 = cond_calibration_coeffs['PTCA1']
+        PTCA2 = cond_calibration_coeffs['PTCA2']
+
+        PTCB0 = cond_calibration_coeffs['PTCB0']
+        PTCB1 = cond_calibration_coeffs['PTCB1']
+        PTCB2 = cond_calibration_coeffs['PTCB2']
+
+        PA0 = cond_calibration_coeffs['PA0']
+        PA1 = cond_calibration_coeffs['PA1']
+        PA2 = cond_calibration_coeffs['PA2']
+
+        cond = PTEMPA0 and PTEMPA0 and PTEMPA2 and PTCA0 and PTCA1 and PTCA2 and PTCB0 and PTCB1 and PTCB2
+        cond = cond and PA0 and PA1 and PA2
+
+        if not cond:
+            raise BadRequest("All the pressure calibration coefficients were not passed through"
+                             "the config. Example: config.process.calibration_coeffs.pres_calibration_coeffs['PTEMPA0']")
+
+        #------------  Computation -------------------------------------
+        tvolt = TEMPWAT_L0 / 13107
+        temp = PTEMPA0 + PTEMPA1 * tvolt + PTEMPA2 * tvolt^2
+        x = PRESWAT_L0 - PTCA0 - PTCA1 * temp - PTCA2 * temp^2
+        n = x * PTCB0 / (PTCB0 + PTCB1 * temp + PTCB2 * temp^2)
+        absolute_pressure = PA0 + PA1 * n + PA2 * n^2
+        PRESWAT_L1 = (absolute_pressure * 0.689475729) - 10.1325
+
+        #------------  Update the output record dictionary with the values ---------
+        for key, value in self.rdt.iteritems():
             if key in out_rdt:
                 out_rdt[key] = value[:]
 
-        out_rdt['pressure'] = pres_value
+        out_rdt['PRESWAT_L1'] = PRESWAT_L1
 
         return out_rdt

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -62,17 +62,24 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         self.rdt = RecordDictionaryTool.load_from_granule(input)
         out_rdt = RecordDictionaryTool(stream_definition_id=params['stream_def_id'])
 
+        # The calibration coefficients
+        temp_calibration_coeffs= params['calibration_coeffs']['temp_calibration_coeffs']
+        pres_calibration_coeffs= params['calibration_coeffs']['pres_calibration_coeffs']
+        cond_calibration_coeffs = params['calibration_coeffs']['cond_calibration_coeffs']
 
         # Set the temperature values for the output granule
-        out_rdt = self.calculate_temperature(out_rdt = out_rdt, temp_calibration_coeffs= params['calibration_coeffs']['temp_calibration_coeffs'] )
+        out_rdt = self.calculate_temperature(   out_rdt = out_rdt,
+                                                temp_calibration_coeffs= temp_calibration_coeffs )
 
         # Set the pressure values for the output granule
-        out_rdt = self.calculate_pressure(out_rdt = out_rdt, TEMPWAT_L0 = self.rdt['TEMPWAT_L0'], pres_calibration_coeffs= params['calibration_coeffs']['pres_calibration_coeffs'])
+        out_rdt = self.calculate_pressure(  out_rdt = out_rdt,
+                                            TEMPWAT_L0 = self.rdt['TEMPWAT_L0'],
+                                            pres_calibration_coeffs= pres_calibration_coeffs)
 
         # Set the conductivity values for the output granule
         # Note that since the conductivity caculation depends on whether TEMPWAT_L1, PRESWAT_L1 have been calculated, we need to do this last
         out_rdt = self.calculate_conductivity(  out_rdt = out_rdt,
-                                                cond_calibration_coeffs = params['calibration_coeffs']['cond_calibration_coeffs'],
+                                                cond_calibration_coeffs = cond_calibration_coeffs,
                                                 TEMPWAT_L1 = TEMPWAT_L1,
                                                 PRESWAT_L1 = PRESWAT_L1)
 
@@ -134,7 +141,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         #------------  Computation -------------------------------------
         MV = (TEMPWAT_L0 - 524288) / 1.6e+007
         R = (MV * 2.900e+009 + 1.024e+008) / (2.048e+004 - MV * 2.0e+005)
-        TEMPWAT_L1 = 1 / (a0 + a1 * np.log(R) + a2 * np.log^2(R) + a3 * np.log^3(R)) - 273.15
+        TEMPWAT_L1 = 1 / (a0 + a1 * np.log(R) + a2 * (np.log(R))**2 + a3 * (np.log(R))**3) - 273.15
 
         #------------  Update the output record dictionary with the values --------------
         for key, value in self.rdt.iteritems():

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -68,6 +68,9 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         rdt = RecordDictionaryTool.load_from_granule(input)
         out_rdt = RecordDictionaryTool(stream_definition_id=params['stream_def_id'])
 
+        # Fill the time values
+        out_rdt['time'] = rdt['time']
+
         # The calibration coefficients
         temp_calibration_coeffs= params['calibration_coeffs']['temp_calibration_coeffs']
         pres_calibration_coeffs= params['calibration_coeffs']['pres_calibration_coeffs']
@@ -80,7 +83,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
         # Set the pressure values for the output granule
         out_rdt = CTDBP_L1_TransformAlgorithm.calculate_pressure(   out_rdt = out_rdt,
-                                                                    TEMPWAT_L0 = rdt['TEMPWAT_L0'],
+                                                                    TEMPWAT_L0 = rdt['temperature'],
                                                                     pres_calibration_coeffs= pres_calibration_coeffs)
 
         # Set the conductivity values for the output granule
@@ -101,7 +104,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
         log.debug("L1 transform applying conductivity algorithm")
 
-        CONDWAT_L0 = input_rdt['CONDWAT_L0']
+        CONDWAT_L0 = input_rdt['conductivity']
 
         #------------  CALIBRATION COEFFICIENTS FOR CONDUCTIVITY  --------------
         g = cond_calibration_coeffs['g']
@@ -129,7 +132,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         #------------------------------------------------------------------------
         # Update the conductivity values
         #------------------------------------------------------------------------
-        out_rdt['CONDWAT_L1'] = CONDWAT_L1
+        out_rdt['conductivity'] = CONDWAT_L1
 
         log.debug("L1 transform conductivity algorithm returning: %s", out_rdt)
 
@@ -142,7 +145,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
         """
         log.debug("L1 transform applying temperature algorithm")
 
-        TEMPWAT_L0 = input_rdt['TEMPWAT_L0']
+        TEMPWAT_L0 = input_rdt['temperature']
 
         #------------  CALIBRATION COEFFICIENTS FOR TEMPERATURE  --------------
         a0 = temp_calibration_coeffs['a0']
@@ -164,7 +167,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
             if key in out_rdt:
                 out_rdt[key] = value[:]
 
-        out_rdt['TEMPWAT_L1'] = TEMPWAT_L1
+        out_rdt['temperature'] = TEMPWAT_L1
 
         log.debug("L1 transform temperature algorithm returning: %s", out_rdt)
 
@@ -178,7 +181,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
 
         log.debug("L1 transform applying pressure algorithm")
 
-        PRESWAT_L0 = input_rdt['PRESWAT_L0']
+        PRESWAT_L0 = input_rdt['pressure']
 
         #------------  CALIBRATION COEFFICIENTS FOR TEMPERATURE  --------------
         PTEMPA0 = pres_calibration_coeffs['PTEMPA0']
@@ -217,7 +220,7 @@ class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
             if key in out_rdt:
                 out_rdt[key] = value[:]
 
-        out_rdt['PRESWAT_L1'] = PRESWAT_L1
+        out_rdt['pressure'] = PRESWAT_L1
 
         log.debug("L1 transform pressure algorithm returning: %s", out_rdt)
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L1.py
@@ -1,0 +1,101 @@
+
+'''
+@author Swarbhanu Chatterjee
+@file ion/processes/data/transforms/ctdbp/ctd_L1.py
+@description Transforms CTD parsed data into L1 products for conductivity, temperature and pressure
+'''
+
+from ion.core.process.transform import TransformDataProcess
+from pyon.core.exception import BadRequest
+
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.core.function.transform_function import SimpleGranuleTransformFunction
+
+
+class CTDBP_L1_Transform(TransformDataProcess):
+    '''
+    L1 takes the L0 stream and the passed in Calibration Coefficients and performs the appropriate calculations
+    to output the L1 values.
+    '''
+    output_bindings = ['conductivity']
+
+    def on_start(self):
+        super(CTDBPL1Transform, self).on_start()
+
+        if not self.CFG.process.publish_streams.has_key('L1_stream'):
+            raise BadRequest("For CTD transforms, please send the stream_id for the L1_stream using "
+                             "a special keyword (L1_stream)")
+        self.L1_stream = self.CFG.process.publish_streams.L1_stream
+
+        # Read the parameter dict from the stream def of the stream
+        pubsub = PubsubManagementServiceProcessClient(process=self)
+        self.stream_definition = pubsub.read_stream_definition(stream_id=self.L1_stream)
+
+    def recv_packet(self, packet, stream_route, stream_id):
+        """Processes incoming data!!!!
+        """
+        if packet == {}:
+            return
+
+        granule = CTDBP_L1_ConductivityTransformAlgorithm.execute(packet, params=self.stream_definition._id)
+        self.conductivity.publish(msg=granule)
+
+
+class CTDBP_L1_TransformAlgorithm(SimpleGranuleTransformFunction):
+    '''
+
+    '''
+    @staticmethod
+    @SimpleGranuleTransformFunction.validate_inputs
+    def execute(input=None, context=None, config=None, params=None, state=None):
+
+        rdt = RecordDictionaryTool.load_from_granule(input)
+        out_rdt = RecordDictionaryTool(stream_definition_id=params)
+
+        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_conductivity(rdt, out_rdt)
+        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_temperature(rdt, out_rdt)
+        out_rdt = CTDBP_L1_TransformAlgorithm.calculate_pressure(rdt, out_rdt)
+
+        # build the granule for conductivity
+        return out_rdt.to_granule()
+
+    @staticmethod
+    def calculate_conductivity(rdt = None, out_rdt = None):
+        conductivity = rdt['conductivity']
+        cond_value = (conductivity / 100000.0) - 0.5
+
+        for key, value in rdt.iteritems():
+            if key in out_rdt:
+                out_rdt[key] = value[:]
+
+        # Update the conductivity values
+        out_rdt['conductivity'] = cond_value
+
+        return out_rdt
+
+    @staticmethod
+    def calculate_temperature(rdt = None, out_rdt = None):
+        temperature = rdt['temp']
+        temp_value = (temperature / 10000.0) - 10
+
+        for key, value in rdt.iteritems():
+            if key in out_rdt:
+                out_rdt[key] = value[:]
+
+        out_rdt['temp'] = temp_value
+
+        return out_rdt
+
+    @staticmethod
+    def calculate_pressure(rdt = None, out_rdt = None):
+        pressure = rdt['pressure']
+        pres_value = (pressure / 100.0) + 0.5
+
+        for key, value in rdt.iteritems():
+            if key in out_rdt:
+                out_rdt[key] = value[:]
+
+        out_rdt['pressure'] = pres_value
+
+        return out_rdt

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
@@ -1,0 +1,86 @@
+
+'''
+@author Swarbhanu Chatterjee
+@file ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
+@description Transforms incoming L1 product into L2 product for density through the L2 stream
+'''
+from pyon.util.log import log
+from pyon.core.exception import BadRequest
+from ion.core.process.transform import TransformDataProcess
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.core.function.transform_function import SimpleGranuleTransformFunction
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
+
+from seawater.gibbs import SP_from_cndr, rho, SA_from_SP
+from seawater.gibbs import cte
+
+class CTDBP_DensityTransform(TransformDataProcess):
+    ''' A basic transform that receives input through a subscription,
+    parses the input from a CTD, extracts the pressure value and scales it according to
+    the defined algorithm. If the transform
+    has an output_stream it will publish the output on the output stream.
+    '''
+    output_bindings = ['density']
+
+    def on_start(self):
+        super(CTDBP_DensityTransform, self).on_start()
+
+        if not self.CFG.process.publish_streams.has_key('density'):
+            raise BadRequest("For CTD transforms, please send the stream_id "
+                             "using a special keyword (ex: density)")
+        self.dens_stream = self.CFG.process.publish_streams.density
+
+        # Read the parameter dict from the stream def of the stream
+        pubsub = PubsubManagementServiceProcessClient(process=self)
+        self.stream_definition = pubsub.read_stream_definition(stream_id=self.dens_stream)
+
+    def recv_packet(self, packet, stream_route, stream_id):
+        """
+        Processes incoming data!!!!
+        """
+        if packet == {}:
+            return
+        log.debug("CTDBP L2 density transform received granule with record dict: %s", packet.record_dictionary)
+
+        granule = CTDBP_DensityTransformAlgorithm.execute(packet, params=self.stream_definition._id)
+
+        log.debug("CTDBP L2 density transform publishing granule with record dict: %s", granule.record_dictionary)
+
+        self.density.publish(msg=granule)
+
+
+class CTDBP_DensityTransformAlgorithm(SimpleGranuleTransformFunction):
+
+    @staticmethod
+    @SimpleGranuleTransformFunction.validate_inputs
+    def execute(input=None, context=None, config=None, params=None, state=None):
+
+        rdt = RecordDictionaryTool.load_from_granule(input)
+        out_rdt = RecordDictionaryTool(stream_definition_id=params)
+
+        conductivity = rdt['conductivity']
+        pressure = rdt['pressure']
+        temperature = rdt['temp']
+
+        longitude = rdt['lon'] if rdt['lon'] is not None else 0
+        latitude = rdt['lat'] if rdt['lat'] is not None else 0
+
+        sp = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=pressure)
+
+        log.debug("CTDBP Density algorithm calculated the sp (practical salinity) values: %s", sp)
+
+        sa = SA_from_SP(sp, pressure, longitude, latitude)
+
+        log.debug("CTDBP Density algorithm calculated the sa (actual salinity) values: %s", sa)
+
+        dens_value = rho(sa, temperature, pressure)
+
+        for key, value in rdt.iteritems():
+            if key in out_rdt:
+                if key=='conductivity' or key=='temp' or key=='pressure':
+                    continue
+                out_rdt[key] = value[:]
+
+        out_rdt['density'] = dens_value
+
+        return out_rdt.to_granule()

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
@@ -1,9 +1,9 @@
 
-'''
+"""
 @author Swarbhanu Chatterjee
 @file ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
 @description Transforms incoming L1 product into L2 product for density through the L2 stream
-'''
+"""
 from pyon.util.log import log
 from pyon.core.exception import BadRequest
 from ion.core.process.transform import TransformDataProcess
@@ -15,11 +15,11 @@ from seawater.gibbs import SP_from_cndr, rho, SA_from_SP
 from seawater.gibbs import cte
 
 class CTDBP_DensityTransform(TransformDataProcess):
-    ''' A basic transform that receives input through a subscription,
+    """ A basic transform that receives input through a subscription,
     parses the input from a CTD, extracts the pressure value and scales it according to
     the defined algorithm. If the transform
     has an output_stream it will publish the output on the output stream.
-    '''
+    """
     output_bindings = ['density']
 
     def on_start(self):

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
@@ -58,6 +58,8 @@ class CTDBP_DensityTransformAlgorithm(SimpleGranuleTransformFunction):
         rdt = RecordDictionaryTool.load_from_granule(input)
         out_rdt = RecordDictionaryTool(stream_definition_id=params)
 
+        out_rdt['time'] = rdt['time']
+
         conductivity = rdt['conductivity']
         pressure = rdt['pressure']
         temperature = rdt['temp']

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
@@ -11,7 +11,7 @@ from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTo
 from ion.core.function.transform_function import SimpleGranuleTransformFunction
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
 
-from seawater.gibbs import SP_from_cndr, rho, SA_from_SP
+from seawater.gibbs import SP_from_cndr, rho, SA_from_SP, conservative_t
 from seawater.gibbs import cte
 
 class CTDBP_DensityTransform(TransformDataProcess):
@@ -86,8 +86,14 @@ class CTDBP_DensityTransformAlgorithm(SimpleGranuleTransformFunction):
 
         log.debug("CTDBP Density algorithm calculated the absolute_salinity (actual salinity) values: %s", absolute_salinity)
 
+        conservative_temperature = conservative_t(absolute_salinity, temperature, pressure)
+
+        log.debug("CTDBP Density algorithm calculated the conservative temperature values: %s", conservative_temperature)
+
         # Doing: DENSITY = gsw_rho(absolute_salinity,conservative_temperature,PRESWAT_L1)
-        dens_value = rho(absolute_salinity, temperature, pressure)
+        dens_value = rho(absolute_salinity, conservative_temperature, pressure)
+
+        log.debug("Calculated density values: %s", dens_value)
 
         for key, value in rdt.iteritems():
             if key in out_rdt:

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
@@ -28,11 +28,11 @@ class CTDBP_DensityTransform(TransformDataProcess):
         if not self.CFG.process.publish_streams.has_key('density'):
             raise BadRequest("For CTD transforms, please send the stream_id "
                              "using a special keyword (ex: density)")
-        self.dens_stream = self.CFG.process.publish_streams.density
+        self.dens_stream_id = self.CFG.process.publish_streams.density
 
         # Read the parameter dict from the stream def of the stream
         pubsub = PubsubManagementServiceProcessClient(process=self)
-        self.stream_definition = pubsub.read_stream_definition(stream_id=self.dens_stream)
+        self.stream_definition = pubsub.read_stream_definition(stream_id=self.dens_stream_id)
 
     def recv_packet(self, packet, stream_route, stream_id):
         """

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
@@ -55,11 +55,21 @@ class CTDBP_DensityTransformAlgorithm(SimpleGranuleTransformFunction):
     @SimpleGranuleTransformFunction.validate_inputs
     def execute(input=None, context=None, config=None, params=None, state=None):
         """
-        Dependencies:    PRACSAL, PRESWAT_L1, longitude, latitude, TEMPWAT_L1
+        Dependencies
+        ------------
+        PRACSAL, PRESWAT_L1, longitude, latitude, TEMPWAT_L1
 
-        absolute_salinity = gsw_SA_from_SP(PRACSAL,PRESWAT_L1,longitude,latitude)
-        conservative_temperature = gsw_CT_from_t(absolute_salinity,TEMPWAT_L1,PRESWAT_L1)
-        DENSITY = gsw_rho(absolute_salinity,conservative_temperature,PRESWAT_L1)
+        Algorithms used
+        ------------
+        1. PRACSAL = gsw_SP_from_C((CONDWAT_L1 * 10),TEMPWAT_L1,PRESWAT_L1)
+        2. absolute_salinity = gsw_SA_from_SP(PRACSAL,PRESWAT_L1,longitude,latitude)
+        3. conservative_temperature = gsw_CT_from_t(absolute_salinity,TEMPWAT_L1,PRESWAT_L1)
+        4. DENSITY = gsw_rho(absolute_salinity,conservative_temperature,PRESWAT_L1)
+
+        Reference
+        ------------
+        The calculations below are based on the following spreadsheet document:
+        https://docs.google.com/spreadsheet/ccc?key=0Au7PUzWoCKU4dDRMeVI0RU9yY180Z0Y5U0hyMUZERmc#gid=0
 
         """
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_density.py
@@ -71,7 +71,7 @@ class CTDBP_DensityTransformAlgorithm(SimpleGranuleTransformFunction):
 
         conductivity = rdt['conductivity']
         pressure = rdt['pressure']
-        temperature = rdt['temp']
+        temperature = rdt['temperature']
 
         longitude = rdt['lon'] if rdt['lon'] is not None else 0
         latitude = rdt['lat'] if rdt['lat'] is not None else 0
@@ -91,7 +91,7 @@ class CTDBP_DensityTransformAlgorithm(SimpleGranuleTransformFunction):
 
         for key, value in rdt.iteritems():
             if key in out_rdt:
-                if key=='conductivity' or key=='temp' or key=='pressure':
+                if key=='conductivity' or key=='temperature' or key=='pressure':
                     continue
                 out_rdt[key] = value[:]
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
@@ -51,7 +51,6 @@ class CTDBP_SalinityTransform(TransformDataProcess):
 
         log.debug("CTDBP L2 salinity transform publishing granule with record dict: %s", granule.record_dictionary)
 
-        granule.data_producer_id=self.id
         self.salinity.publish(msg=granule)
 
 
@@ -61,11 +60,22 @@ class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
     @SimpleGranuleTransformFunction.validate_inputs
     def execute(input=None, context=None, config=None, params=None, state=None):
         """
-        Dependencies: CONDWAT_L1, TEMPWAT_L1, PRESWAT_L1
+        Dependencies
+        ------------
+        CONDWAT_L1, TEMPWAT_L1, PRESWAT_L1
 
+
+        Algorithms used
+        ---------------
         PRACSAL = gsw_SP_from_C((CONDWAT_L1 * 10),TEMPWAT_L1,PRESWAT_L1)
-        """
 
+
+        Reference
+        ---------
+        The calculations below are based on the following spreadsheet document:
+        https://docs.google.com/spreadsheet/ccc?key=0Au7PUzWoCKU4dDRMeVI0RU9yY180Z0Y5U0hyMUZERmc#gid=0
+
+        """
 
         rdt = RecordDictionaryTool.load_from_granule(input)
         out_rdt = RecordDictionaryTool(stream_definition_id=params)
@@ -77,8 +87,6 @@ class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
         temperature = rdt['temperature']
 
         sal_value = SP_from_cndr(conductivity * 10, t=temperature, p=pressure)
-
-#        sal_value = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=pressure)
 
         log.debug("CTDBP Salinity algorithm calculated the sp (practical salinity) values: %s", sal_value)
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
@@ -1,0 +1,84 @@
+
+'''
+@author Swarbhanu Chatterjee
+@file ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+@description Transforms CTD parsed data into L2 product for salinity
+'''
+from pyon.util.log import log
+from ion.core.process.transform import TransformDataProcess
+from pyon.core.exception import BadRequest
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.core.function.transform_function import SimpleGranuleTransformFunction
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceProcessClient
+
+from seawater.gibbs import SP_from_cndr
+from seawater.gibbs import cte
+
+# For usage: please refer to the integration tests in
+# ion/processes/data/transforms/ctd/test/test_ctd_transforms.py
+
+class CTDBP_SalinityTransform(TransformDataProcess):
+    ''' A basic transform that receives input through a subscription,
+    parses the input from a CTD, extracts the pressure value and scales it according to
+    the defined algorithm. If the transform
+    has an output_stream it will publish the output on the output stream.
+    '''
+    output_bindings = ['salinity']
+
+    def on_start(self):
+        super(CTDBP_SalinityTransform, self).on_start()
+
+        if not self.CFG.process.publish_streams.has_key('salinity'):
+            raise BadRequest("For CTD transforms, please send the stream_id "
+                             "using a special keyword (ex: salinity)")
+
+        self.sal_stream = self.CFG.process.publish_streams.salinity
+
+        # Read the parameter dict from the stream def of the stream
+        pubsub = PubsubManagementServiceProcessClient(process=self)
+        self.stream_definition = pubsub.read_stream_definition(stream_id=self.sal_stream)
+
+    def recv_packet(self, packet, stream_route, stream_id):
+        """
+        Processes incoming data!!!!
+        """
+        if packet == {}:
+            return
+
+        log.debug("CTDBP L2 salinity transform received granule with record dict: %s", packet.record_dictionary)
+
+        granule = CTDBP_SalinityTransformAlgorithm.execute(packet, params=self.stream_definition._id)
+
+        log.debug("CTDBP L2 salinity transform publishing granule with record dict: %s", granule.record_dictionary)
+
+        granule.data_producer_id=self.id
+        self.salinity.publish(msg=granule)
+
+
+class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
+
+    @staticmethod
+    @SimpleGranuleTransformFunction.validate_inputs
+    def execute(input=None, context=None, config=None, params=None, state=None):
+
+        rdt = RecordDictionaryTool.load_from_granule(input)
+        out_rdt = RecordDictionaryTool(stream_definition_id=params)
+
+        conductivity = rdt['conductivity']
+        pressure = rdt['pressure']
+        temperature = rdt['temp']
+
+        sal_value = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=pressure)
+
+        log.debug("CTDBP Salinity algorithm calculated the sp (practical salinity) values: %s", sal_value)
+
+        for key, value in rdt.iteritems():
+            if key in out_rdt:
+                if key=='conductivity' or key=='temp' or key=='pressure':
+                    continue
+                out_rdt[key] = value[:]
+
+        out_rdt['salinity'] = sal_value
+
+        return out_rdt.to_granule()
+

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
@@ -64,6 +64,8 @@ class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
         rdt = RecordDictionaryTool.load_from_granule(input)
         out_rdt = RecordDictionaryTool(stream_definition_id=params)
 
+        out_rdt['time'] = rdt['time']
+
         conductivity = rdt['conductivity']
         pressure = rdt['pressure']
         temperature = rdt['temp']

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
@@ -32,11 +32,11 @@ class CTDBP_SalinityTransform(TransformDataProcess):
             raise BadRequest("For CTD transforms, please send the stream_id "
                              "using a special keyword (ex: salinity)")
 
-        self.sal_stream = self.CFG.process.publish_streams.salinity
+        self.sal_stream_id = self.CFG.process.publish_streams.salinity
 
         # Read the parameter dict from the stream def of the stream
         pubsub = PubsubManagementServiceProcessClient(process=self)
-        self.stream_definition = pubsub.read_stream_definition(stream_id=self.sal_stream)
+        self.stream_definition = pubsub.read_stream_definition(stream_id=self.sal_stream_id)
 
     def recv_packet(self, packet, stream_route, stream_id):
         """

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
@@ -74,7 +74,7 @@ class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
 
         conductivity = rdt['conductivity']
         pressure = rdt['pressure']
-        temperature = rdt['temp']
+        temperature = rdt['temperature']
 
         #todo Is this the same as "gsw_SP_from_C((CONDWAT_L1 * 10),TEMPWAT_L1,PRESWAT_L1)" ?
         sal_value = SP_from_cndr(conductivity * 10, t=temperature, p=pressure)
@@ -85,7 +85,7 @@ class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
 
         for key, value in rdt.iteritems():
             if key in out_rdt:
-                if key=='conductivity' or key=='temp' or key=='pressure':
+                if key=='conductivity' or key=='temperature' or key=='pressure':
                     continue
                 out_rdt[key] = value[:]
 

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
@@ -76,7 +76,6 @@ class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
         pressure = rdt['pressure']
         temperature = rdt['temperature']
 
-        #todo Is this the same as "gsw_SP_from_C((CONDWAT_L1 * 10),TEMPWAT_L1,PRESWAT_L1)" ?
         sal_value = SP_from_cndr(conductivity * 10, t=temperature, p=pressure)
 
 #        sal_value = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=pressure)

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
@@ -1,9 +1,9 @@
 
-'''
+"""
 @author Swarbhanu Chatterjee
 @file ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
 @description Transforms CTD parsed data into L2 product for salinity
-'''
+"""
 from pyon.util.log import log
 from ion.core.process.transform import TransformDataProcess
 from pyon.core.exception import BadRequest
@@ -18,11 +18,11 @@ from seawater.gibbs import cte
 # ion/processes/data/transforms/ctd/test/test_ctd_transforms.py
 
 class CTDBP_SalinityTransform(TransformDataProcess):
-    ''' A basic transform that receives input through a subscription,
+    """ A basic transform that receives input through a subscription,
     parses the input from a CTD, extracts the pressure value and scales it according to
     the defined algorithm. If the transform
     has an output_stream it will publish the output on the output stream.
-    '''
+    """
     output_bindings = ['salinity']
 
     def on_start(self):

--- a/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
+++ b/ion/processes/data/transforms/ctdbp/ctdbp_L2_salinity.py
@@ -60,6 +60,12 @@ class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
     @staticmethod
     @SimpleGranuleTransformFunction.validate_inputs
     def execute(input=None, context=None, config=None, params=None, state=None):
+        """
+        Dependencies: CONDWAT_L1, TEMPWAT_L1, PRESWAT_L1
+
+        PRACSAL = gsw_SP_from_C((CONDWAT_L1 * 10),TEMPWAT_L1,PRESWAT_L1)
+        """
+
 
         rdt = RecordDictionaryTool.load_from_granule(input)
         out_rdt = RecordDictionaryTool(stream_definition_id=params)
@@ -70,7 +76,10 @@ class CTDBP_SalinityTransformAlgorithm(SimpleGranuleTransformFunction):
         pressure = rdt['pressure']
         temperature = rdt['temp']
 
-        sal_value = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=pressure)
+        #todo Is this the same as "gsw_SP_from_C((CONDWAT_L1 * 10),TEMPWAT_L1,PRESWAT_L1)" ?
+        sal_value = SP_from_cndr(conductivity * 10, t=temperature, p=pressure)
+
+#        sal_value = SP_from_cndr(r=conductivity/cte.C3515, t=temperature, p=pressure)
 
         log.debug("CTDBP Salinity algorithm calculated the sp (practical salinity) values: %s", sal_value)
 

--- a/ion/processes/data/transforms/ctdbp/test/__init__.py
+++ b/ion/processes/data/transforms/ctdbp/test/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'SChatterjee'

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
@@ -93,7 +93,7 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
         tdom = tdom.dump()
 
         # Get the stream definition for the stream using the parameter dictionary
-        parsed_pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
+        parsed_pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctdbp_cdef_sample', id_only=True)
         parsed_stream_def_id = self.pubsub.create_stream_definition(name='parsed', parameter_dictionary_id=parsed_pdict_id)
 
         log.debug("Got the parsed parameter dictionary: id: %s", parsed_pdict_id)

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
@@ -115,7 +115,9 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
         #create temp streamdef so the data product can create the stream
         pc_list = []
         for pc_k, pc in pdict.iteritems():
-            pc_list.append(self.dataset_management.create_parameter_context(pc_k, pc[1].dump()))
+            ctxt_id = self.dataset_management.create_parameter_context(pc_k, pc[1].dump())
+            pc_list.append(ctxt_id)
+            self.addCleanup(self.dataset_management.delete_parameter_context,ctxt_id)
 
         pdict_id = self.dataset_management.create_parameter_dictionary(parameter_dict_name, pc_list)
 

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
@@ -22,7 +22,7 @@ from interface.services.coi.iresource_registry_service import ResourceRegistrySe
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
 from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
 from ion.services.dm.utility.granule_utils import time_series_domain
-from coverage_model import QuantityType
+from coverage_model import ParameterContext, AxisTypeEnum, QuantityType
 from coverage_model.parameter import ParameterDictionary
 
 import gevent
@@ -68,7 +68,7 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
             xn = self.container.ex_manager.create_xn_queue(queue)
             xn.delete()
 
-    def _create_input_param_dict_for_test(self):
+    def _create_input_param_dict_for_test(self, parameter_dict_name = ''):
 
         pdict = ParameterDictionary()
 
@@ -110,9 +110,9 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
         #create temp streamdef so the data product can create the stream
         pc_list = []
         for pc_k, pc in pdict.iteritems():
-            pc_list.append(dms_cli.create_parameter_context(pc_k, pc[1].dump()))
+            pc_list.append(self.dataset_management.create_parameter_context(pc_k, pc[1].dump()))
 
-        pdict_id = dms_cli.create_parameter_dictionary('fictitious_ctdp_param_dict', pc_list)
+        pdict_id = self.dataset_management.create_parameter_dictionary(parameter_dict_name, pc_list)
 
         return pdict_id
 
@@ -141,7 +141,7 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
         sdom = sdom.dump()
         tdom = tdom.dump()
 
-        input_param_dict = self._create_input_param_dict_for_test()
+        input_param_dict = self._create_input_param_dict_for_test(parameter_dict_name = 'fictitious_ctdp_param_dict')
 
         # Get the stream definition for the stream using the parameter dictionary
 #        input_param_dict = self.dataset_management.read_parameter_dictionary_by_name('ctdbp_cdef_sample', id_only=True)

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+
+'''
+@brief Test to check CTD
+@author Swarbhanu Chatterjee
+'''
+
+
+import os
+from pyon.ion.stream import  StandaloneStreamPublisher
+from pyon.public import log, IonObject, RT
+from pyon.util.containers import DotDict
+from pyon.util.file_sys import FileSystem
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.util.containers import get_safe
+from pyon.ion.stream import StandaloneStreamSubscriber
+from nose.plugins.attrib import attr
+
+from interface.objects import ProcessDefinition
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
+from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
+from interface.services.sa.idata_process_management_service import DataProcessManagementServiceClient
+from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
+
+from interface.objects import StreamRoute, Granule
+from ion.processes.data.ctd_stream_publisher import SimpleCtdPublisher
+from ion.processes.data.transforms.ctd.ctd_L0_all import ctd_L0_all
+from ion.processes.data.transforms.ctd.ctd_L1_conductivity import CTDL1ConductivityTransform
+from ion.processes.data.transforms.ctd.ctd_L1_pressure import CTDL1PressureTransform
+from ion.processes.data.transforms.ctd.ctd_L1_temperature import CTDL1TemperatureTransform
+from ion.processes.data.transforms.ctd.ctd_L2_salinity import SalinityTransform
+from ion.processes.data.transforms.ctd.ctd_L2_density import DensityTransform
+from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule_utils import time_series_domain
+from coverage_model import QuantityType
+import unittest, gevent
+import numpy, random
+from seawater.gibbs import SP_from_cndr, rho, SA_from_SP
+from seawater.gibbs import cte
+
+@attr('INT', group='dm')
+class CtdTransformsIntTest(IonIntegrationTestCase):
+    def setUp(self):
+        super(CtdTransformsIntTest, self).setUp()
+
+        self._start_container()
+        self.container.start_rel_from_url('res/deploy/r2deploy.yml')
+
+        self.pubsub            = PubsubManagementServiceClient()
+        self.process_dispatcher = ProcessDispatcherServiceClient()
+        self.dataset_management = DatasetManagementServiceClient()
+        self.data_process_management = DataProcessManagementServiceClient()
+        self.dataproduct_management = DataProductManagementServiceClient()
+
+    def test_ctd_L0_all(self):
+        '''
+        Test that packets are processed by the ctd_L0_all transform
+        '''
+
+        #----------- Data Process Definition --------------------------------
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+            name='CTDBP_L0_all',
+            description='Take parsed stream and put the C, T and P into three separate L0 streams.',
+            module='ion.processes.data.transforms.ctdbp.ctdbp_L0',
+            class_name='CTDBP_L0_all')
+
+        dprocdef_id = self.data_process_management.create_data_process_definition(dpd_obj)
+
+        log.debug("created data process definition: id = %s", dprocdef_id)
+
+        #----------- Data Products --------------------------------
+
+
+        # Construct temporal and spatial Coordinate Reference System objects
+        tdom, sdom = time_series_domain()
+
+        sdom = sdom.dump()
+        tdom = tdom.dump()
+
+        # Get the stream definition for the stream using the parameter dictionary
+        parsed_pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
+        parsed_stream_def_id = self.pubsub.create_stream_definition(name='parsed', parameter_dictionary_id=parsed_pdict_id)
+
+        log.debug("Got the parsed parameter dictionary: id: %s", parsed_pdict_id)
+        log.debug("Got the stream def for parsed input: %s", parsed_stream_def_id)
+
+        # Input data product
+        parsed_stream_dp_obj = IonObject(RT.DataProduct,
+            name='parsed_stream',
+            description='Parsed stream input to CTBP L0 transform',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        input_dp_id = self.dataproduct_management.create_data_product(data_product=parsed_stream_dp_obj,
+            stream_definition_id=parsed_stream_def_id
+        )
+
+        # output data product
+        L0_stream_dp_obj = IonObject(RT.DataProduct,
+            name='L0_stream',
+            description='L0_stream output of CTBP L0 transform',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        L0_stream_dp_id = self.dataproduct_management.create_data_product(data_product=L0_stream_dp_obj,
+                                                                    stream_definition_id=parsed_stream_def_id
+                                                                    )
+        self.output_products = {'L0_stream' : L0_stream_dp_id}
+
+        dproc_id = self.data_process_management.create_data_process( dprocdef_id, [input_dp_id], self.output_products)
+
+        log.debug("Created a data process for ctdbp_L0. id: %s", dproc_id)
+
+
+
+#    def check_cond_algorithm_execution(self, publish_granule, granule_from_transform):
+#
+#        input_rdt_to_transform = RecordDictionaryTool.load_from_granule(publish_granule)
+#        output_rdt_transform = RecordDictionaryTool.load_from_granule(granule_from_transform)
+#
+#        output_data = output_rdt_transform['conductivity']
+#        input_data = input_rdt_to_transform['conductivity']
+#
+#        self.assertTrue(numpy.array_equal(((input_data / 100000.0) - 0.5), output_data))
+#
+#
+#    def check_granule_splitting(self, publish_granule, out_dict):
+#        '''
+#        This checks that the ctd_L0_all transform is able to split out one of the
+#        granules from the whole granule
+#        fed into the transform
+#        '''
+#
+#        input_rdt_to_transform = RecordDictionaryTool.load_from_granule(publish_granule)
+#
+#        in_cond = input_rdt_to_transform['conductivity']
+#        in_pressure = input_rdt_to_transform['pressure']
+#        in_temp = input_rdt_to_transform['temp']
+#
+#        out_cond = out_dict['c']
+#        out_pres = out_dict['p']
+#        out_temp = out_dict['t']
+#
+#        self.assertTrue(numpy.array_equal(in_cond,out_cond))
+#        self.assertTrue(numpy.array_equal(in_pressure, out_pres))
+#        self.assertTrue(numpy.array_equal(in_temp,out_temp))

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-'''
+"""
 @brief Test to check CTD
 @author Swarbhanu Chatterjee
-'''
+"""
 
 
 from pyon.ion.stream import  StandaloneStreamPublisher
@@ -68,9 +68,9 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
             xn.delete()
 
     def test_ctdbp_L0_all(self):
-        '''
+        """
         Test packets processed by the ctdbp_L0_all transform
-        '''
+        """
 
         #----------- Data Process Definition --------------------------------
 
@@ -182,9 +182,9 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
 
 
     def _check_granule_from_transform(self, granule):
-        '''
+        """
         An internal method to check if a granule has the right properties
-        '''
+        """
 
         pass
 

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
@@ -48,6 +48,7 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
 
         # Cleanup of queue created by the subscriber
         self.queue_cleanup = []
+        self.data_process_cleanup = []
 
     def _get_new_ctd_packet(self, stream_definition_id, length):
 
@@ -67,6 +68,10 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
         for queue in self.queue_cleanup:
             xn = self.container.ex_manager.create_xn_queue(queue)
             xn.delete()
+
+    def cleaning_operations(self):
+        for dproc_id in self.data_process_cleanup:
+            self.data_process_management.delete_data_process(dproc_id)
 
     def _create_input_param_dict_for_test(self, parameter_dict_name = ''):
 
@@ -179,6 +184,9 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
         output_stream_id = out_stream_ids[0]
 
         dproc_id = self.data_process_management.create_data_process( dprocdef_id, [input_dp_id], self.output_products)
+
+        self.data_process_cleanup.append(dproc_id)
+        self.addCleanup(self.cleaning_operations)
 
         log.debug("Created a data process for ctdbp_L0. id: %s", dproc_id)
 

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
@@ -53,6 +53,7 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
 
         # Cleanup of queue created by the subscriber
         self.queue_cleanup = []
+        self.data_process_cleanup = []
 
     def _create_input_param_dict_for_test(self, parameter_dict_name = ''):
 
@@ -151,6 +152,10 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
             xn = self.container.ex_manager.create_xn_queue(queue)
             xn.delete()
 
+    def cleaning_operations(self):
+        for dproc_id in self.data_process_cleanup:
+            self.data_process_management.delete_data_process(dproc_id)
+
     def test_ctd_L1_all(self):
         """
         Test that packets are processed by the ctd_L1_all transform
@@ -214,7 +219,7 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
 
         config = self._create_calibration_coefficients_dict()
         dproc_id = self.data_process_management.create_data_process( dprocdef_id, [input_dp_id], self.output_products, config)
-
+        self.data_process_cleanup.append(dproc_id)
         log.debug("Created a data process for ctdbp_L1. id: %s", dproc_id)
 
         # Activate the data process

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-'''
+"""
 @brief Test to check CTD
 @author Swarbhanu Chatterjee
-'''
+"""
 
 
 
@@ -72,9 +72,9 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
             xn.delete()
 
     def test_ctd_L1_all(self):
-        '''
+        """
         Test that packets are processed by the ctd_L1_all transform
-        '''
+        """
 
         #----------- Data Process Definition --------------------------------
 
@@ -186,9 +186,9 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
 
 
     def _check_granule_from_transform(self, granule):
-        '''
+        """
         An internal method to check if a granule has the right properties
-        '''
+        """
 
         pass
 
@@ -209,11 +209,11 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
 #
 #
 #    def check_granule_splitting(self, publish_granule, out_dict):
-#        '''
+#        """
 #        This checks that the ctd_L1_all transform is able to split out one of the
 #        granules from the whole granule
 #        fed into the transform
-#        '''
+#        """
 #
 #        input_rdt_to_transform = RecordDictionaryTool.load_from_granule(publish_granule)
 #

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
@@ -97,7 +97,9 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
         #create temp streamdef so the data product can create the stream
         pc_list = []
         for pc_k, pc in pdict.iteritems():
-            pc_list.append(self.dataset_management.create_parameter_context(pc_k, pc[1].dump()))
+            ctxt_id = self.dataset_management.create_parameter_context(pc_k, pc[1].dump())
+            pc_list.append(ctxt_id)
+            self.addCleanup(self.dataset_management.delete_parameter_context,ctxt_id)
 
         pdict_id = self.dataset_management.create_parameter_dictionary(parameter_dict_name, pc_list)
 

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+
+'''
+@brief Test to check CTD
+@author Swarbhanu Chatterjee
+'''
+
+
+
+from pyon.ion.stream import  StandaloneStreamPublisher
+from pyon.public import log, IonObject, RT, PRED
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.ion.stream import StandaloneStreamSubscriber
+from nose.plugins.attrib import attr
+
+from interface.objects import ProcessDefinition
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
+from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
+from interface.services.sa.idata_process_management_service import DataProcessManagementServiceClient
+from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
+from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
+
+from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule_utils import time_series_domain
+from coverage_model import QuantityType
+
+import gevent
+import numpy, random
+
+from seawater.gibbs import SP_from_cndr, rho, SA_from_SP
+from seawater.gibbs import cte
+
+@attr('INT', group='dm')
+class CtdTransformsIntTest(IonIntegrationTestCase):
+    def setUp(self):
+        super(CtdTransformsIntTest, self).setUp()
+
+        self._start_container()
+        self.container.start_rel_from_url('res/deploy/r2deploy.yml')
+
+        self.pubsub            = PubsubManagementServiceClient()
+        self.process_dispatcher = ProcessDispatcherServiceClient()
+        self.dataset_management = DatasetManagementServiceClient()
+        self.data_process_management = DataProcessManagementServiceClient()
+        self.dataproduct_management = DataProductManagementServiceClient()
+        self.resource_registry = ResourceRegistryServiceClient()
+
+        # This is for the time values inside the packets going into the transform
+        self.i = 0
+
+        # Cleanup of queue created by the subscriber
+        self.queue_cleanup = []
+
+    def _get_new_ctd_L0_packet(self, stream_definition_id, length):
+
+        rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
+        rdt['time'] = numpy.arange(self.i, self.i+length)
+
+        for field in rdt:
+            if isinstance(rdt._pdict.get_context(field).param_type, QuantityType):
+                rdt[field] = numpy.array([random.uniform(0.0,75.0)  for i in xrange(length)])
+
+        g = rdt.to_granule()
+        self.i+=length
+
+        return g
+
+    def clean_queues(self):
+        for queue in self.queue_cleanup:
+            xn = self.container.ex_manager.create_xn_queue(queue)
+            xn.delete()
+
+    def test_ctd_L1_all(self):
+        '''
+        Test that packets are processed by the ctd_L1_all transform
+        '''
+
+        #----------- Data Process Definition --------------------------------
+
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+            name='CTDBP_L1_Transform',
+            description='Take granules on the L0 stream which have the C, T and P data and separately apply algorithms and output on the L1 stream.',
+            module='ion.processes.data.transforms.ctdbp.ctdbp_L1',
+            class_name='CTDBP_L1_Transform')
+
+        dprocdef_id = self.data_process_management.create_data_process_definition(dpd_obj)
+
+        log.debug("created data process definition: id = %s", dprocdef_id)
+
+        #----------- Data Products --------------------------------
+
+        # Construct temporal and spatial Coordinate Reference System objects
+        tdom, sdom = time_series_domain()
+
+        sdom = sdom.dump()
+        tdom = tdom.dump()
+
+        # Get the stream definition for the stream using the parameter dictionary
+        L0_pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
+        L0_stream_def_id = self.pubsub.create_stream_definition(name='parsed', parameter_dictionary_id=L0_pdict_id)
+
+        log.debug("Got the parsed parameter dictionary: id: %s", L0_pdict_id)
+        log.debug("Got the stream def for parsed input: %s", L0_stream_def_id)
+
+        # Input data product
+        L0_stream_dp_obj = IonObject(RT.DataProduct,
+            name='L0_stream',
+            description='L0 stream input to CTBP L1 transform',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        input_dp_id = self.dataproduct_management.create_data_product(data_product=L0_stream_dp_obj,
+            stream_definition_id=L0_stream_def_id
+        )
+
+        # output data product
+        L1_stream_dp_obj = IonObject(RT.DataProduct,
+            name='L1_stream',
+            description='L1_stream output of CTBP L1 transform',
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        L1_stream_dp_id = self.dataproduct_management.create_data_product(data_product=L1_stream_dp_obj,
+            stream_definition_id=L0_stream_def_id
+        )
+
+        # We need the key name here to be "L1_stream", since when the data process is launched, this name goes into
+        # the config as in config.process.publish_streams.L1_stream when the config is used to launch the data process
+        self.output_products = {'L1_stream' : L1_stream_dp_id}
+        out_stream_ids, _ = self.resource_registry.find_objects(L1_stream_dp_id, PRED.hasStream, RT.Stream, True)
+        output_stream_id = out_stream_ids[0]
+
+        dproc_id = self.data_process_management.create_data_process( dprocdef_id, [input_dp_id], self.output_products)
+
+        log.debug("Created a data process for ctdbp_L1. id: %s", dproc_id)
+
+        # Activate the data process
+        self.data_process_management.activate_data_process(dproc_id)
+
+        #----------- Find the stream that is associated with the input data product when it was created by create_data_product() --------------------------------
+
+        stream_ids, _ = self.resource_registry.find_objects(input_dp_id, PRED.hasStream, RT.Stream, True)
+
+        input_stream_id = stream_ids[0]
+        input_stream = self.resource_registry.read(input_stream_id)
+        stream_route = input_stream.stream_route
+
+        log.debug("The input stream for the L1 transform: %s", input_stream_id)
+
+        #----------- Create a subscriber that will listen to the transform's output --------------------------------
+
+        ar = gevent.event.AsyncResult()
+        def subscriber(m,r,s):
+            ar.set(m)
+
+        sub = StandaloneStreamSubscriber(exchange_name='sub', callback=subscriber)
+
+        sub_id = self.pubsub.create_subscription('subscriber_to_transform',
+            stream_ids=[output_stream_id],
+            exchange_name='sub')
+
+        self.pubsub.activate_subscription(sub_id)
+
+        self.addCleanup(sub.stop)
+        self.queue_cleanup.append(sub.xn.queue)
+        self.addCleanup(self.clean_queues)
+
+        sub.start()
+
+        #----------- Publish on that stream so that the transform can receive it --------------------------------
+
+        pub = StandaloneStreamPublisher(input_stream_id, stream_route)
+        publish_granule = self._get_new_ctd_L0_packet(stream_definition_id=L0_stream_def_id, length = 5)
+
+        pub.publish(publish_granule)
+
+        log.debug("Published the following granule: %s", publish_granule)
+
+        granule_from_transform = ar.get(timeout=20)
+
+        log.debug("Got the following granule from the transform: %s", granule_from_transform)
+
+        # Check that the granule published by the L1 transform has the right properties
+        self._check_granule_from_transform(granule_from_transform)
+
+
+    def _check_granule_from_transform(self, granule):
+        '''
+        An internal method to check if a granule has the right properties
+        '''
+
+        pass
+
+
+
+
+
+
+#    def check_cond_algorithm_execution(self, publish_granule, granule_from_transform):
+#
+#        input_rdt_to_transform = RecordDictionaryTool.load_from_granule(publish_granule)
+#        output_rdt_transform = RecordDictionaryTool.load_from_granule(granule_from_transform)
+#
+#        output_data = output_rdt_transform['conductivity']
+#        input_data = input_rdt_to_transform['conductivity']
+#
+#        self.assertTrue(numpy.array_equal(((input_data / 100000.0) - 0.5), output_data))
+#
+#
+#    def check_granule_splitting(self, publish_granule, out_dict):
+#        '''
+#        This checks that the ctd_L1_all transform is able to split out one of the
+#        granules from the whole granule
+#        fed into the transform
+#        '''
+#
+#        input_rdt_to_transform = RecordDictionaryTool.load_from_granule(publish_granule)
+#
+#        in_cond = input_rdt_to_transform['conductivity']
+#        in_pressure = input_rdt_to_transform['pressure']
+#        in_temp = input_rdt_to_transform['temp']
+#
+#        out_cond = out_dict['c']
+#        out_pres = out_dict['p']
+#        out_temp = out_dict['t']
+#
+#        self.assertTrue(numpy.array_equal(in_cond,out_cond))
+#        self.assertTrue(numpy.array_equal(in_pressure, out_pres))
+#        self.assertTrue(numpy.array_equal(in_temp,out_temp))

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L2.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L2.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python
+
+"""
+@brief Test to check CTD
+@author Swarbhanu Chatterjee
+"""
+
+
+
+from pyon.ion.stream import  StandaloneStreamPublisher
+from pyon.public import log, IonObject, RT, PRED
+from pyon.util.int_test import IonIntegrationTestCase
+from pyon.ion.stream import StandaloneStreamSubscriber
+from nose.plugins.attrib import attr
+
+from interface.objects import ProcessDefinition
+from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
+from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
+from interface.services.sa.idata_process_management_service import DataProcessManagementServiceClient
+from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
+from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
+
+from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
+from ion.services.dm.utility.granule.record_dictionary import RecordDictionaryTool
+from ion.services.dm.utility.granule_utils import time_series_domain
+from coverage_model import QuantityType
+
+import gevent
+import numpy, random
+
+from seawater.gibbs import SP_from_cndr, rho, SA_from_SP
+from seawater.gibbs import cte
+
+@attr('INT', group='dm')
+class TestCTDPChain(IonIntegrationTestCase):
+    def setUp(self):
+        super(CtdTransformsIntTest, self).setUp()
+
+        self._start_container()
+        self.container.start_rel_from_url('res/deploy/r2deploy.yml')
+
+        self.pubsub            = PubsubManagementServiceClient()
+        self.process_dispatcher = ProcessDispatcherServiceClient()
+        self.dataset_management = DatasetManagementServiceClient()
+        self.data_process_management = DataProcessManagementServiceClient()
+        self.dataproduct_management = DataProductManagementServiceClient()
+        self.resource_registry = ResourceRegistryServiceClient()
+
+        # This is for the time values inside the packets going into the transform
+        self.i = 0
+        self.cnt = 0
+
+        # Cleanup of queue created by the subscriber
+        self.queue_cleanup = []
+
+    def _get_new_ctd_L1_packet(self, stream_definition_id, length):
+
+        rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
+        rdt['time'] = numpy.arange(self.i, self.i+length)
+
+        for field in rdt:
+            if isinstance(rdt._pdict.get_context(field).param_type, QuantityType):
+                rdt[field] = numpy.array([random.uniform(0.0,75.0)  for i in xrange(length)])
+
+        g = rdt.to_granule()
+        self.i+=length
+
+        return g
+
+    def clean_queues(self):
+        for queue in self.queue_cleanup:
+            xn = self.container.ex_manager.create_xn_queue(queue)
+            xn.delete()
+
+    def _prepare_stream_for_transform_chain(self):
+
+        # Get the stream definition for the stream using the parameter dictionary
+        #todo Check whether the right parameter dictionary is being used
+        pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
+        stream_def_id = self.pubsub.create_stream_definition(name='stream_def_for_CTDBP_transforms', parameter_dictionary_id=pdict_id)
+
+        log.debug("Got the parsed parameter dictionary: id: %s", pdict_id)
+        log.debug("Got the stream def for parsed input: %s", stream_def_id)
+
+
+    def _get_class_module(self, name_of_transform):
+
+        options = {'L0' : self._class_module_L0,
+                   'L1' : self._class_module_L1,
+                   'L2_density' : self._class_module_L2_density,
+                   'L2_salinity' : self._class_module_L2_salinity}
+
+        return options[name_of_transform]()
+
+    def _class_module_L0(self):
+        module = 'ion.processes.data.transforms.ctdbp.ctdbp_L0'
+        class_name = 'CTDBP_L0_all'
+        return module, class_name
+
+    def _class_module_L1(self):
+
+        module = 'ion.processes.data.transforms.ctdbp.ctdbp_L1'
+        class_name = 'CTDBP_L1_Transform'
+        return module, class_name
+
+    def _class_module_L2_density(self):
+
+        module = 'ion.processes.data.transforms.ctdbp.ctdbp_L2_density'
+        class_name = 'CTDBP_DensityTransform'
+
+        return module, class_name
+
+    def _class_module_L2_salinity(self):
+
+        module = 'ion.processes.data.transforms.ctdbp.ctdbp_L2_salinity'
+        class_name = 'CTDBP_SalinityTransform'
+
+        return module, class_name
+
+    def _create_input_data_product(self, name_of_transform = '', tdom = None, sdom = None, stream_def_id = None):
+
+        dpod_obj = IonObject(RT.DataProduct,
+            name='in_data_prod_for_%s' % name_of_transform,
+            description='in_data_prod_for_%s' % name_of_transform,
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        dpod_id = self.dataproduct_management.create_data_product(data_product=dpod_obj,
+            stream_definition_id=stream_def_id
+        )
+
+        return dpod_id
+
+    def _create_output_data_product(self, name_of_transform = '', tdom = None, sdom = None, stream_def_id = None):
+
+        dpod_obj = IonObject(RT.DataProduct,
+            name='out_data_prod_for_%s' % name_of_transform,
+            description='out_data_prod_for_%s' % name_of_transform,
+            temporal_domain = tdom,
+            spatial_domain = sdom)
+
+        dpod_id = self.dataproduct_management.create_data_product(data_product=dpod_obj,
+            stream_definition_id=stream_def_id
+        )
+
+        return dpod_id
+
+    def _launch_a_ctdbp_transform(self, name_of_transform = ''):
+
+        module, class_name = self._get_class_module(name_of_transform)
+
+        #-------------------------------------------------------------------------
+        # Data Process Definition
+        #-------------------------------------------------------------------------
+
+        dpd_obj = IonObject(RT.DataProcessDefinition,
+            name= 'CTDBP_%s_Transform' % name_of_transform,
+            description= 'Data Process Definition for the CTDBP %s transform.' % name_of_transform,
+            module= module,
+            class_name=class_name)
+
+        dprocdef_density_id = self.data_process_management.create_data_process_definition(dpd_obj)
+        log.debug("created data process definition: id = %s", dprocdef_density_id)
+
+        #-------------------------------------------------------------------------
+        # Construct temporal and spatial Coordinate Reference System objects for the data product objects
+        #-------------------------------------------------------------------------
+
+        tdom, sdom = time_series_domain()
+        sdom = sdom.dump()
+        tdom = tdom.dump()
+
+        #-------------------------------------------------------------------------
+        # Input data product
+        #-------------------------------------------------------------------------
+        input_dpod_id = self._create_input_data_product(tdom, sdom, stream_def_id)
+
+        #-------------------------------------------------------------------------
+        # output data product
+        #-------------------------------------------------------------------------
+        output_dpod_id = self._create_output_data_product(tdom, sdom, stream_def_id)
+
+    def _launch_L0_transform(self, input_dpod_id = None, output_dpod_id = None):
+
+
+
+        # We need the key name here to be "L2_stream", since when the data process is launched, this name goes into
+        # the config as in config.process.publish_streams.L2_stream when the config is used to launch the data process
+        self.output_products = {'L2_stream' : L2_stream_dp_id}
+        out_stream_ids, _ = self.resource_registry.find_objects(L2_stream_dp_id, PRED.hasStream, RT.Stream, True)
+        output_stream_id = out_stream_ids[0]
+
+        dproc_dens_id = self.data_process_management.create_data_process( dprocdef_density_id, [input_dp_id], self.output_products)
+
+        log.debug("Created a data process for ctdbp_L2. id: %s", dproc_dens_id)
+
+        # Activate the data process
+        self.data_process_management.activate_data_process(dproc_dens_id)
+
+        #----------- Find the stream that is associated with the input data product when it was created by create_data_product() --------------------------------
+
+        stream_ids, _ = self.resource_registry.find_objects(input_dp_id, PRED.hasStream, RT.Stream, True)
+
+        input_stream_id = stream_ids[0]
+        input_stream = self.resource_registry.read(input_stream_id)
+        stream_route = input_stream.stream_route
+
+        log.debug("The input stream for the L2 transform: %s", input_stream_id)
+
+
+
+    def _launch_L2_transform(self):
+
+        self._launch_a_ctdbp_transform(name_of_transform='L2')
+
+
+    def test_ctdp_chain(self):
+        """
+        Test that packets are processed by a chain of CTDP transforms: L0, L1 and L2
+        """
+
+        #------------------------------------------------------------
+        # Launch the CTDP transforms
+        #------------------------------------------------------------
+
+        self._launch_L0_transform()
+
+        self._launch_L1_transform()
+
+        self._launch_L2_transform()
+
+        #-------------------------------------------------------------------------
+        # Start a subscriber listening to the output of each of the transforms
+        #-------------------------------------------------------------------------
+
+        ar_L0 = self.start_subscriber_listening_to_L0_transform()
+        ar_L1 = self.start_subscriber_listening_to_L1_transform()
+        ar_L2 = self.start_subscriber_listening_to_L2_transform()
+
+        #-------------------------------------------------------------------
+        # Publish the parsed packets that the L0 transform is listening for
+        #-------------------------------------------------------------------
+
+        self._publish_for_L0_transform(input_stream_id, stream_route)
+
+        #-------------------------------------------------------------------
+        # Check the granules being outputted by the transforms
+        #-------------------------------------------------------------------
+        self._check_granule_from_L0_transform(ar_L0)
+        self._check_granule_from_L1_transform(ar_L1)
+        self._check_granule_from_L2_transform(ar_L2)
+
+    def start_subscriber_listening_to_L0_transform(self):
+
+        #----------- Create subscribers to listen to the two transforms --------------------------------
+
+        ar_L0 = self._start_subscriber_to_transform( name_of_transform = 'L0',stream_id=output_stream_id)
+
+        return ar_L0
+
+
+    def start_subscriber_listening_to_L1_transform(self):
+
+        #----------- Create subscribers to listen to the two transforms --------------------------------
+
+        ar_L1 = self._start_subscriber_to_transform( name_of_transform = 'L1',stream_id=output_stream_id)
+
+        return ar_L1
+
+
+    def start_subscriber_listening_to_L2_transform(self):
+
+        #----------- Create subscribers to listen to the two transforms --------------------------------
+
+        ar_L2 = self._start_subscriber_to_transform( name_of_transform = 'L2',stream_id=output_stream_id)
+
+        return ar_L2
+
+    def _start_subscriber_to_transform(self,  name_of_transform = '', stream_id = ''):
+
+        ar = gevent.event.AsyncResult()
+        def subscriber(m,r,s):
+            ar.set(m)
+
+        sub = StandaloneStreamSubscriber(exchange_name='sub_%s' % name_of_transform, callback=subscriber)
+
+        # Note that this running the below line creates an exchange since none of that name exists before
+        sub_id = self.pubsub.create_subscription('subscriber_to_transform_%s' % name_of_transform,
+            stream_ids=[stream_id],
+            exchange_name='sub_%s' % name_of_transform)
+
+        self.pubsub.activate_subscription(sub_id)
+
+        # Cleanups for the subscriber
+        self.addCleanup(sub.stop)
+        self.queue_cleanup.append(sub.xn.queue)
+        self.addCleanup(self.clean_queues)
+
+        sub.start()
+
+        return ar
+
+    def _check_granule_from_L0_transform(self, ar = None):
+
+        granule_from_transform = ar.get(timeout=20)
+        log.debug("Got the following granule from the L0 transform: %s", granule_from_transform)
+
+        # Check the algorithm being applied
+        self._check_application_of_L0_algorithm(granule)
+
+
+    def _check_granule_from_L1_transform(self, ar = None):
+
+        granule_from_transform = ar.get(timeout=20)
+        log.debug("Got the following granule from the L1 transform: %s", granule_from_transform)
+
+        # Check the algorithm being applied
+        self._check_application_of_L1_algorithm(granule_from_transform)
+
+    def _check_granule_from_L2_transform(self, ar = None):
+
+        granule_from_transform = ar.get(timeout=20)
+        log.debug("Got the following granule from the L2 transform: %s", granule_from_transform)
+
+        # Check the algorithm being applied
+        self._check_application_of_L2_algorithm(granule_from_transform)
+
+    def _check_application_of_L0_algorithm(self, granule = None):
+        """ Check the algorithm applied by the L0 transform """
+        pass
+
+    def _check_application_L1_algorithm(self, granule = None):
+        """ Check the algorithm applied by the L1 transform """
+        pass
+
+    def _check_application_L2_algorithm(self, granule = None):
+        """ Check the algorithm applied by the L2 transform """
+        pass
+
+    def _publish_for_L0_transform(self, input_stream_id = None, stream_route = None):
+
+        #----------- Publish on that stream so that the transform can receive it --------------------------------
+        self._publish_to_transform(input_stream_id, stream_route )
+
+    def _publish_to_transform(self, stream_id = '', stream_route = None):
+
+        pub = StandaloneStreamPublisher(stream_id, stream_route)
+        publish_granule = self._get_new_ctd_L1_packet(stream_definition_id=L1_stream_def_id, length = 5)
+        pub.publish(publish_granule)
+
+        log.debug("Published the following granule: %s", publish_granule)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#    def check_cond_algorithm_execution(self, publish_granule, granule_from_transform):
+#
+#        input_rdt_to_transform = RecordDictionaryTool.load_from_granule(publish_granule)
+#        output_rdt_transform = RecordDictionaryTool.load_from_granule(granule_from_transform)
+#
+#        output_data = output_rdt_transform['conductivity']
+#        input_data = input_rdt_to_transform['conductivity']
+#
+#        self.assertTrue(numpy.array_equal(((input_data / 100000.0) - 0.5), output_data))
+#
+#
+#    def check_granule_splitting(self, publish_granule, out_dict):
+#        """
+#        This checks that the ctd_L2_all transform is able to split out one of the
+#        granules from the whole granule
+#        fed into the transform
+#        """
+#
+#        input_rdt_to_transform = RecordDictionaryTool.load_from_granule(publish_granule)
+#
+#        in_cond = input_rdt_to_transform['conductivity']
+#        in_pressure = input_rdt_to_transform['pressure']
+#        in_temp = input_rdt_to_transform['temp']
+#
+#        out_cond = out_dict['c']
+#        out_pres = out_dict['p']
+#        out_temp = out_dict['t']
+#
+#        self.assertTrue(numpy.array_equal(in_cond,out_cond))
+#        self.assertTrue(numpy.array_equal(in_pressure, out_pres))
+#        self.assertTrue(numpy.array_equal(in_temp,out_temp))

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_chain_L0_L1_L2.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_chain_L0_L1_L2.py
@@ -54,6 +54,7 @@ class TestCTDPChain(IonIntegrationTestCase):
 
         # Cleanup of queue created by the subscriber
         self.queue_cleanup = []
+        self.data_process_cleanup = []
 
     def _get_new_ctd_L1_packet(self, stream_definition_id, length):
 
@@ -74,6 +75,9 @@ class TestCTDPChain(IonIntegrationTestCase):
             xn = self.container.ex_manager.create_xn_queue(queue)
             xn.delete()
 
+    def cleaning_operations(self):
+        for dproc_id in self.data_process_cleanup:
+            self.data_process_management.delete_data_process(dproc_id)
 
     def test_ctdp_chain(self):
         """
@@ -299,8 +303,8 @@ class TestCTDPChain(IonIntegrationTestCase):
             config = self._create_calibration_coefficients_dict()
 
         data_proc_id = self.data_process_management.create_data_process( data_proc_def_id, [input_dpod_id], output_products, config)
+        self.data_process_cleanup.append(data_proc_id)
 
-        # Activate the data process
         self.data_process_management.activate_data_process(data_proc_id)
 
         log.debug("Created a data process for ctdbp %s transform: id = %s", name_of_transform, data_proc_id)

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_chain_L0_L1_L2.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_chain_L0_L1_L2.py
@@ -519,7 +519,9 @@ class TestCTDPChain(IonIntegrationTestCase):
         #create temp streamdef so the data product can create the stream
         pc_list = []
         for pc_k, pc in pdict.iteritems():
-            pc_list.append(self.dataset_management.create_parameter_context(pc_k, pc[1].dump()))
+            ctxt_id = self.dataset_management.create_parameter_context(pc_k, pc[1].dump())
+            pc_list.append(ctxt_id)
+            self.addCleanup(self.dataset_management.delete_parameter_context,ctxt_id)
 
         pdict_id = self.dataset_management.create_parameter_dictionary(parameter_dict_name, pc_list)
 

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_chain_L0_L1_L2.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_chain_L0_L1_L2.py
@@ -139,8 +139,8 @@ class TestCTDPChain(IonIntegrationTestCase):
         #-------------------------------------------------------------------
         self._check_granule_from_L0_transform(ar_L0)
         self._check_granule_from_L1_transform(ar_L1)
-        self._check_granule_from_L2_transform(ar_L2_density)
-        self._check_granule_from_L2_transform(ar_L2_salinity)
+        self._check_granule_from_L2_density_transform(ar_L2_density)
+        self._check_granule_from_L2_salinity_transform(ar_L2_salinity)
 
 
     def _prepare_stream_def_for_transform_chain(self, parameter_dict_name = ''):
@@ -403,25 +403,61 @@ class TestCTDPChain(IonIntegrationTestCase):
         # Check the algorithm being applied
         self._check_application_of_L1_algorithm(granule_from_transform)
 
-    def _check_granule_from_L2_transform(self, ar = None):
+    def _check_granule_from_L2_density_transform(self, ar = None):
 
         granule_from_transform = ar.get(timeout=20)
         log.debug("Got the following granule from the L2 transform: %s", granule_from_transform)
 
         # Check the algorithm being applied
-        self._check_application_of_L2_algorithm(granule_from_transform)
+        self._check_application_of_L2_density_algorithm(granule_from_transform)
+
+    def _check_granule_from_L2_salinity_transform(self, ar = None):
+
+        granule_from_transform = ar.get(timeout=20)
+        log.debug("Got the following granule from the L2 transform: %s", granule_from_transform)
+
+        # Check the algorithm being applied
+        self._check_application_of_L2_salinity_algorithm(granule_from_transform)
+
 
     def _check_application_of_L0_algorithm(self, granule = None):
         """ Check the algorithm applied by the L0 transform """
-        pass
+
+        rdt = RecordDictionaryTool.load_from_granule(granule)
+
+        for key, value in rdt.iteritems():
+            list_of_expected_keys = ['lat', 'lon', 'time', 'pressure', 'conductivity', 'temperature']
+            if key not in list_of_expected_keys:
+                self.fail("The L0 transform is sending out data for more parameters than it should")
+
 
     def _check_application_of_L1_algorithm(self, granule = None):
         """ Check the algorithm applied by the L1 transform """
-        pass
+        rdt = RecordDictionaryTool.load_from_granule(granule)
 
-    def _check_application_of_L2_algorithm(self, granule = None):
+        for key, value in rdt.iteritems():
+            list_of_expected_keys = ['lat', 'lon', 'time', 'pressure', 'conductivity', 'temperature']
+            if key not in list_of_expected_keys:
+                self.fail("The L1 transform is sending out data for more parameters than it should")
+
+    def _check_application_of_L2_density_algorithm(self, granule = None):
         """ Check the algorithm applied by the L2 transform """
-        pass
+        rdt = RecordDictionaryTool.load_from_granule(granule)
+
+        for key, value in rdt.iteritems():
+            list_of_expected_keys = ['lat', 'lon', 'time', 'density']
+            if key not in list_of_expected_keys:
+                self.fail("The L2 density transform is sending out data for more parameters than it should")
+
+    def _check_application_of_L2_salinity_algorithm(self, granule = None):
+        """ Check the algorithm applied by the L2 transform """
+        rdt = RecordDictionaryTool.load_from_granule(granule)
+
+        for key, value in rdt.iteritems():
+            list_of_expected_keys = ['lat', 'lon', 'time', 'salinity']
+            if key not in list_of_expected_keys:
+                self.fail("The L2 salinity transform is sending out data for more parameters than it should")
+
 
     def _publish_for_L0_transform(self, input_stream_id = None, stream_route = None):
 


### PR DESCRIPTION
- Adds the CTDBP L0, L1, L2 salinity and L2 density transforms.
- Note that there is one L0 transform, one L1 transform and two L2 transforms.
- Adds integration tests: one each for L0 and L1, and another integration test which links L0, L1 and the two L2 (density and salinity) transforms together in a chain and checks that the granules published by each is the right kind.
- For the test, we are using fictitious values of calibration coefficients. If we later know about the calibration coefficients used in the real world, maybe those could be imported later for the test. Note that these CTDBP transforms are not going to stay for long. They are only for the pathfinder. Pending changes to the transform structure, they might be replaced.
- What may be added later is more assertions to check that the algorithms have been performed. So far we are only checking that the granules published by each transform contains data for the appropriate parameters.
- Also, in test_ctd_transforms.py, there were lines that were unnecessary, so they have been removed.
