### PR TITLE
expanding parser for 'simple' dicts

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -871,7 +871,7 @@ class IONLoader(ImmediateProcess):
 
         which would translate back to
         { "PARAMETERS": { "TXWAVESTATS": False, "TXREALTIME": True, "TXWAVEBURST": "false" },
-          "SCHEDULER": { "ACQUIRE_STATUS": { }, "CLOCK_SYNC", 48.3, "VERSION": "3.0"}
+          "SCHEDULER": { "ACQUIRE_STATUS": { }, "CLOCK_SYNC", 48.2, "VERSION": "3.0"}
         }
 
         """

--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -849,16 +849,80 @@ class IONLoader(ImmediateProcess):
         self.contact_defs[id] = contact
 
     def _parse_dict(self, text):
-        """ parse a SIMPLE dictionary of unquoted string keys and values
         """
+        parse a "simple" dictionary of unquoted string keys and values. -- no nested values, no complex characters
+
+        But is it really simple?  Not quite.  The following substitutions are made:
+
+        keys with dots ('.') will be split into dictionaries.
+        booleans "True", "False" will be parsed
+        numbers will be parsed as floats unless they begin with "0" or include one "." and end with "0"
+        "{}" will be converted to {}
+        "[]" will be converted to [] (that's "[ ]" with no space)
+
+        For example, an entry in preload would be this:
+
+        PARAMETERS.TXWAVESTATS: False,
+        PARAMETERS.TXREALTIME: True,
+        PARAMETERS.TXWAVEBURST: false,
+        SCHEDULER.ACQUIRE_STATUS: {},
+        SCHEDULER.CLOCK_SYNC: 48.2
+        SCHEDULER.VERSION: 3.0
+
+        which would translate back to
+        { "PARAMETERS": { "TXWAVESTATS": False, "TXREALTIME": True, "TXWAVEBURST": "false" },
+          "SCHEDULER": { "ACQUIRE_STATUS": { }, "CLOCK_SYNC", 48.3, "VERSION": "3.0"}
+        }
+
+        """
+
+        substitutions = {"{}": {}, "[]": [], "True": True, "False": False}
+
+        def parse_value(some_val):
+            if some_val in substitutions:
+                return substitutions[some_val]
+
+            try:
+                int_val = int(some_val)
+                if str(int_val) == some_val:
+                    return int_val
+            except ValueError:
+                pass
+
+            try:
+                float_val = float(some_val)
+                if str(float_val) == some_val:
+                    return float_val
+            except ValueError:
+                pass
+
+            return some_val
+
         out = { }
-        pairs = text.split(',')
+        pairs = text.split(',') # pairs separated by commas
         for pair in pairs:
-            fields = pair.split(':')
+            fields = pair.split(':') # pair separated by colon
             key = fields[0].strip()
             value = fields[1].strip()
-            out[key] = value
+
+            dotcount = key.count(".")
+            if 1 < dotcount:
+                raise iex.BadRequest("Key field has %s '.' separators, can only handle 0 or 1" % dotcount)
+            elif 0 == dotcount:
+                out[key] = parse_value(value)
+            else:
+                keypart = key.split(".")
+                k0 = keypart[0]
+                k1 = keypart[1]
+                if not k0 in out:
+                    out[k0] = {}
+                else:
+                    if type(out[k0]) != type({}):
+                        raise iex.BadRequest("Building a dict in %s field, but it exists as %s already" %
+                                             (k0, type(out[k0])))
+                    out[k0][k1] = parse_value(value)
         return out
+
 
     def _parse_phones(self, text):
         if ':' in text:

--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -1851,6 +1851,9 @@ Reason: %s
             self._load_InstrumentAgent(fakerow)
 
     def _load_InstrumentAgentInstance(self, row):
+
+        startup_config = self._parse_dict(row['startup_config'])
+
         # define complicated attributes
         driver_config = { 'comms_config': { 'addr':  row['comms_server_address'],
                                                     'port':  int(row['comms_server_port']),
@@ -1868,7 +1871,9 @@ Reason: %s
 
         res_id = self._basic_resource_create(row, "InstrumentAgentInstance", "iai/",
             "instrument_management", "create_instrument_agent_instance",
-            set_attributes=dict(driver_config=driver_config, port_agent_config=port_agent_config),
+            set_attributes=dict(driver_config=driver_config,
+                                port_agent_config=port_agent_config,
+                                startup_config=startup_config),
             support_bulk=True)
 
         agent_id = self.resource_ids[row["instrument_agent_id"]]

--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -90,10 +90,11 @@ TESTED_UI_ASSETS = 'https://userexperience.oceanobservatories.org/database-expor
 CANDIDATE_UI_ASSETS = 'https://userexperience.oceanobservatories.org/database-exports/Candidates'
 
 ### this master URL has the latest changes, but if columns have changed, it may no longer work with this commit of the loader code
+# Edit the doc here: https://docs.google.com/spreadsheet/ccc?key=0AttCeOvLP6XMdG82NHZfSEJJOGdQTkgzb05aRjkzMEE
 MASTER_DOC = "https://docs.google.com/spreadsheet/pub?key=0AttCeOvLP6XMdG82NHZfSEJJOGdQTkgzb05aRjkzMEE&output=xls"
 
 ### the URL below should point to a COPY of the master google spreadsheet that works with this version of the loader
-TESTED_DOC = "https://docs.google.com/spreadsheet/pub?key=0AgkUKqO5m-ZidDFSc1RSaVFqVVR4OS1iS0dzejZkRmc&output=xls"
+TESTED_DOC = "https://docs.google.com/spreadsheet/pub?key=0AiJoHeWBzmnAdG1JMXlBamZrbnRSWmdjcjhqeE5XbFE&output=xls"
 #
 ### while working on changes to the google doc, use this to run test_loader.py against the master spreadsheet
 #TESTED_DOC=MASTER_DOC
@@ -901,6 +902,8 @@ class IONLoader(ImmediateProcess):
         out = { }
         pairs = text.split(',') # pairs separated by commas
         for pair in pairs:
+            if 0 == pair.count(':'):
+                continue
             fields = pair.split(':') # pair separated by colon
             key = fields[0].strip()
             value = fields[1].strip()

--- a/ion/processes/bootstrap/test/test_loader.py
+++ b/ion/processes/bootstrap/test/test_loader.py
@@ -213,3 +213,7 @@ class TestLoader(IonIntegrationTestCase):
         # check for data process definition
         self.find_object_by_name("Logical Transform Definition", RT.DataProcessDefinition)
 
+        iai = self.find_object_by_name("Test InstrumentAgentInstance", RT.InstrumentAgentInstance)
+        self.assertEqual(iai.startup_config, {'SCHEDULER': {'VERSION': 3.0, 'CLOCK_SYNC': 48.2},
+                                              'PARAMETERS': {'TXWAVEBURST': 'false', 'TXREALTIME': True}})
+


### PR DESCRIPTION
Ready to merge.  This PR adds support for more complicated 'simple' dicts.  

``` python
        But is it really simple?  Not quite.  The following substitutions are made:

        keys with dots ('.') will be split into dictionaries.
        booleans "True", "False" will be parsed
        numbers will be parsed as floats unless they begin with "0" or include one "." and end with "0"
        "{}" will be converted to {}
        "[]" will be converted to [] (that's "[ ]" with no space)

        For example, an entry in preload would be this:

        PARAMETERS.TXWAVESTATS: False,
        PARAMETERS.TXREALTIME: True,
        PARAMETERS.TXWAVEBURST: false,
        SCHEDULER.ACQUIRE_STATUS: {},
        SCHEDULER.CLOCK_SYNC: 48.2
        SCHEDULER.VERSION: 3.0

        which would translate back to
        { "PARAMETERS": { "TXWAVESTATS": False, "TXREALTIME": True, "TXWAVEBURST": "false" },
          "SCHEDULER": { "ACQUIRE_STATUS": { }, "CLOCK_SYNC", 48.2, "VERSION": "3.0"}
        }

```

In addition, startup_config is added to the preload sheet for InstrumentAgentInstance resources, imported as a "simple dict".
