### PR TITLE
Platform instrument hierarchy launch

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -193,7 +193,7 @@ class PlatformAgent(ResourceAgent):
         self._ia_clients = {}  # Never None
 
         # self.CFG.endpoint.receive.timeout -- see on_init
-        self._timeout = 30
+        self._timeout = 160
 
         log.info("PlatformAgent constructor complete.")
 
@@ -204,7 +204,8 @@ class PlatformAgent(ResourceAgent):
         super(PlatformAgent, self).on_init()
         log.trace("on_init")
 
-        self._timeout = self.CFG.get("endpoint.receive.timeout", 30)
+        self._timeout = self.CFG.get_safe("endpoint.receive.timeout", self._timeout)
+        log.debug("self._timeout = %s", self._timeout)
 
         self._plat_config = self.CFG.get("platform_config", None)
         self._plat_config_processed = False

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -205,13 +205,12 @@ class PlatformAgent(ResourceAgent):
         log.trace("on_init")
 
         self._timeout = self.CFG.get_safe("endpoint.receive.timeout", self._timeout)
-        log.debug("self._timeout = %s", self._timeout)
-
         self._plat_config = self.CFG.get("platform_config", None)
         self._plat_config_processed = False
 
         if log.isEnabledFor(logging.DEBUG):  # pragma: no cover
             platform_id = self.CFG.get_safe('platform_config.platform_id', '')
+            log.debug("%r: self._timeout = %s", platform_id, self._timeout)
             outname = "logs/platform_CFG_received_%s.txt" % platform_id
             try:
                 pprint.PrettyPrinter(stream=file(outname, "w")).pprint(self.CFG)

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -35,7 +35,6 @@ __license__ = 'Apache 2.0'
 
 from pyon.public import log
 import logging
-from pyon.public import CFG
 from pyon.public import IonObject
 from pyon.core.exception import ServerError
 
@@ -164,7 +163,6 @@ class FakeProcess(LocalContextMixin):
 
 
 @attr('INT', group='sa')
-@patch.dict(CFG, {'endpoint':{'receive':{'timeout': 180}}})
 class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
     """
     A base class with several conveniences supporting specific platform agent

--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -37,21 +37,26 @@ from ion.agents.platform.platform_agent import PlatformAgentState
 from ion.agents.platform.platform_agent import PlatformAgentEvent
 from ion.agents.platform.responses import NormalResponse
 
-from nose.plugins.attrib import attr
-
 from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform
 
+from mock import patch
+from pyon.public import CFG
 
-@attr('INT', group='sa')
+
+@patch.dict(CFG, {'endpoint': {'receive': {'timeout': 180}}})
 class TestPlatformAgent(BaseIntTestPlatform):
 
-    def setUp(self):
-        super(TestPlatformAgent, self).setUp()
+    def _create_network_and_start_root_platform(self):
+        """
+        Call this at the beginning of each test. We need to make sure that
+        the patched timeout is in effect for the actions performed here.
 
-        #
+        @note this used to be done in setUp, but the patch.dict mechanism does
+        *not* take effect in setUp!
+        """
+
         # NOTE The tests expect to use values set up by HelperTestMixin for
         # for the following networks (see ion/agents/platform/test/helper.py)
-        #
         if self.PLATFORM_ID == 'Node1D':
             self.p_root = self._create_small_hierarchy()
 
@@ -218,6 +223,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         return retval.result
 
     def test_capabilities(self):
+        self._create_network_and_start_root_platform()
 
         agt_cmds_all = [
             PlatformAgentEvent.INITIALIZE,
@@ -522,6 +528,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._reset()
 
     def test_some_state_transitions(self):
+        self._create_network_and_start_root_platform()
 
         self._assert_state(PlatformAgentState.UNINITIALIZED)
         self._initialize()   # -> INACTIVE
@@ -538,6 +545,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._reset()        # -> UNINITIALIZED
 
     def test_get_set_resources(self):
+        self._create_network_and_start_root_platform()
 
         self._assert_state(PlatformAgentState.UNINITIALIZED)
         self._ping_agent()
@@ -553,6 +561,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._reset()
 
     def test_some_commands(self):
+        self._create_network_and_start_root_platform()
 
         self._assert_state(PlatformAgentState.UNINITIALIZED)
         self._ping_agent()
@@ -572,6 +581,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._reset()
 
     def test_resource_monitoring(self):
+        self._create_network_and_start_root_platform()
 
         self._assert_state(PlatformAgentState.UNINITIALIZED)
         self._ping_agent()
@@ -588,6 +598,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._reset()
 
     def test_external_event_dispatch(self):
+        self._create_network_and_start_root_platform()
 
         self._assert_state(PlatformAgentState.UNINITIALIZED)
         self._ping_agent()
@@ -602,6 +613,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._reset()
 
     def test_connect_disconnect_instrument(self):
+        self._create_network_and_start_root_platform()
 
         self._assert_state(PlatformAgentState.UNINITIALIZED)
         self._ping_agent()
@@ -622,6 +634,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._reset()
 
     def test_check_sync(self):
+        self._create_network_and_start_root_platform()
 
         self._assert_state(PlatformAgentState.UNINITIALIZED)
         self._ping_agent()

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -28,11 +28,7 @@ import time
 
 from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform
 
-from nose.plugins.attrib import attr
-from unittest import skip
 
-
-@attr('INT', group='sa')
 class TestPlatformLaunch(BaseIntTestPlatform):
 
     def _run_commands(self):
@@ -82,7 +78,6 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         self._run_commands()
         self._stop_platform(p_root.platform_agent_instance_id)
 
-    @skip("running fine locally but skipped for buildbot for the moment")
     def test_platform_hierarchy_with_some_instruments(self):
         #
         # test of launching a multiple-level platform hierarchy with

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -28,7 +28,11 @@ import time
 
 from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform
 
+from mock import patch
+from pyon.public import CFG
 
+
+@patch.dict(CFG, {'endpoint': {'receive': {'timeout': 180}}})
 class TestPlatformLaunch(BaseIntTestPlatform):
 
     def _run_commands(self):


### PR DESCRIPTION
Includes updates related with appropriate use of patching the receive timeout, which is set to reasonable value (180) in the integration tests. 
test_platform_hierarchy_with_some_instruments is not skipped anymore so it can now be tried on the various buildbots.
