### PR TITLE
Rename Parameters with their ID to prevent duplicate parameters inside data containers

### DIFF
--- a/ion/agents/instrument/instrument_agent.py
+++ b/ion/agents/instrument/instrument_agent.py
@@ -862,7 +862,11 @@ class InstrumentAgent(ResourceAgent):
                             data_arrays['time'][i] = tv    
             
             for (k,v) in data_arrays.iteritems():
-                rdt[k] = numpy.array(v)
+                try:
+                    rdt[k] = v
+                except:
+                    log.error('Problem with %s incorrect value: %s', repr(k), repr(v))
+                    raise
             
             log.info('Outgoing granule: %s' % ['%s: %s'%(k,v) for k,v in rdt.iteritems()])
             g = rdt.to_granule(data_producer_id=self.resource_id)

--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -1494,6 +1494,14 @@ Reason: %s
 
         name = row['name']
         definitions = row['parameter_ids'].replace(' ','').split(',')
+        try:
+            if row['temporal_parameter']:
+                temporal_parameter_name = self.resource_objs[row['temporal_parameter']].name
+            else:
+                temporal_parameter_name = ''
+        except KeyError:
+            temporal_parameter_name = ''
+
 
         context_ids = {}
         for i in definitions:
@@ -1512,7 +1520,7 @@ Reason: %s
             return
         dataset_management = self._get_service_client('dataset_management')
         try:
-            pdict_id = dataset_management.create_parameter_dictionary(name=name, parameter_context_ids=context_ids.keys(), temporal_context=row['temporal_parameter'], headers=self._get_system_actor_headers())
+            pdict_id = dataset_management.create_parameter_dictionary(name=name, parameter_context_ids=context_ids.keys(), temporal_context=temporal_parameter_name, headers=self._get_system_actor_headers())
         except:
             log.exception( '%s has a problem', row['name'])
             return
@@ -1567,7 +1575,9 @@ Reason: %s
         pmap         = row['Parameter Function Map']
         sname        = row['Data Product Identifier']
         precision    = row['Precision']
+        param_id     = row['ID']
 
+        name = '%s_%s' %(name,param_id)
         try:
             param_type = get_parameter_type(ptype, encoding,code_set,pfid, pmap)
             context = ParameterContext(name=name, param_type=param_type)
@@ -1655,7 +1665,7 @@ Reason: %s
             else:
                 self._conflict_report(row['ID'], row['Name'], e.message)
                 return
-        self._register_id(row[COL_ID], context_id)
+        self._register_id(row[COL_ID], context_id, context)
         parameter_lookups[row[COL_ID]] = name
 
 

--- a/ion/processes/data/transforms/ctd/test/test_ctd_transforms.py
+++ b/ion/processes/data/transforms/ctd/test/test_ctd_transforms.py
@@ -836,11 +836,11 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
     def _get_new_ctd_packet(self, stream_definition_id, length):
 
         rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
-        rdt['time'] = numpy.arange(self.i, self.i+length)
 
         for field in rdt:
             if isinstance(rdt._pdict.get_context(field).param_type, QuantityType):
                 rdt[field] = numpy.array([random.uniform(0.0,75.0)  for i in xrange(length)])
+        rdt['time'] = numpy.arange(self.i, self.i+length)
 
         g = rdt.to_granule()
         self.i+=length

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L0.py
@@ -51,11 +51,11 @@ class CtdbpTransformsIntTest(IonIntegrationTestCase):
     def _get_new_ctd_packet(self, stream_definition_id, length):
 
         rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
-        rdt['time'] = numpy.arange(self.i, self.i+length)
 
         for field in rdt:
             if isinstance(rdt._pdict.get_context(field).param_type, QuantityType):
                 rdt[field] = numpy.array([random.uniform(0.0,75.0)  for i in xrange(length)])
+        rdt['time'] = numpy.arange(self.i, self.i+length)
 
         g = rdt.to_granule()
         self.i+=length

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_L1.py
@@ -106,11 +106,11 @@ class CtdTransformsIntTest(IonIntegrationTestCase):
     def _get_new_ctd_L0_packet(self, stream_definition_id, length):
 
         rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
-        rdt['time'] = numpy.arange(self.i, self.i+length)
 
         for field in rdt:
             if isinstance(rdt._pdict.get_context(field).param_type, QuantityType):
                 rdt[field] = numpy.array([random.uniform(0.0,75.0)  for i in xrange(length)])
+        rdt['time'] = numpy.arange(self.i, self.i+length)
 
         g = rdt.to_granule()
         self.i+=length

--- a/ion/processes/data/transforms/ctdbp/test/test_ctdbp_chain_L0_L1_L2.py
+++ b/ion/processes/data/transforms/ctdbp/test/test_ctdbp_chain_L0_L1_L2.py
@@ -57,11 +57,11 @@ class TestCTDPChain(IonIntegrationTestCase):
     def _get_new_ctd_L0_packet(self, stream_definition_id, length):
 
         rdt = RecordDictionaryTool(stream_definition_id=stream_definition_id)
-        rdt['time'] = numpy.arange(self.i, self.i+length)
 
         for field in rdt:
             if isinstance(rdt._pdict.get_context(field).param_type, QuantityType):
                 rdt[field] = numpy.array([random.uniform(0.0,75.0)  for i in xrange(length)])
+        rdt['time'] = numpy.arange(self.i, self.i+length)
 
         g = rdt.to_granule()
         self.i+=length

--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -197,10 +197,10 @@ class TestDMEnd2End(IonIntegrationTestCase):
         done = False
         with gevent.Timeout(40):
             while not done:
-                extents = self.dataset_management.dataset_extents(dataset_id, 'time')[0]
+                extents = self.dataset_management.dataset_extents(dataset_id, 'time_PD7')[0]
                 granule = self.data_retriever.retrieve_last_data_points(dataset_id, 1)
                 rdt     = RecordDictionaryTool.load_from_granule(granule)
-                if rdt['time'] and rdt['time'][0] != rdt._pdict.get_context('time').fill_value and extents >= data_size:
+                if rdt['time'] and rdt['time'][0] != rdt._pdict.get_context('time_PD7').fill_value and extents >= data_size:
                     done = True
                 else:
                     gevent.sleep(0.2)

--- a/ion/services/dm/utility/granule/record_dictionary.py
+++ b/ion/services/dm/utility/granule/record_dictionary.py
@@ -86,6 +86,15 @@ class RecordDictionaryTool(object):
         retval = np.atleast_1d(self[name])
         return retval[slice_]
 
+    def _get_field_name(self, field_name):
+        field_pool = [f for f in self.fields if f.startswith(field_name)]
+        if len(field_pool) == 1:
+            return field_pool[0]
+        elif len(field_pool) > 0:
+            raise KeyError('%s has multiple parameters' % field_name)
+        else:
+            return field_name # Let it happen
+
     @classmethod
     def get_paramval(cls, ptype, domain, values):
         paramval = get_value_class(ptype, domain_set=domain)
@@ -165,6 +174,7 @@ class RecordDictionaryTool(object):
         return self._pdict.temporal_parameter_name
 
     def fill_value(self,name):
+        name = self._get_field_name(name)
         return self._pdict.get_context(name).fill_value
 
     def _replace_hook(self, name,vals):
@@ -188,6 +198,7 @@ class RecordDictionaryTool(object):
         return np.atleast_1d(vals)
 
     def __setitem__(self, name, vals):
+        name = self._get_field_name(name)
         return self._set(name, self._replace_hook(name,vals))
 
     def _set(self, name, vals):
@@ -240,6 +251,7 @@ class RecordDictionaryTool(object):
         """
         Get an item by nick name from the record dictionary.
         """
+        name = self._get_field_name(name)
         if self._available_fields and name not in self._available_fields:
             raise KeyError(name)
         if self._rd[name] is not None:

--- a/ion/services/dm/utility/test/test_granule.py
+++ b/ion/services/dm/utility/test/test_granule.py
@@ -92,10 +92,10 @@ class RecordDictionaryIntegrationTest(IonIntegrationTestCase):
         self.pubsub_management.deactivate_subscription(subscription_id)
         self.pubsub_management.delete_subscription(subscription_id)
         
-        filtered_stream_def_id = self.pubsub_management.create_stream_definition('filtered', parameter_dictionary_id=pdict_id, available_fields=['time', 'temp'])
+        filtered_stream_def_id = self.pubsub_management.create_stream_definition('filtered', parameter_dictionary_id=pdict_id, available_fields=['time_PD7', 'temp_PD6'])
         self.addCleanup(self.pubsub_management.delete_stream_definition, filtered_stream_def_id)
         rdt = RecordDictionaryTool(stream_definition_id=filtered_stream_def_id)
-        self.assertEquals(rdt._available_fields,['time','temp'])
+        self.assertEquals(rdt._available_fields,['time_PD7','temp_PD6'])
         rdt['time'] = np.arange(20)
         rdt['temp'] = np.arange(20)
         with self.assertRaises(KeyError):


### PR DESCRIPTION
Data Containers such as the coverage or record dictionary tool or parameter dictionary will fail with parameters with the same name inside the data containers. We designed the framework to allow multiple parameters with the same name in the system but forbid it inside the data containers under the premise that we would never have a need for two things labeled the same. 

A specific use case for this arose when discussing L1/L0 parameters where the L1 parameters have identical names but different units from their L0 counterparts. We are now conquering this issue by appending the parameter identifier to the parameter name. 

Backwards compatibility is maintained by giving the data containers the ability to identify field names with the prefix of the new parameter names.  What was once `time` is now `time_PD7` but the RDT will still recognize it as `time` in cases where there is not more than one. If there are two parameters with the same name, explicit field names should be used:

``` python
rdt['salinity_PD3'] = ...
rdt['salinity_PD4'] = ...
```
