### PR TITLE
CIDEVSA-486 - added alert config to agent launch

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -2000,7 +2000,7 @@ Reason: %s
 
         alerts_config  = self._parse_dict(row['alerts'])
 
-    # Note: platform_id currently expected by PlatformAgent as follows:
+        # Note: platform_id currently expected by PlatformAgent as follows:
         agent_config = {
             'platform_config': {'platform_id': platform_id}
         }

--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -93,7 +93,7 @@ CANDIDATE_UI_ASSETS = 'https://userexperience.oceanobservatories.org/database-ex
 MASTER_DOC = "https://docs.google.com/spreadsheet/pub?key=0AttCeOvLP6XMdG82NHZfSEJJOGdQTkgzb05aRjkzMEE&output=xls"
 
 ### the URL below should point to a COPY of the master google spreadsheet that works with this version of the loader
-TESTED_DOC = "https://docs.google.com/spreadsheet/pub?key=0AgGScp7mjYjydElFSTFrbVhsZzQ3djRCOHdZVmVtZmc&output=xls"
+TESTED_DOC = "https://docs.google.com/spreadsheet/pub?key=0AiJoHeWBzmnAdHRSa0hZN0pVV0R1ME4zSzgtOXEzNmc&output=xls"
 #
 ### while working on changes to the google doc, use this to run test_loader.py against the master spreadsheet
 #TESTED_DOC=MASTER_DOC
@@ -1909,6 +1909,7 @@ Reason: %s
     def _load_InstrumentAgentInstance(self, row):
 
         startup_config = self._parse_dict(row['startup_config'])
+        alerts_config  = self._parse_dict(row['alerts'])
 
         # define complicated attributes
         driver_config = { 'comms_config': { 'addr':  row['comms_server_address'],
@@ -1929,7 +1930,8 @@ Reason: %s
             "instrument_management", "create_instrument_agent_instance",
             set_attributes=dict(driver_config=driver_config,
                                 port_agent_config=port_agent_config,
-                                startup_config=startup_config),
+                                startup_config=startup_config,
+                                alerts=alerts_config),
             support_bulk=True)
 
         agent_id = self.resource_ids[row["instrument_agent_id"]]
@@ -1996,7 +1998,9 @@ Reason: %s
         driver_config = self._parse_dict(row['driver_config'])
         log.debug("driver_config = %s", driver_config)
 
-        # Note: platform_id currently expected by PlatformAgent as follows:
+        alerts_config  = self._parse_dict(row['alerts'])
+
+    # Note: platform_id currently expected by PlatformAgent as follows:
         agent_config = {
             'platform_config': {'platform_id': platform_id}
         }
@@ -2005,7 +2009,8 @@ Reason: %s
         res_id = self._basic_resource_create(row, "PlatformAgentInstance", "pai/",
             "instrument_management", "create_platform_agent_instance",
             set_attributes=dict(agent_config=agent_config,
-                                driver_config=driver_config),
+                                driver_config=driver_config,
+                                alerts=alerts_config),
             support_bulk=True)
 
         client = self._get_service_client("instrument_management")

--- a/ion/processes/bootstrap/test/test_loader.py
+++ b/ion/processes/bootstrap/test/test_loader.py
@@ -217,6 +217,10 @@ class TestLoader(IonIntegrationTestCase):
         self.assertEqual({'SCHEDULER': {'VERSION': {'number': 3.0}, 'CLOCK_SYNC': 48.2, 'ACQUIRE_STATUS': {}},
                           'PARAMETERS': {"TXWAVESTATS": False, 'TXWAVEBURST': 'false', 'TXREALTIME': True}},
                         iai.startup_config)
+        self.assertEqual({'entry': 'foo'}, iai.alerts['complex'])
+
+        pai = self.find_object_by_name("Unit Test Platform Agent Instance", RT.PlatformAgentInstance)
+        self.assertEqual({'entry': 'foo'}, pai.alerts['complex'])
 
         orgs, _ = self.container.resource_registry.find_subjects(RT.Org, PRED.hasResource, iai._id, True)
         self.assertEqual(1, len(orgs))

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -207,9 +207,9 @@ class AgentConfigurationBuilder(object):
         # should override this
         return {}
 
-    def _generate_alarms_config(self):
+    def _generate_alerts_config(self):
         # should override this
-        return {}
+        return self.agent_instance_obj.alerts
 
     def _generate_startup_config(self):
         # should override this
@@ -224,14 +224,14 @@ class AgentConfigurationBuilder(object):
         agent_config = self.agent_instance_obj.agent_config
 
         # Create agent_ config.
-        agent_config['org_name']       = self._generate_org_name()
-        agent_config['device_type']    = self._generate_device_type()
-        agent_config['driver_config']  = self._generate_driver_config()
-        agent_config['stream_config']  = self._generate_stream_config()
-        agent_config['agent']          = self._generate_agent_config()
-        agent_config['alarm_defs']     = self._generate_alarms_config()
-        agent_config['startup_config'] = self._generate_startup_config()
-        agent_config['children']       = self._generate_children()
+        agent_config['org_name']            = self._generate_org_name()
+        agent_config['device_type']         = self._generate_device_type()
+        agent_config['driver_config']       = self._generate_driver_config()
+        agent_config['stream_config']       = self._generate_stream_config()
+        agent_config['agent']               = self._generate_agent_config()
+        agent_config['aparam_alert_config'] = self._generate_alerts_config()
+        agent_config['startup_config']      = self._generate_startup_config()
+        agent_config['children']            = self._generate_children()
 
         return agent_config
 
@@ -416,9 +416,6 @@ class InstrumentAgentConfigurationBuilder(AgentConfigurationBuilder):
         self._augment_dict("Instrument Agent driver_config", driver_config, add_driver_config)
 
         return driver_config
-
-
-
 
 
 class PlatformAgentConfigurationBuilder(AgentConfigurationBuilder):


### PR DESCRIPTION
Added a column called "alerts" for instrument and platform agent instances in preload.  The value is a "simple dict" exactly like it is for driver config.  This config is put into the agent config under the key "aparam_alert_config" as per Edward's needs.

test_loader.py tests added to confirm preload behavior, IMS tests updated to confirm config behavior.  SMOKE tests pass.
