### PR TITLE
Update OOI asset parse and preload

### DIFF
--- a/README_DEMO
+++ b/README_DEMO
@@ -56,6 +56,9 @@ Start the services container and preload with UI (no OOI):
 Preload system with UI (without OOI assets)
 > bin/pycc -x ion.processes.bootstrap.ion_loader.IONLoader op=load scenario=BASE,BETA,R2_DEMO ui_path='https://userexperience.oceanobservatories.org/database-exports' attachments=res/preload/r2_ioc/attachments assets=res/preload/r2_ioc/ooi_assets loadui=True
 
+OR: Preload system OOI assets only, create User/Org on the fly; bulk+debug mode not ready for production). Exclude data product etc
+> bin/pycc -x ion.processes.bootstrap.ion_loader.IONLoader op=load scenario=X loadooi=True assets=res/preload/r2_ioc/ooi_assets bulk=True debug=True ooiexclude=DataProduct,DataProductLink,Deployment,Workflow,WorkflowDefinition
+
 OR: Preload system with UI and OOI assets, bulk mode not ready for production)
 > bin/pycc -x ion.processes.bootstrap.ion_loader.IONLoader op=load scenario=BASE,BETA,R2_DEMO ui_path='https://userexperience.oceanobservatories.org/database-exports' attachments=res/preload/r2_ioc/attachments assets=res/preload/r2_ioc/ooi_assets loadui=True loadooi=True bulk=True
 

--- a/ion/core/ooiref.py
+++ b/ion/core/ooiref.py
@@ -39,7 +39,8 @@ class OOIReferenceDesignator(object):
             self.rd_subtype = "class"
             self.dataproduct = rdstr
         else:
-            m = re.match('^([A-Z]{2})(?:(\d{2})(?:(\w{4})(?:-([A-Z]{2})(?:([A-Z0-9]{3})(?:-(\d{2})(?:-([A-Z0-9]{5})([A-Z0-9])(\d{3})?)?)?)?)?)?)?$', rdstr)
+            #              <array   >   <site >   <subs >   -<nodetype>   <nodeseq    >   -<port#      >   -<instclass  ><series  ><seq>
+            m = re.match('^([A-Z]{2})(?:(\d{2})(?:(\w{4})(?:-([A-Z]{2})(?:([A-Z0-9]{3})(?:-([A-Z0-9]{2})(?:-([A-Z0-9]{5})([A-Z0-9])(\d{3})?)?)?)?)?)?)?$', rdstr)
             if m:
                 self.rd_type = "asset"
                 self.array, self.site, self.subsite, self.node_type, self.node_seq, self.port, self.inst_class, self.inst_series, self.inst_seq = m.groups()

--- a/ion/core/ooiref.py
+++ b/ion/core/ooiref.py
@@ -21,7 +21,7 @@ class OOIReferenceDesignator(object):
         # Example: CE01ISSM-MF004-01-DOSTAD999
         self.marine_io = None
         self.array, self.site, self.subsite, self.node_type, self.node_seq, self.port, self.inst_class, self.inst_series, self.inst_seq = None, None, None, None, None, None, None, None, None
-        self.site_rd, self.subsite_rd, self.node_rd, self.port_rd, self.inst_rd, self.subseries_rd = None, None, None, None, None, None
+        self.site_rd, self.subsite_rd, self.node_rd, self.port_rd, self.inst_rd, self.series_rd, self.subseries_rd = None, None, None, None, None, None, None
         # Type dataproduct
         self.dataproduct = None
         self.dataproduct_level = None
@@ -46,6 +46,7 @@ class OOIReferenceDesignator(object):
                 self.array, self.site, self.subsite, self.node_type, self.node_seq, self.port, self.inst_class, self.inst_series, self.inst_seq = m.groups()
                 if self.inst_class:
                     self.inst_rd = rdstr
+                    self.series_rd = self.inst_class + self.inst_series
                     self.subseries_rd = self.inst_class + self.inst_series + "01"  # !!! Underspecified !!!
                     self.rd_subtype = "instrument"
                 if self.port:

--- a/ion/util/parse_utils.py
+++ b/ion/util/parse_utils.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+
+"""Common utilities to parse external files, e.g. for preload"""
+
+__author__ = 'Michael Meisinger, Ian Katz'
+
+import ast
+
+from pyon.public import iex, IonObject, log
+
+from interface import objects
+
+
+def get_typed_value(self, value, schema_entry=None, targettype=None):
+    """
+    Performs a value type conversion according to a schema specified target type.
+    """
+    targettype = targettype or schema_entry["type"]
+    if schema_entry and 'enum_type' in schema_entry:
+        enum_clzz = getattr(objects, schema_entry['enum_type'])
+        return enum_clzz._value_map[value]
+    elif targettype is 'str':
+        return str(value)
+    elif targettype is 'bool':
+        lvalue = value.lower()
+        if lvalue == 'true' or lvalue == '1':
+            return True
+        elif lvalue == 'false' or lvalue == '' or lvalue == '0':
+            return False
+        else:
+            raise iex.BadRequest("Value %s is no bool" % value)
+    elif targettype is 'int':
+        try:
+            return int(value)
+        except Exception:
+            log.warn("Value %s is type %s not type %s" % (value, type(value), targettype))
+            return ast.literal_eval(value)
+    elif targettype is 'float':
+        try:
+            return float(value)
+        except Exception:
+            log.warn("Value %s is type %s not type %s" % (value, type(value), targettype))
+            return ast.literal_eval(value)
+    elif targettype is 'simplelist':
+        if value.startswith('[') and value.endswith(']'):
+            value = value[1:len(value)-1].strip()
+        elif not value.strip():
+            return []
+        return list(value.split(','))
+    else:
+        log.trace('parsing value as %s: %s', targettype, value)
+        return ast.literal_eval(value)
+
+def parse_dict(text):
+    """
+    parse a "simple" dictionary of unquoted string keys and values. -- no nested values, no complex characters
+
+    But is it really simple?  Not quite.  The following substitutions are made:
+
+    keys with dots ('.') will be split into dictionaries.
+    booleans "True", "False" will be parsed
+    numbers will be parsed as floats unless they begin with "0" or include one "." and end with "0"
+    "{}" will be converted to {}
+    "[]" will be converted to [] (that's "[ ]" with no space)
+
+    For example, an entry in preload would be this:
+
+    PARAMETERS.TXWAVESTATS: False,
+    PARAMETERS.TXREALTIME: True,
+    PARAMETERS.TXWAVEBURST: false,
+    SCHEDULER.ACQUIRE_STATUS: {},
+    SCHEDULER.CLOCK_SYNC: 48.2
+    SCHEDULER.VERSION.number: 3.0
+
+    which would translate back to
+    { "PARAMETERS": { "TXWAVESTATS": False, "TXREALTIME": True, "TXWAVEBURST": "false" },
+      "SCHEDULER": { "ACQUIRE_STATUS": { }, "CLOCK_SYNC", 48.2, "VERSION": {"number": "3.0"}}
+    }
+
+    """
+
+    substitutions = {"{}": {}, "[]": [], "True": True, "False": False}
+
+    def parse_value(some_val):
+        if some_val in substitutions:
+            return substitutions[some_val]
+
+        try:
+            int_val = int(some_val)
+            if str(int_val) == some_val:
+                return int_val
+        except ValueError:
+            pass
+
+        try:
+            float_val = float(some_val)
+            if str(float_val) == some_val:
+                return float_val
+        except ValueError:
+            pass
+
+        return some_val
+
+
+    def chomp_key_list(out_dict, keys, value):
+        """
+        turn keys like ['a', 'b', 'c', 'd'] and a value into
+        out_dict['a']['b']['c']['d'] = value
+        """
+        dict_ptr = out_dict
+        last_ptr = out_dict
+        for i, key in enumerate(keys):
+            last_ptr = dict_ptr
+            if not key in dict_ptr:
+                dict_ptr[key] = {}
+            else:
+                if type(dict_ptr[key]) != type({}):
+                    raise iex.BadRequest("Building a dict in %s field, but it exists as %s already" %
+                                         (key, type(dict_ptr[key])))
+            dict_ptr = dict_ptr[key]
+        last_ptr[keys[-1]] = value
+
+
+    out = { }
+    pairs = text.split(',') # pairs separated by commas
+    for pair in pairs:
+        if 0 == pair.count(':'):
+            continue
+        fields = pair.split(':') # pair separated by colon
+        key = fields[0].strip()
+        value = fields[1].strip()
+
+        keyparts = key.split(".")
+        chomp_key_list(out, keyparts, parse_value(value))
+
+
+    return out
+
+
+def parse_phones(text):
+    if ':' in text:
+        out = []
+        for type,number in parse_dict(text).iteritems():
+            out.append(IonObject("Phone", phone_number=number, phone_type=type))
+        return out
+    elif text:
+        return [ IonObject("Phone", phone_number=text.strip(), phone_type='office') ]
+    else:
+        return []

--- a/ion/util/parse_utils.py
+++ b/ion/util/parse_utils.py
@@ -11,7 +11,7 @@ from pyon.public import iex, IonObject, log
 from interface import objects
 
 
-def get_typed_value(self, value, schema_entry=None, targettype=None):
+def get_typed_value(value, schema_entry=None, targettype=None):
     """
     Performs a value type conversion according to a schema specified target type.
     """


### PR DESCRIPTION
Includes latest OOI asset exports pointer and new parsing routines for OOI assets.
- Preload of the OOI observatory structure is much simplified. Only Observatory resource with PlatformSite direct children. No more Subsite needed.
- InstrumentModels now derived from instrument class, leaving 48
- PlatformAgent now derived from mapping spreadsheet, leaving 2
- Added an analyze mode with an end deployment date to show platforms and instrument models until this date
