### PR TITLE
CIDEVSA-499: Dicts in preload now support nested entries

### DIFF
--- a/ion/processes/bootstrap/test/test_loader.py
+++ b/ion/processes/bootstrap/test/test_loader.py
@@ -214,8 +214,9 @@ class TestLoader(IonIntegrationTestCase):
         self.find_object_by_name("Logical Transform Definition", RT.DataProcessDefinition)
 
         iai = self.find_object_by_name("Test InstrumentAgentInstance", RT.InstrumentAgentInstance)
-        self.assertEqual(iai.startup_config, {'SCHEDULER': {'VERSION': 3.0, 'CLOCK_SYNC': 48.2},
-                                              'PARAMETERS': {'TXWAVEBURST': 'false', 'TXREALTIME': True}})
+        self.assertEqual({'SCHEDULER': {'VERSION': {'number': 3.0}, 'CLOCK_SYNC': 48.2, 'ACQUIRE_STATUS': {}},
+                          'PARAMETERS': {"TXWAVESTATS": False, 'TXWAVEBURST': 'false', 'TXREALTIME': True}},
+                        iai.startup_config)
 
         orgs, _ = self.container.resource_registry.find_subjects(RT.Org, PRED.hasResource, iai._id, True)
         self.assertEqual(1, len(orgs))


### PR DESCRIPTION
Similar to DotDict syntax, the following input is now supported in "simple dict" entries in preload sheets (specifically intended for startup_config entries):

Input data:

```
grandparent.parent.child.attr1 = 3
grandparent.parent.child.attr2 = blue
```

Output data:

``` python
{'grandparent': {'parent': {'child': {'attr1': 3, 'attr2': 'blue'}}}}
```
