### PR TITLE
Aggressive agent config builder caching

### DIFF
--- a/ion/services/dm/distribution/pubsub_management_service.py
+++ b/ion/services/dm/distribution/pubsub_management_service.py
@@ -75,14 +75,20 @@ class PubsubManagementService(BasePubsubManagementService):
         self.clients.resource_registry.delete(stream_definition_id)
         return True
 
+    @classmethod
+    def compare_stream_definition_objects(cls, def1, def2):
+        if def1._id == def2._id:
+            return True
+        pdict_compare = cls._compare_pdicts(def1.parameter_dictionary, def2.parameter_dictionary)
+        return pdict_compare and sorted(def1.available_fields) == sorted(def2.available_fields)
+
     def compare_stream_definition(self, stream_definition1_id='', stream_definition2_id=''):
         # returns True if the 2 stream definitions are equivalent
         if stream_definition1_id == stream_definition2_id and self.read_stream_definition(stream_definition1_id):
             return True
         def1 = self.read_stream_definition(stream_definition1_id)
         def2 = self.read_stream_definition(stream_definition2_id)
-        pdict_compare = self._compare_pdicts(def1.parameter_dictionary, def2.parameter_dictionary) 
-        return pdict_compare and sorted(def1.available_fields) == sorted(def2.available_fields)
+        return self.compare_stream_definition_objects(def1, def2)
 
     def compatible_stream_definitions(self, in_stream_definition_id, out_stream_definition_id):
         if in_stream_definition_id == out_stream_definition_id and self.read_stream_definition(in_stream_definition_id):

--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -368,8 +368,13 @@ class DatasetManagementService(BaseDatasetManagementService):
         pd  = dms_cli.read_parameter_dictionary(parameter_dictionary_id)
         pcs = dms_cli.read_parameter_contexts(parameter_dictionary_id=parameter_dictionary_id, id_only=False)
 
-        pdict = cls._merge_contexts([ParameterContext.load(i.parameter_context) for i in pcs], pd.temporal_context)
-        pdict._identifier = parameter_dictionary_id
+        return cls.build_parameter_dictionary(pd, pcs)
+
+    @classmethod
+    def build_parameter_dictionary(cls, parameter_dictionary_obj, parameter_contexts):
+        pdict = cls._merge_contexts([ParameterContext.load(i.parameter_context) for i in parameter_contexts],
+                                    parameter_dictionary_obj.temporal_context)
+        pdict._identifier = parameter_dictionary_obj._id
 
         return pdict
 

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -7,6 +7,7 @@
 
 import tempfile
 from ion.agents.instrument.driver_process import DriverProcessType
+from ion.services.dm.distribution.pubsub_management_service import PubsubManagementService
 from ion.services.dm.inventory.dataset_management_service import DatasetManagementService
 from ion.util.enhanced_resource_registry_client import EnhancedResourceRegistryClient
 from pyon.core.exception import NotFound, BadRequest
@@ -60,7 +61,13 @@ class AgentConfigurationBuilder(object):
                 PRED.hasAgentInstance,
                 PRED.hasAgentDefinition,
                 PRED.hasDataset,
-                PRED.hasDevice]
+                PRED.hasDevice,
+                PRED.hasParameterContext]
+
+    def _resources_to_cache(self):
+        return [RT.StreamDefinition,
+                RT.ParameterDictionary,
+                RT.ParameterContext]
 
     def _update_cached_predicates(self):
         # cache some predicates for in-memory lookups
@@ -75,6 +82,20 @@ class AgentConfigurationBuilder(object):
         total_time = int(time_caching_stop) - int(time_caching_start)
 
         log.info("Cached %s predicates in %s seconds", len(preds), total_time / 1000.0)
+
+    def _update_cached_resources(self):
+        # cache some resources for in-memory lookups
+        rsrcs = self._resources_to_cache()
+        log.debug("updating cached resources: %s" % rsrcs)
+        time_caching_start = get_ion_ts()
+        for r in rsrcs:
+            log.debug(" - %s", r)
+            self.clients.RR2.cache_resources(r)
+        time_caching_stop = get_ion_ts()
+
+        total_time = int(time_caching_stop) - int(time_caching_start)
+
+        log.info("Cached %s resource types in %s seconds", len(rsrcs), total_time / 1000.0)
 
 
     def _lookup_means(self):
@@ -151,6 +172,9 @@ class AgentConfigurationBuilder(object):
         if any([not self.RR2.has_cached_prediate(x) for x in self._predicates_to_cache()]):
             self._update_cached_predicates()
 
+        if any([not self.RR2.has_cached_resource(x) for x in self._resources_to_cache()]):
+            self._update_cached_resources()
+
         # validate the associations, then pick things up
         self._collect_agent_instance_associations()
         self.will_launch = will_launch
@@ -158,6 +182,7 @@ class AgentConfigurationBuilder(object):
 
 
     def _generate_org_name(self):
+        log.debug("_generate_org_name for %s", self.agent_instance_obj.name)
         log.debug("retrieve the Org name to which this agent instance belongs")
         try:
             org_obj = self.RR2.find_subject(RT.Org, PRED.hasResource, self.agent_instance_obj._id, id_only=False)
@@ -168,9 +193,11 @@ class AgentConfigurationBuilder(object):
             raise
 
     def _generate_device_type(self):
+        log.debug("_generate_device_type for %s", self.agent_instance_obj.name)
         return type(self._get_device()).__name__
 
     def _generate_driver_config(self):
+        log.debug("_generate_driver_config for %s", self.agent_instance_obj.name)
         # get default config
         driver_config = self.agent_instance_obj.driver_config
 
@@ -187,8 +214,14 @@ class AgentConfigurationBuilder(object):
 
         return driver_config
 
+    def _get_param_dict_by_name(self, name):
+        dict_obj = self.RR2.find_by_name(RT.ParameterDictionary, name)
+        parameter_contexts = self.RR2.find_parameter_contexts_of_parameter_dictionary(dict_obj._id)
+        return DatasetManagementService.build_parameter_dictionary(dict_obj, parameter_contexts)
+
 
     def _generate_stream_config(self):
+        log.debug("_generate_stream_config for %s", self.agent_instance_obj.name)
         dsm = self.clients.dataset_management
         psm = self.clients.pubsub_management
 
@@ -219,7 +252,7 @@ class AgentConfigurationBuilder(object):
 
         stream_config = {}
 
-        log.debug("Creating a stream config got each stream (dataproduct) assoc with this agent/device")
+        log.debug("Creating a stream config for each stream (dataproduct) assoc with this agent/device")
         for product_stream_id in out_streams:
 
             #get the streamroute object from pubsub by passing the stream_id
@@ -227,20 +260,25 @@ class AgentConfigurationBuilder(object):
 
             #match the streamdefs/apram dict for this model with the data products attached to this device to know which tag to use
             for model_stream_name, stream_info_dict  in streams_dict.items():
-
-                if self.clients.pubsub_management.compare_stream_definition(stream_info_dict.get('stream_def_id'),
-                                                                            stream_def_id):
-                    model_param_dict = DatasetManagementService.get_parameter_dictionary_by_name(stream_info_dict.get('param_dict_name'))
-                    stream_route = self.clients.pubsub_management.read_stream_route(stream_id=product_stream_id)
+                # read objects from cache to be compared
+                out_stream_def_obj = self.RR2.read(stream_def_id, RT.StreamDefinition)
+                agent_stream_def_obj = self.RR2.read(stream_info_dict.get('stream_def_id'), RT.StreamDefinition)
+                if PubsubManagementService.compare_stream_definition_objects(out_stream_def_obj, agent_stream_def_obj):
+                    #model_param_dict = self.RR2.find_by_name(RT.ParameterDictionary,
+                    #                                         stream_info_dict.get('param_dict_name'))
+                    model_param_dict = self._get_param_dict_by_name(stream_info_dict.get('param_dict_name'))
+                    stream_route = self.RR2.read(product_stream_id).stream_route
+                    #model_param_dict = dsm.read_parameter_dictionary_by_name(stream_info_dict.get('param_dict_name'))
+                    #stream_route = psm.read_stream_route(stream_id=product_stream_id)
 
                     stream_config[model_stream_name] = {'routing_key'           : stream_route.routing_key,
-                                                            'stream_id'             : product_stream_id,
-                                                            'stream_definition_ref' : stream_def_id,
-                                                            'exchange_point'        : stream_route.exchange_point,
-                                                            'parameter_dictionary'  : model_param_dict.dump(),
-                                                            'records_per_granule'  : stream_info_dict.get('records_per_granule'),
-                                                            'granule_publish_rate'  : stream_info_dict.get('granule_publish_rate'),
-                                                            'alarms'                : stream_info_dict.get('alarms')
+                                                        'stream_id'             : product_stream_id,
+                                                        'stream_definition_ref' : stream_def_id,
+                                                        'exchange_point'        : stream_route.exchange_point,
+                                                        'parameter_dictionary'  : model_param_dict.dump(),
+                                                        'records_per_granule'   : stream_info_dict.get('records_per_granule'),
+                                                        'granule_publish_rate'  : stream_info_dict.get('granule_publish_rate'),
+                                                        'alarms'                : stream_info_dict.get('alarms')
                     }
 
         log.debug("Stream config generated")
@@ -248,22 +286,28 @@ class AgentConfigurationBuilder(object):
         return stream_config
 
     def _generate_agent_config(self):
+        log.debug("_generate_agent_config for %s", self.agent_instance_obj.name)
         # should override this
         return {}
 
     def _generate_alerts_config(self):
+        log.debug("_generate_alerts_config for %s", self.agent_instance_obj.name)
         # should override this
         return self.agent_instance_obj.alerts
 
     def _generate_startup_config(self):
+        log.debug("_generate_startup_config for %s", self.agent_instance_obj.name)
         # should override this
         return {}
 
     def _generate_children(self):
+        log.debug("_generate_children for %s", self.agent_instance_obj.name)
         # should override this
         return {}
 
     def _generate_skeleton_config_block(self):
+        log.info("Generating skeleton config block for %s", self.agent_instance_obj.name)
+
         # should override this
         agent_config = self.agent_instance_obj.agent_config
 
@@ -276,6 +320,8 @@ class AgentConfigurationBuilder(object):
         agent_config['aparam_alert_config'] = self._generate_alerts_config()
         agent_config['startup_config']      = self._generate_startup_config()
         agent_config['children']            = self._generate_children()
+
+        log.info("DONE generating skeleton config block for %s", self.agent_instance_obj.name)
 
         return agent_config
 
@@ -443,9 +489,11 @@ class InstrumentAgentConfigurationBuilder(AgentConfigurationBuilder):
 
 
     def _generate_startup_config(self):
+        log.debug("_generate_startup_config for %s", self.agent_instance_obj.name)
         return self.agent_instance_obj.startup_config
 
     def _generate_driver_config(self):
+        log.debug("_generate_driver_config for %s", self.agent_instance_obj.name)
         # get default config
         driver_config = super(InstrumentAgentConfigurationBuilder, self)._generate_driver_config()
 
@@ -477,6 +525,7 @@ class PlatformAgentConfigurationBuilder(AgentConfigurationBuilder):
         """
         Generate the configuration for child devices
         """
+        log.debug("_generate_children for %s", self.agent_instance_obj.name)
         log.debug("Getting child platform device ids")
         child_pdevice_ids = self.RR2.find_platform_device_ids_of_device(self._get_device()._id)
         log.debug("found platform device ids: %s", child_pdevice_ids)

--- a/ion/util/enhanced_resource_registry_client.py
+++ b/ion/util/enhanced_resource_registry_client.py
@@ -7,7 +7,7 @@
 
 # THIS SHOULD BE FALSE IN COMMITTED CODE
 from ooi import logging
-from pyon.util.containers import get_ion_ts
+from pyon.util.containers import get_ion_ts, DotDict
 
 TEST_LOCALLY=False
 #TEST_LOCALLY=True
@@ -90,6 +90,7 @@ class EnhancedResourceRegistryClient(object):
         #
 
         self._cached_predicates = {}
+        self._cached_resources  = {}
 
         log.debug("done init")
 
@@ -159,12 +160,51 @@ class EnhancedResourceRegistryClient(object):
         @param resource_id the id to be deleted
         @param specific_type the name of an Ion type (e.g. RT.Resource)
         """
+        if specific_type in self._cached_resources and resource_id in self._cached_resources[specific_type].by_id:
+            log.info("Returning cached %s object", specific_type)
+            return self._cached_resources[specific_type].by_id[resource_id]
 
         resource_obj = self.RR.read(resource_id)
 
         self._check_type(resource_obj, specific_type, "to be read")
 
+        if specific_type in self._cached_resources:
+            log.info("Adding cached %s object", specific_type)
+            self._cached_resources[specific_type].by_id[resource_id] = resource_obj
+            self._cached_resources[specific_type].by_name[resource_obj.name] = resource_obj
+
         return resource_obj
+
+    def read_mult(self, resource_ids=None, specific_type=None):
+        if None is resource_ids:
+            resource_ids = []
+
+        if [] == resource_ids:
+            return [] # HACK because RR.read_mult([]) raises error instead of returning []
+
+        # normal case, check return types
+        if not specific_type in self._cached_resources:
+            ret = self.RR.read_mult(resource_ids)
+            if None is not specific_type:
+                if not all([type(r).__name__ == specific_type for r in ret]):
+                    raise BadRequest("Expected %s resources from read_mult, but received different type" %
+                                     specific_type)
+            return ret
+
+        log.info("Returning cached %s resources", specific_type)
+        cache = self._cached_resources[specific_type]
+
+        # fill in any holes that we can
+        misses = [x for x in resource_ids if x not in cache.by_id]
+        if misses:
+            log.info("Attempting to fill in %s cache misses", len(misses))
+            misses_objs = self.RR.read_mult(misses)
+            for mo in misses_objs:
+                if None is not mo:
+                    cache.by_id[mo._id] = mo
+                    cache.by_name[mo.name] = mo
+
+        return [cache.by_id.get(r, None) for r in resource_ids]
 
 
     def update(self, resource_obj=None, specific_type=None):
@@ -250,6 +290,22 @@ class EnhancedResourceRegistryClient(object):
                                         object=object_id)
         self.RR.delete_association(assoc)
 
+
+    def find_by_name(self, resource_type, name, id_only=False):
+        assert name
+        if resource_type not in self._cached_resources:
+            log.warn("Using find_by_name on resource type %s, which was not cached", resource_type)
+            ret, _ = self.RR.find_resources(restype=resource_type, name=name, id_only=id_only)
+            return ret[0]
+
+        log.info("Returning object from cache")
+        obj = self._cached_resources[resource_type].by_name[name]
+        if id_only:
+            return obj._id
+        else:
+            return obj
+
+
     def find_subjects(self, subject_type, predicate, object, id_only=False):
         object_id, object_type = self._extract_id_and_type(object)
 
@@ -271,13 +327,11 @@ class EnhancedResourceRegistryClient(object):
         log.debug("Processed %s %s predicates for subjects in %s seconds", len(preds), predicate, total_time / 1000.0)
 
         subject_ids = [a.s for a in self._cached_predicates[predicate] if object_id == a.o and a.st == subject_type]
-        if [] == subject_ids:
-            return [] # HACK because read_mult([]) raises error instead of returning []
-        elif id_only:
+        if id_only:
             return subject_ids
         else:
             log.debug("getting full subject IonObjects with read_mult")
-            return self.RR.read_mult(subject_ids)
+            return self.read_mult(subject_ids, subject_type)
 
 
     def find_objects(self, subject, predicate, object_type, id_only=False):
@@ -300,15 +354,11 @@ class EnhancedResourceRegistryClient(object):
         total_time = int(time_search_stop) - int(time_search_start)
         log.debug("Processed %s %s predicates for objects in %s seconds", len(preds), predicate, total_time / 1000.0)
 
-
-
-        if [] == object_ids:
-            return [] # HACK because read_mult([]) raises error instead of returning []
-        elif id_only:
+        if id_only:
             return object_ids
         else:
             log.debug("getting full object IonObjects with read_mult")
-            return self.RR.read_mult(object_ids)
+            return self.read_mult(object_ids)
 
 
     def find_subject(self, subject_type, predicate, object, id_only=False):
@@ -397,6 +447,7 @@ class EnhancedResourceRegistryClient(object):
 
         return ret
 
+
     def cache_predicate(self, predicate):
         """
         Save all associations of a given predicate type to memory, for in-memory find_subjects/objects ops
@@ -411,8 +462,52 @@ class EnhancedResourceRegistryClient(object):
         self._cached_predicates[predicate] = preds
 
 
+    def cache_resources(self, resource_type, specific_ids=None):
+        """
+        Save all resources of a given type to memory, for in-memory lookup ops
+        """
+        time_caching_start = get_ion_ts()
+
+        resource_objs = []
+        if None is specific_ids:
+            resource_objs, _ = self.RR.find_resources(restype=resource_type, id_only=False)
+        else:
+            assert type([]) == type(specific_ids)
+            if specific_ids:
+                resource_objs = self.RR.read_mult(specific_ids)
+
+        lookups = DotDict()
+        lookups.by_id =   dict([(r._id, r) for r in resource_objs])
+        lookups.by_name = dict([(r.name, r) for r in resource_objs])
+
+        time_caching_stop = get_ion_ts()
+
+        total_time = int(time_caching_stop) - int(time_caching_start)
+
+        log.info("Cached %s %s resources in %s seconds", len(resource_objs), resource_type, total_time / 1000.0)
+        self._cached_resources[resource_type] = lookups
+
+
     def has_cached_prediate(self, predicate):
         return predicate in self._cached_predicates
+
+
+    def has_cached_resource(self, resource_type):
+        return resource_type in self._cached_resources
+
+
+    def clear_cached_predicate(self, predicate=None):
+        if None is predicate:
+            self._cached_predicates = {}
+        else:
+            del self._cached_predicates[predicate]
+
+    def clear_cached_resource(self, resource_type=None):
+        if None is resource_type:
+            self._cached_resources = {}
+        else:
+            del self._cached_resources[resource_type]
+
 
     def _uncamel(self, name):
         """


### PR DESCRIPTION
Aggressive caching behavior reduces the time taken to run test_platform_hierarchy_with_some_instruments from 347 seconds to 218 seconds -- about a 2-minute improvement.  Almost all of this speedup was from working in generate_stream_config in the agent config building process, and there are still more gains to be realized.

Functionality added to enhanced resource registry client to support caching resources as well as predicates.

Functionality added to some DM classes to support resource-object-level operations so that RR.read can be avoided.
