### PR TITLE
Addresses Ooiion 745 (Instrument and platform extended resource "agent" attribute sending back more than associated agent)

### DIFF
--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1558,10 +1558,11 @@ class InstrumentManagementService(BaseInstrumentManagementService):
             user_id=user_id)
 
         # clean up InstAgent list as it sometimes includes the device
-        ia = []
+        ia = None
         for agent in extended_instrument.instrument_agent:
             if agent.type_ == 'InstrumentAgent':
-                ia.append(agent)
+                ia = agent
+                break
         extended_instrument.instrument_agent = ia
 
         # Status computation
@@ -1745,10 +1746,11 @@ class InstrumentManagementService(BaseInstrumentManagementService):
         s_unknown = StatusType.STATUS_UNKNOWN
 
         # clean up platform agent list as it sometimes includes the device
-        pa = []
+        pa = None
         for agent in extended_platform.platform_agent:
             if agent.type_ == 'PlatformAgent':
-                pa.append(agent)
+                pa = agent
+                break
         extended_platform.platform_agent = pa
 
         # Status computation

--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1744,6 +1744,13 @@ class InstrumentManagementService(BaseInstrumentManagementService):
 
         s_unknown = StatusType.STATUS_UNKNOWN
 
+        # clean up platform agent list as it sometimes includes the device
+        pa = []
+        for agent in extended_platform.platform_agent:
+            if agent.type_ == 'PlatformAgent':
+                pa.append(agent)
+        extended_platform.platform_agent = pa
+
         # Status computation
         extended_platform.computed.instrument_status = [s_unknown] * len(extended_platform.instrument_devices)
         extended_platform.computed.platform_status   = [s_unknown] * len(extended_platform.platforms)

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -186,7 +186,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         #check agent
         inst_agent_obj = self.RR.read(instrument_agent_id)
         #compound assoc return list of lists so check the first element
-        self.assertEqual(inst_agent_obj.name, extended_instrument.instrument_agent[0].name)
+        self.assertEqual(inst_agent_obj.name, extended_instrument.instrument_agent.name)
 
         #check platform device
         plat_device_obj = self.RR.read(platform_device_id)
@@ -198,6 +198,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         self.assertEqual(instrument_device_id, extended_platform.instrument_devices[0]._id)
         self.assertEqual(1, len(extended_platform.instrument_models))
         self.assertEqual(instrument_model_id, extended_platform.instrument_models[0]._id)
+        self.assertEquals(extended_platform.platform_agent._id, platform_agent_id)
 
         #check sensor devices
         self.assertEqual(1, len(extended_instrument.sensor_devices))


### PR DESCRIPTION
- The extended_instrument.instrument_agent is now a single object, the instrument agent, and not a list.
- The extended_platform.platform_agent is now a single object, the platform agent, and not a  list.
