### PR TITLE
Fix DataProcessManagementService int tests in buildbot

### DIFF
--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -649,7 +649,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         self.clients.data_acquisition_management.unregister_process(data_process_id=data_process_id)
 
         #Delete the data process from the resource registry
-        self.clients.resource_registry.delete(object_id=data_process_id)
+        self.RR2.retire(data_process_id, RT.DataProcess)
 
     def force_delete_data_process(self, data_process_id=""):
 
@@ -658,8 +658,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         if dp_obj.lcstate != LCS.RETIRED:
             self.delete_data_process(data_process_id)
 
-        self._remove_associations(data_process_id)
-        self.clients.resource_registry.delete(data_process_id)
+        self.RR2.pluck_delete(data_process_id, RT.DataProcess)
 
     def _stop_process(self, data_process):
         log.debug("stopping data process '%s'" % data_process.process_id)

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -532,23 +532,6 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
             self.rrclient.read(ctd_l0_all_data_process_id)
 
 
-    def test_transform_function_crd(self):
-        tf = TransformFunction(name='simple', module='pyon.ion.process', cls='SimpleProcess')
-
-        tf_id = self.dataprocessclient.create_transform_function(tf)
-        self.assertTrue(tf_id)
-
-        tf2_id = self.dataprocessclient.create_transform_function(tf)
-        self.assertEquals(tf_id, tf2_id)
-
-        tf_obj = self.dataprocessclient.read_transform_function(tf_id)
-        self.assertEquals([tf.name, tf.module, tf.cls, tf.function_type], [tf_obj.name, tf_obj.module, tf_obj.cls, tf_obj.function_type])
-
-        tf.module = 'dev.null'
-        self.assertRaises(BadRequest, self.dataprocessclient.create_transform_function, tf)
-
-        self.dataprocessclient.delete_transform_function(tf_id)
-        self.assertRaises(NotFound, self.dataprocessclient.read_transform_function, tf_id)
     
 
 @attr('INT',grou='sa')


### PR DESCRIPTION
Fixes 2 tests:
- test_transform_function_crd (ion.services.sa.process.test.test_int_data_process_management_service.TestIntDataProcessManagementServiceMultiOut) - **removed.  already tested by unit test generator.**
- test_createDataProcessUsingSim (ion.services.sa.process.test.test_int_data_process_management_service.TestIntDataProcessManagementServiceMultiOut) - **typo in delete method**
