### PR TITLE
use seabird_sbe37smb_ooicore-0.1.0-py2.7.egg

### DIFF
--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -152,6 +152,10 @@ instruments_dict = {
     }
 }
 
+# The value should probably be defined in pyon.yml or some common place so
+# clients don't have to do updates upon new versions of the egg.
+SBE37_EGG = "http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.1.0-py2.7.egg"
+
 
 class FakeProcess(LocalContextMixin):
     """
@@ -654,7 +658,7 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         from ion.agents.instrument.driver_process import ZMQEggDriverProcess
 
         # A seabird driver.
-        DRV_URI = 'http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.7-py2.7.egg'
+        DRV_URI = SBE37_EGG
         DRV_MOD = 'mi.instrument.seabird.sbe37smb.ooicore.driver'
         DRV_CLS = 'SBE37Driver'
 
@@ -726,7 +730,7 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         instrument_agent_obj = IonObject(RT.InstrumentAgent,
                                          name='agent007_%s' % instr_key,
                                          description="SBE37IMAgent_%s" % instr_key,
-                                         driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1a-py2.7.egg",
+                                         driver_uri=SBE37_EGG,
                                          stream_configurations=self._get_instrument_stream_configs())
 
         instrument_agent_id = self.IMS.create_instrument_agent(instrument_agent_obj)


### PR DESCRIPTION
use http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.1.0-py2.7.egg per recent update in
MI , which includes bug fixes that are exposed when running the platform commands in the UI 

(BTW, a property defining the URI to the latest egg should probably be defined in a single common place like pyon.yml)
