### PR TITLE
Added ability to cache predicates for in-memory lookup inside EnhancedResourceRegistryClient

### DIFF
--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -625,6 +625,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
 
         # can't do anything without an agent instance obj
         log.debug("Testing that preparing a launcher without agent instance raises an error")
+        pconfig_builder._update_cached_predicates() # associations have changed since builder was instantiated
         self.assertRaises(AssertionError, pconfig_builder.prepare, will_launch=False)
 
         log.debug("Making the structure for a platform agent, which will be the child")
@@ -632,6 +633,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         platform_agent_instance_child_obj = self.RR2.read(platform_agent_instance_child_id)
 
         log.debug("Preparing a valid agent instance launch, for config only")
+        pconfig_builder._update_cached_predicates() # associations have changed since builder was instantiated
         pconfig_builder.set_agent_instance_object(platform_agent_instance_child_obj)
         child_config = pconfig_builder.prepare(will_launch=False)
         verify_child_config(child_config, platform_device_child_id)
@@ -642,6 +644,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         platform_agent_instance_parent_obj = self.RR2.read(platform_agent_instance_parent_id)
 
         log.debug("Testing child-less parent as a child config")
+        pconfig_builder._update_cached_predicates() # associations have changed since builder was instantiated
         pconfig_builder.set_agent_instance_object(platform_agent_instance_parent_obj)
         parent_config = pconfig_builder.prepare(will_launch=False)
         verify_child_config(parent_config, platform_device_parent_id)
@@ -652,6 +655,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         self.assertNotEqual(0, len(child_device_ids))
 
         log.debug("Testing parent + child as parent config")
+        pconfig_builder._update_cached_predicates() # associations have changed since builder was instantiated
         pconfig_builder.set_agent_instance_object(platform_agent_instance_parent_obj)
         parent_config = pconfig_builder.prepare(will_launch=False)
         verify_parent_config(parent_config, platform_device_parent_id, platform_device_child_id)
@@ -662,6 +666,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         instrument_agent_instance_obj = self.RR2.read(instrument_agent_instance_id)
 
         log.debug("Testing instrument config")
+        iconfig_builder._update_cached_predicates() # associations have changed since builder was instantiated
         iconfig_builder.set_agent_instance_object(instrument_agent_instance_obj)
         instrument_config = iconfig_builder.prepare(will_launch=False)
         verify_instrument_config(instrument_config, instrument_device_id)
@@ -672,6 +677,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         self.assertNotEqual(0, len(child_device_ids))
 
         log.debug("Testing entire config")
+        pconfig_builder._update_cached_predicates() # associations have changed since builder was instantiated
         pconfig_builder.set_agent_instance_object(platform_agent_instance_parent_obj)
         full_config = pconfig_builder.prepare(will_launch=False)
         verify_parent_config(full_config, platform_device_parent_id, platform_device_child_id, instrument_device_id)

--- a/ion/util/enhanced_resource_registry_client.py
+++ b/ion/util/enhanced_resource_registry_client.py
@@ -86,6 +86,8 @@ class EnhancedResourceRegistryClient(object):
         #raise BadRequest(str(mults))
         #
 
+        self._cached_predicates = {}
+
         log.debug("done init")
 
 
@@ -245,14 +247,59 @@ class EnhancedResourceRegistryClient(object):
                                         object=object_id)
         self.RR.delete_association(assoc)
 
+    def find_subjects(self, subject_type, predicate, object, id_only=False):
+        object_id, object_type = self._extract_id_and_type(object)
+
+        if not self.has_cached_prediate(predicate):
+            ret, _ = self.RR.find_subjects(subject_type=subject_type,
+                                           predicate=predicate,
+                                           object=object_id,
+                                           id_only=id_only)
+            return ret
+
+        log.info("Using %s cached results for 'find (%s) subjects'", len(self._cached_predicates[predicate]), predicate)
+
+        log.debug("Checking object_id=%s, subject_type=%s", object_id, subject_type)
+        subject_ids = [a.s for a in self._cached_predicates[predicate] if object_id == a.o and a.st == subject_type]
+        if [] == subject_ids:
+            return [] # HACK because read_mult([]) raises error instead of returning []
+        elif id_only:
+            return subject_ids
+        else:
+            log.debug("getting full subject IonObjects with read_mult")
+            return self.RR.read_mult(subject_ids)
+
+
+    def find_objects(self, subject, predicate, object_type, id_only=False):
+        subject_id, subject_type = self._extract_id_and_type(subject)
+
+        if not self.has_cached_prediate(predicate):
+            ret, _ = self.RR.find_objects(subject=subject_id,
+                                         predicate=predicate,
+                                         object_type=object_type,
+                                         id_only=id_only)
+            return ret
+
+        log.info("Using %s cached results for 'find (%s) objects'", len(self._cached_predicates[predicate]), predicate)
+
+        log.debug("Checking subject_id=%s, object_type=%s", subject_id, object_type)
+        object_ids = [a.o for a in self._cached_predicates[predicate] if subject_id == a.s and a.ot == object_type]
+        if [] == object_ids:
+            return [] # HACK because read_mult([]) raises error instead of returning []
+        elif id_only:
+            return object_ids
+        else:
+            log.debug("getting full object IonObjects with read_mult")
+            return self.RR.read_mult(object_ids)
+
 
     def find_subject(self, subject_type, predicate, object, id_only=False):
         object_id, object_type = self._extract_id_and_type(object)
 
-        objs, _  = self.RR.find_subjects(subject_type=subject_type,
-                                         predicate=predicate,
-                                         object=object_id,
-                                         id_only=id_only)
+        objs  = self.find_subjects(subject_type=subject_type,
+                                   predicate=predicate,
+                                   object=object_id,
+                                   id_only=id_only)
 
         if 1 == len(objs):
             return objs[0]
@@ -267,10 +314,10 @@ class EnhancedResourceRegistryClient(object):
     def find_object(self, subject, predicate, object_type, id_only=False):
         subject_id, subject_type = self._extract_id_and_type(subject)
 
-        objs, _  = self.RR.find_objects(subject=subject_id,
-                                        predicate=predicate,
-                                        object_type=object_type,
-                                        id_only=id_only)
+        objs = self.find_objects(subject=subject_id,
+                                 predicate=predicate,
+                                 object_type=object_type,
+                                 id_only=id_only)
 
         if 1 == len(objs):
             return objs[0]
@@ -332,6 +379,11 @@ class EnhancedResourceRegistryClient(object):
 
         return ret
 
+    def cache_predicate(self, predicate):
+        self._cached_predicates[predicate] = self.RR.find_associations(predicate=predicate, id_only=False)
+
+    def has_cached_prediate(self, predicate):
+        return predicate in self._cached_predicates
 
     def _uncamel(self, name):
         """
@@ -554,7 +606,7 @@ class EnhancedResourceRegistryClient(object):
             def ret_fn(obj_id, subj_id):
                 log.info("Dynamically creating association (1)%s -> %s -> %s", isubj, ipred, iobj)
                 # see if there are any other objects of this type and pred on this subject
-                existing_subjs, _ = self.RR.find_subjects(isubj, ipred, obj_id, id_only=True)
+                existing_subjs = self.find_subjects(isubj, ipred, obj_id, id_only=True)
 
                 if len(existing_subjs) > 1:
                     raise Inconsistent("Multiple %s-%s subjects found associated to the same %s object with id='%s'" %
@@ -603,7 +655,7 @@ class EnhancedResourceRegistryClient(object):
                 log.info("Dynamically creating association %s -> %s -> (1)%s", isubj, ipred, iobj)
 
                 # see if there are any other objects of this type and pred on this subject
-                existing_objs, _ = self.RR.find_objects(subj_id, ipred, iobj, id_only=True)
+                existing_objs = self.find_objects(subj_id, ipred, iobj, id_only=True)
 
                 if len(existing_objs) > 1:
                     raise Inconsistent("Multiple %s-%s objects found with the same %s subject with id='%s'" %
@@ -684,7 +736,7 @@ class EnhancedResourceRegistryClient(object):
             def ret_fn(subj):
                 log.info("Dynamically finding objects %s -> %s -> %s", isubj, ipred, iobj)
                 subj_id, _ = self._extract_id_and_type(subj)
-                ret, _ = self.RR.find_objects(subject=subj_id, predicate=ipred, object_type=iobj, id_only=False)
+                ret = self.find_objects(subject=subj_id, predicate=ipred, object_type=iobj, id_only=False)
                 return ret
 
             return ret_fn
@@ -716,7 +768,7 @@ class EnhancedResourceRegistryClient(object):
             def ret_fn(obj):
                 log.info("Dynamically finding subjects %s <- %s <- %s", iobj, ipred, isubj)
                 obj_id, _ = self._extract_id_and_type(obj)
-                ret, _ = self.RR.find_subjects(subject_type=isubj, predicate=ipred, object=obj_id, id_only=False)
+                ret = self.find_subjects(subject_type=isubj, predicate=ipred, object=obj_id, id_only=False)
                 return ret
 
             return ret_fn
@@ -816,7 +868,7 @@ class EnhancedResourceRegistryClient(object):
             def ret_fn(subj):
                 log.info("Dynamically finding object_ids %s -> %s -> %s", isubj, ipred, iobj)
                 subj_id, _ = self._extract_id_and_type(subj)
-                ret, _ = self.RR.find_objects(subject=subj_id, predicate=ipred, object_type=iobj, id_only=True)
+                ret = self.find_objects(subject=subj_id, predicate=ipred, object_type=iobj, id_only=True)
                 return ret
 
             return ret_fn
@@ -848,7 +900,7 @@ class EnhancedResourceRegistryClient(object):
             def ret_fn(obj):
                 log.info("Dynamically finding subject_ids %s <- %s <- %s", iobj, ipred, isubj)
                 obj_id, _ = self._extract_id_and_type(obj)
-                ret, _ = self.RR.find_subjects(subject_type=isubj, predicate=ipred, object=obj_id, id_only=True)
+                ret = self.find_subjects(subject_type=isubj, predicate=ipred, object=obj_id, id_only=True)
                 return ret
 
             return ret_fn


### PR DESCRIPTION
This commit addresses the timeout error present in some extensive "launch platform agent" tests, caused by excessive calls to RR.find_subjects and RR.find_objects.

This has been fixed by adding capability the EnhancedResourceRegistryClient.

old way:

``` python
# makes 2 calls to resource registry
RR2 = EnhancedResourceRegistryClient(self.clients.resource_registry)
models1 = self.RR2.find_objects("device1", PRED.hasModel, RT.InstrumentModel, True)
models2 = self.RR2.find_objects("device2", PRED.hasModel, RT.InstrumentModel, True)
```

new way:

``` python
# makes 1 call to resource registry
RR2 = EnhancedResourceRegistryClient(self.clients.resource_registry)
RR2.cache_predicate(PRED.hasModel)
models1 = self.RR2.find_objects("device1", PRED.hasModel, RT.InstrumentModel, True)
models2 = self.RR2.find_objects("device2", PRED.hasModel, RT.InstrumentModel, True)
```

Note that no change is required to existing find_\* calls.
