### PR TITLE
Ion functions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "extern/eeagent"]
 	path = extern/eeagent
 	url = https://github.com/ooici/eeagent.git
+[submodule "extern/ion-functions"]
+	path = extern/ion-functions
+	url = https://github.com/ooici/ion-functions.git

--- a/README
+++ b/README
@@ -47,6 +47,12 @@ For Mac, use homebrew
     (If you have trouble with brew 'MD5 mismatch' errors, try running 'brew update'
     and try the install again)
 
+- Install libgswteos-10 for marine science calculations
+    > brew tap lukecampbell/homebrew-libgswteos
+    > brew install libgswteos-10
+    > brew test -v libgswteos-10
+    
+
 
 installation
 - Install

--- a/build.xml
+++ b/build.xml
@@ -41,6 +41,7 @@
             <fileset dir="extern/pyon" includes="**/*.pyc"/>
             <fileset dir="extern/marine-integrations" includes="**/*.pyc"/>
             <fileset dir="extern/coverage-model" includes="**/*.pyc"/>
+            <fileset dir="extern/ion-functions" includes="**/*.pyc"/>
             <fileset dir="extern/parameter-definitions" includes="**/*.pyc"/>
         </delete>
         <delete dir="interface" failonerror="false"/>

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -5,6 +5,7 @@ develop =
     extern/pyon
     extern/epu
     extern/eeagent
+    extern/ion-functions
 parts =
     project-directories
     numpy-install

--- a/ion/services/coi/service_gateway_service.py
+++ b/ion/services/coi/service_gateway_service.py
@@ -702,6 +702,7 @@ def get_version_info():
     pkg_list = ["coi-services",
                 "pyon",
                 "coverage-model",
+                "ion-functions",
                 "eeagent",
                 "epu",
                 "utilities",

--- a/pyon_buildout.cfg
+++ b/pyon_buildout.cfg
@@ -5,3 +5,4 @@ develop =
     ../pyon
     extern/coverage-model
     extern/marine-integrations
+    extern/ion-functions

--- a/pyon_mi_buildout.cfg
+++ b/pyon_mi_buildout.cfg
@@ -5,3 +5,4 @@ develop =
     ../pyon
     ../marine-integrations
     extern/coverage-model
+    extern/ion-functions

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(  name = 'coi-services',
         install_requires = [
             'pyzmq==2.2.0',
             'coverage-model',
+            'ion-functions',
             'pyon',
             'Flask==0.9',
             'python-dateutil==1.5',


### PR DESCRIPTION
## Adds a new submodule for marine science functions

This will require a buildout to accomodate the changes. Very important component is that developers will need to include the libgswteos-10 library:

``` bash
brew tap lukecampbell/hombrew-libgswteos
brew install libgswteos-10
brew test -v libgswteos-10
```

A subsequent buildout will include all of the necessary libraries. 

This submodule will host a repository for authors to define and manage functions to execute marine science calculations. These are required to calculate the marine seawater variables used ultimately for deriving data products from instrument variables.
