### PR TITLE
Platform instrument hierarchy launch

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -211,7 +211,7 @@ class PlatformAgent(ResourceAgent):
 
         if log.isEnabledFor(logging.DEBUG):  # pragma: no cover
             platform_id = self.CFG.get_safe('platform_config.platform_id', '')
-            outname = "logs/platform_CFG_%s.txt" % platform_id
+            outname = "logs/platform_CFG_received_%s.txt" % platform_id
             try:
                 pprint.PrettyPrinter(stream=file(outname, "w")).pprint(self.CFG)
                 log.debug("%r: on_init: CFG printed to %s", platform_id, outname)

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -1117,8 +1117,8 @@ class PlatformAgent(ResourceAgent):
 
         assert i_resource_id, "agent.resource_id must be present for child %r" % instrument_id
 
-        if log.isEnabledFor(logging.DEBUG):  # pragma: no cover
-            log.debug("%r: launching instrument agent %r: CFG=%s",
+        if log.isEnabledFor(logging.TRACE):  # pragma: no cover
+            log.trace("%r: launching instrument agent %r: CFG=%s",
                       self._platform_id, instrument_id, self._pp.pformat(i_CFG))
         elif log.isEnabledFor(logging.DEBUG):  # pragma: no cover
             log.debug("%r: launching instrument agent %r",

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -218,6 +218,10 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         self.instModel_id = self.IMS.create_instrument_model(instModel_obj)
         log.debug('new InstrumentModel id = %s ', self.instModel_id)
 
+        self.pconfig_builder = self._create_platform_config_builder()
+
+        self.iconfig_builder = self._create_instrument_config_builder()
+
         # Use the network definition provided by RSN OMS directly.
         rsn_oms = CIOMSClientFactory.create_instance(DVR_CONFIG['oms_uri'])
         self._network_definition = RsnOmsUtil.build_network_definition(rsn_oms)
@@ -372,9 +376,8 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         return pconfig_builder
 
     def _generate_parent_with_child_config(self, p_parent, p_child):
-        pconfig_builder = self._create_platform_config_builder()
-        pconfig_builder.set_agent_instance_object(p_parent.platform_agent_instance_obj)
-        parent_config = pconfig_builder.prepare(will_launch=False)
+        self.pconfig_builder.set_agent_instance_object(p_parent.platform_agent_instance_obj)
+        parent_config = self.pconfig_builder.prepare(will_launch=False)
         self._verify_parent_config(parent_config,
                                    p_parent.platform_device_id,
                                    p_child.platform_device_id,
@@ -385,9 +388,8 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
                            p_parent.platform_id, p_child.platform_id))
 
     def _generate_platform_with_instrument_config(self, p_obj, i_obj):
-        pconfig_builder = self._create_platform_config_builder()
-        pconfig_builder.set_agent_instance_object(p_obj.platform_agent_instance_obj)
-        parent_config = pconfig_builder.prepare(will_launch=False)
+        self.pconfig_builder.set_agent_instance_object(p_obj.platform_agent_instance_obj)
+        parent_config = self.pconfig_builder.prepare(will_launch=False)
         self._verify_parent_config(parent_config,
                                    p_obj.platform_device_id,
                                    i_obj.instrument_device_id,
@@ -398,9 +400,8 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
                            p_obj.platform_id, i_obj.instrument_device_id))
 
     def _generate_config(self, platform_agent_instance_obj, platform_id, suffix=''):
-        pconfig_builder = self._create_platform_config_builder()
-        pconfig_builder.set_agent_instance_object(platform_agent_instance_obj)
-        config = pconfig_builder.prepare(will_launch=False)
+        self.pconfig_builder.set_agent_instance_object(platform_agent_instance_obj)
+        config = self.pconfig_builder.prepare(will_launch=False)
 
         self._debug_config(config, "platform_CFG_generated_%s%s.txt" % (platform_id, suffix))
 
@@ -445,9 +446,8 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         return iconfig_builder
 
     def _generate_instrument_config(self, instrument_agent_instance_obj, instrument_id, suffix=''):
-        pconfig_builder = self._create_instrument_config_builder()
-        pconfig_builder.set_agent_instance_object(instrument_agent_instance_obj)
-        config = pconfig_builder.prepare(will_launch=False)
+        self.iconfig_builder.set_agent_instance_object(instrument_agent_instance_obj)
+        config = self.iconfig_builder.prepare(will_launch=False)
 
         self._debug_config(config, "instrument_CFG_generated_%s%s.txt" % (instrument_id, suffix))
 
@@ -885,8 +885,6 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         log.debug("_create_instrument: creating instrument %r: %s",
                   instr_key, instr_info)
 
-        iconfig_builder = self._create_instrument_config_builder()
-
         org_obj = any_old(RT.Org)
 
         log.debug("making the structure for an instrument agent")
@@ -896,8 +894,8 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
 
         instrument_agent_instance_obj = self.RR2.read(i_obj.instrument_agent_instance_id)
 
-        iconfig_builder.set_agent_instance_object(instrument_agent_instance_obj)
-        instrument_config = iconfig_builder.prepare(will_launch=False)
+        self.iconfig_builder.set_agent_instance_object(instrument_agent_instance_obj)
+        instrument_config = self.iconfig_builder.prepare(will_launch=False)
         self.verify_instrument_config(instrument_config, org_obj,
                                       i_obj.instrument_device_id)
 

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -335,13 +335,11 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         pconfig_builder = PlatformAgentConfigurationBuilder(clients)
 
         # can't do anything without an agent instance obj
-        log.debug("Testing that preparing a launcher without agent instance raises an error")
         self.assertRaises(AssertionError, pconfig_builder.prepare, will_launch=False)
 
         return pconfig_builder
 
     def _generate_parent_with_child_config(self, p_parent, p_child):
-        log.debug("Testing parent platform + child platform as parent config")
         pconfig_builder = self._create_platform_config_builder()
         pconfig_builder.set_agent_instance_object(p_parent.platform_agent_instance_obj)
         parent_config = pconfig_builder.prepare(will_launch=False)
@@ -355,7 +353,6 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
                            p_parent.platform_id, p_child.platform_id))
 
     def _generate_platform_with_instrument_config(self, p_obj, i_obj):
-        log.debug("Testing parent platform + child instrument as parent config")
         pconfig_builder = self._create_platform_config_builder()
         pconfig_builder.set_agent_instance_object(p_obj.platform_agent_instance_obj)
         parent_config = pconfig_builder.prepare(will_launch=False)
@@ -857,7 +854,6 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
 
         instrument_agent_instance_obj = self.RR2.read(i_obj.instrument_agent_instance_id)
 
-        log.debug("Testing instrument config")
         iconfig_builder.set_agent_instance_object(instrument_agent_instance_obj)
         instrument_config = iconfig_builder.prepare(will_launch=False)
         self.verify_instrument_config(instrument_config, org_obj,

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -84,6 +84,9 @@ class AgentConfigurationBuilder(object):
                 # just warn if the new value is different
                 if v != prev_v:
                     log.warn("Overwriting %s[%s] of '%s' with '%s'", title, k, prev_v, v)
+                else:
+                    log.debug("Overwriting %s[%s] with same value already assigned '%s'",
+                              title, k, v)
             basedict[k] = v
 
     def _check_associations(self):

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -57,7 +57,10 @@ class AgentConfigurationBuilder(object):
     def _augment_dict(self, title, basedict, newitems):
         for k, v in newitems.iteritems():
             if k in basedict:
-                log.warn("Overwriting %s[%s] of '%s' with '%s'", title, k, basedict[k], v)
+                prev_v = basedict[k]
+                # just warn if the new value is different
+                if v != prev_v:
+                    log.warn("Overwriting %s[%s] of '%s' with '%s'", title, k, prev_v, v)
             basedict[k] = v
 
     def _check_associations(self):

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -29,6 +29,7 @@ import time
 from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform
 
 from nose.plugins.attrib import attr
+from unittest import skip
 
 
 @attr('INT', group='sa')
@@ -79,6 +80,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         self._run_commands()
         self._stop_platform(p_root.platform_agent_instance_id)
 
+    @skip("running fine locally but skipped for buildbot for the moment")
     def test_platform_hierarchy_with_some_instruments(self):
         #
         # test of launching a multiple-level platform hierarchy with

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -76,6 +76,8 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         i_obj = self._create_instrument('SBE37_SIM_01')
         self._assign_instrument_to_platform(i_obj, p_root)
 
+        self._generate_platform_config(p_root, "_complete")
+
         self._start_platform(p_root.platform_agent_instance_id)
         self._run_commands()
         self._stop_platform(p_root.platform_agent_instance_id)
@@ -129,13 +131,14 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #####################################
         # create platform hierarchy
         #####################################
+        log.info("will create platform hierarchy ...")
         start_time = time.time()
 
         root_platform_id = 'Node1B'
         p_objs = {}
         p_root = self._create_hierarchy(root_platform_id, p_objs)
 
-        log.debug("platform hierarchy built. Took %.3f secs. "
+        log.info("platform hierarchy built. Took %.3f secs. "
                   "Root platform=%r, number of platforms=%d: %s",
                   time.time() - start_time,
                   root_platform_id, len(p_objs), p_objs.keys())
@@ -146,6 +149,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #####################################
         # create some instruments
         #####################################
+        log.info("will create instruments ...")
         start_time = time.time()
 
         i1_obj = self._create_instrument('SBE37_SIM_01')
@@ -154,12 +158,12 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         i2_obj = self._create_instrument('SBE37_SIM_02')
         log.debug("instrument created = %r", i2_obj.instrument_agent_instance_id)
 
-
-        log.debug("instruments created. Took %.3f secs.", time.time() - start_time)
+        log.info("instruments created. Took %.3f secs.", time.time() - start_time)
 
         #####################################
         # assign the instruments
         #####################################
+        log.info("will assign instruments ...")
         start_time = time.time()
 
         pid_LV01C = 'LV01C'
@@ -172,38 +176,43 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         self._assign_instrument_to_platform(i2_obj, p_objs[pid_LJ01B])
         log.debug("instrument assigned to = %r", pid_LJ01B)
 
-
-        log.debug("instruments assigned. Took %.3f secs.",
+        log.info("instruments assigned. Took %.3f secs.",
                   time.time() - start_time)
 
         #####################################
         # generate the config for the whole hierarchy including instruments:
         #####################################
+        log.info("will generate configuration ...")
         start_time = time.time()
         self._debug_config_enabled = True
-        self._generate_config(p_root.platform_agent_instance_obj,
-                              root_platform_id, "_complete")
+        self._generate_platform_config(p_root, "_complete")
 
-        log.debug("configuration generated. Took %.3f secs.", time.time() - start_time)
+        log.info("configuration generated. Took %.3f secs.", time.time() - start_time)
 
         #####################################
         # start the root platform:
         #####################################
+        log.info("will start the root platform ...")
         start_time = time.time()
 
         self._start_platform(p_root.platform_agent_instance_id)
 
-        log.debug("root platform started. Took %.3f secs.", time.time() - start_time)
+        log.info("root platform started. Took %.3f secs.", time.time() - start_time)
 
         #####################################
         # run the commands:
         #####################################
+        log.info("will run commands ...")
         start_time = time.time()
         self._run_commands()
 
-        log.debug("commands run. Took %.3f secs.", time.time() - start_time)
+        log.info("commands run. Took %.3f secs.", time.time() - start_time)
 
         #####################################
         # stop the root platform
         #####################################
+        log.info("will stop the root platform ...")
+        start_time = time.time()
         self._stop_platform(p_root.platform_agent_instance_id)
+
+        log.info("root platform stopped. Took %.3f secs.", time.time() - start_time)

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -99,17 +99,22 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #                     SF01B
         #             LJ01C
         #     LV01B
-        #         LV01B
-        #             LJ01B
+        #         LJ01B
         #         MJ01B
 
-        # the test completes ok if we use root_platform_id = 'LV01C'
+        # disable the generation of config files (to only generate the
+        # complete one below)
+        self._debug_config_enabled = False
+
         root_platform_id = 'Node1B'
         p_objs = {}
         p_root = self._create_hierarchy(root_platform_id, p_objs)
 
-        log.debug("hierarchy built. Root platform=%r, #p_objs=%d",
-                  root_platform_id, len(p_objs))
+        log.debug("platform hierarchy built. Root platform=%r, number of platforms=%d: %s",
+                  root_platform_id, len(p_objs), p_objs.keys())
+
+        self.assertIn(root_platform_id, p_objs)
+        self.assertEquals(13, len(p_objs))
 
         # create and assign some instruments
 
@@ -125,10 +130,12 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
         log.debug("instrument assigned to = %r", pid_LV01C)
 
-        # start the root platform and run the commands:
-        log.debug("starting platforn agent %r", p_root.platform_agent_instance_id)
-        self._start_platform(p_root.platform_agent_instance_id)
-        log.debug("started platforn agent %r", p_root.platform_agent_instance_id)
+        # generate the config for the whole hierarchy including instruments:
+        self._debug_config_enabled = True
+        self._generate_config(p_root.platform_agent_instance_obj,
+                              root_platform_id, "_complete")
 
+        # start the root platform and run the commands:
+        self._start_platform(p_root.platform_agent_instance_id)
         self._run_commands()
         self._stop_platform(p_root.platform_agent_instance_id)

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -101,6 +101,24 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #     LV01B
         #         LJ01B
         #         MJ01B
+        #
+        # In DEBUG logging level for the relevant modules (in particular, the
+        # parent class of this test, and PlatformAgent), the following files are
+        # generated under logs/:
+        #    platform_CFG_generated_Node1B_complete.txt
+        #    platform_CFG_received_Node1B.txt
+        #    platform_CFG_received_Node1C.txt
+        #    platform_CFG_received_Node1D.txt
+        #    platform_CFG_received_MJ01C.txt
+        #    platform_CFG_received_LJ01D.txt
+        #    platform_CFG_received_LV01C.txt
+        #    platform_CFG_received_PC01B.txt
+        #    platform_CFG_received_SC01B.txt
+        #    platform_CFG_received_SF01B.txt
+        #    platform_CFG_received_LJ01C.txt
+        #    platform_CFG_received_LV01B.txt
+        #    platform_CFG_received_LJ01B.txt
+        #    platform_CFG_received_MJ01B.txt
 
         # disable the generation of config files (to only generate the
         # complete one below)

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -103,6 +103,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #             LJ01B
         #         MJ01B
 
+        # the test completes ok if we use root_platform_id = 'LV01C'
         root_platform_id = 'Node1B'
         p_objs = {}
         p_root = self._create_hierarchy(root_platform_id, p_objs)
@@ -124,7 +125,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
         log.debug("instrument assigned to = %r", pid_LV01C)
 
-        # start the rot platform and run the commands:
+        # start the root platform and run the commands:
         log.debug("starting platforn agent %r", p_root.platform_agent_instance_id)
         self._start_platform(p_root.platform_agent_instance_id)
         log.debug("started platforn agent %r", p_root.platform_agent_instance_id)

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -21,6 +21,7 @@ __license__ = 'Apache 2.0'
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_platform
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_hierarchy
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_platform_with_an_instrument
+# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_platform_hierarchy_with_some_instruments
 
 from pyon.public import log
 import logging
@@ -47,7 +48,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
     def test_single_platform(self):
         #
-        # Tests the launch and shutdown of a single platform.
+        # Tests the launch and shutdown of a single platform (no instruments).
         #
         p_root = self._create_single_platform()
 
@@ -57,7 +58,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
     def test_hierarchy(self):
         #
-        # Tests the launch and shutdown of a small platform topology.
+        # Tests the launch and shutdown of a small platform topology (no instruments).
         #
         p_root = self._create_small_hierarchy()
 
@@ -75,5 +76,58 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         self._assign_instrument_to_platform(i_obj, p_root)
 
         self._start_platform(p_root.platform_agent_instance_id)
+        self._run_commands()
+        self._stop_platform(p_root.platform_agent_instance_id)
+
+    def test_platform_hierarchy_with_some_instruments(self):
+        #
+        # test of launching a multiple-level platform hierarchy with
+        # instruments associated to some of the platforms.
+        #
+        # The platform hierarchy corresponds to the sub-network in the
+        # simulated topology rooted at 'Node1B', which at time of writing
+        # looks like this:
+        #
+        # Node1B
+        #     Node1C
+        #         Node1D
+        #             MJ01C
+        #                 LJ01D
+        #         LV01C
+        #             PC01B
+        #                 SC01B
+        #                     SF01B
+        #             LJ01C
+        #     LV01B
+        #         LV01B
+        #             LJ01B
+        #         MJ01B
+
+        root_platform_id = 'Node1B'
+        p_objs = {}
+        p_root = self._create_hierarchy(root_platform_id, p_objs)
+
+        log.debug("hierarchy built. Root platform=%r, #p_objs=%d",
+                  root_platform_id, len(p_objs))
+
+        # create and assign some instruments
+
+        # TODO just creating/assigning a single instrument at the moment.
+
+        i_obj = self._create_instrument()
+
+        log.debug("instrument created = %r", i_obj.instrument_agent_instance_id)
+
+        pid_LV01C = 'LV01C'
+        self.assertIn(pid_LV01C, p_objs)
+        self._assign_instrument_to_platform(i_obj, p_objs[pid_LV01C])
+
+        log.debug("instrument assigned to = %r", pid_LV01C)
+
+        # start the rot platform and run the commands:
+        log.debug("starting platforn agent %r", p_root.platform_agent_instance_id)
+        self._start_platform(p_root.platform_agent_instance_id)
+        log.debug("started platforn agent %r", p_root.platform_agent_instance_id)
+
         self._run_commands()
         self._stop_platform(p_root.platform_agent_instance_id)


### PR DESCRIPTION
Set-up of the launch tests now enabled to create and associate instruments to desired platforms in the network. The concrete test is:

```
bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_platform_hierarchy_with_some_instruments
```

which exercises the 2 currently available SBE37 simulators in a multi-level network comprising 13 platforms.

NOTE: this test is skipped to avoid potential timeout issues on the buildbots, but it runs fine with a reasonable endpoint.receive.timeout (which I'm setting to 180 in my pyon.local.yml).  

But please review, test, and merge at the earliest. 
