### PR TITLE
assertions to determine where empty process_id comes from

### DIFF
--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -19,7 +19,7 @@ from ooi.logging import log
 
 from pyon.agent.agent import ResourceAgentClient
 from pyon.core.bootstrap import IonObject
-from pyon.core.exception import Inconsistent,BadRequest, NotFound
+from pyon.core.exception import Inconsistent,BadRequest, NotFound, ServerError
 from pyon.ion.resource import ExtendedResourceContainer
 from pyon.util.ion_time import IonTime
 from pyon.public import LCE
@@ -367,6 +367,8 @@ class InstrumentManagementService(BaseInstrumentManagementService):
             raise
 
         process_id = launcher.launch(config, config_builder._get_process_definition()._id)
+        if not process_id:
+            raise ServerError("Launched instrument agent instance return process_id='%s'" % process_id)
         config_builder.record_launch_parameters(config, process_id)
 
         self.record_instrument_producer_activation(config_builder._get_device()._id, instrument_agent_instance_id)

--- a/ion/services/sa/test/test_driver_egg.py
+++ b/ion/services/sa/test/test_driver_egg.py
@@ -318,6 +318,8 @@ class TestDriverEgg(IonIntegrationTestCase):
 
         #wait for start
         instance_obj = self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
+        print "Agent process id is '%s'" % str(instance_obj.agent_process_id)
+        self.assertTrue(instance_obj.agent_process_id)
         gate = ProcessStateGate(self.processdispatchclient.read_process,
                                 instance_obj.agent_process_id,
                                 ProcessStateEnum.RUNNING)

--- a/ion/util/agent_launcher.py
+++ b/ion/util/agent_launcher.py
@@ -32,7 +32,6 @@ class AgentLauncher(object):
                                                                       configuration=agent_config)
 
         log.info("AgentLauncher got process id='%s' from process_dispatcher.schedule_process()", process_id)
-        assert process_id
         self.process_id = process_id
         return process_id
 

--- a/ion/util/agent_launcher.py
+++ b/ion/util/agent_launcher.py
@@ -31,6 +31,8 @@ class AgentLauncher(object):
                                                                       schedule=process_schedule,
                                                                       configuration=agent_config)
 
+        log.info("AgentLauncher got process id='%s' from process_dispatcher.schedule_process()", process_id)
+        assert process_id
         self.process_id = process_id
         return process_id
 


### PR DESCRIPTION
Attempting to fix the broken buildbot test for instrument agent driver eggs, seemingly caused by a blank process_id being sent to read_process.
