### PR TITLE
Addresses problem in SMOKE

### DIFF
--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -58,18 +58,20 @@ class AgentConfigurationBuilder(object):
 
     def _predicates_to_cache(self):
         return [PRED.hasOutputProduct,
-                PRED.hasStream,
-                PRED.hasStreamDefinition,
+                #PRED.hasStream,
+                #PRED.hasStreamDefinition,
                 PRED.hasAgentInstance,
                 PRED.hasAgentDefinition,
                 PRED.hasDataset,
                 PRED.hasDevice,
-                PRED.hasParameterContext]
+                #PRED.hasParameterContext,
+                ]
 
     def _resources_to_cache(self):
-        return [RT.StreamDefinition,
-                RT.ParameterDictionary,
-                RT.ParameterContext]
+        return [#RT.StreamDefinition,
+                #RT.ParameterDictionary,
+                #RT.ParameterContext,
+                ]
 
     def _update_cached_predicates(self):
         # cache some predicates for in-memory lookups
@@ -253,18 +255,19 @@ class AgentConfigurationBuilder(object):
 
         #retrieve the output products
         device_id = device_obj._id
-        data_product_ids = self.RR2.find_data_product_ids_of_instrument_device_using_has_output_product(device_id)
+        data_product_objs = self.RR2.find_data_products_of_instrument_device_using_has_output_product(device_id)
 
-        out_streams = []
-        for product_id in data_product_ids:
+        out_streams = {}
+        for d in data_product_objs:
+            product_id = d._id
             stream_id = self.RR2.find_stream_id_of_data_product_using_has_stream(product_id)
-            out_streams.append(stream_id)
+            out_streams[stream_id] = d.name
 
 
         stream_config = {}
 
         log.debug("Creating a stream config for each stream (dataproduct) assoc with this agent/device")
-        for product_stream_id in out_streams:
+        for product_stream_id in out_streams.keys():
 
             #get the streamroute object from pubsub by passing the stream_id
             stream_def_id = self.RR2.find_stream_definition_id_of_stream_using_has_stream_definition(product_stream_id)
@@ -272,15 +275,16 @@ class AgentConfigurationBuilder(object):
             #match the streamdefs/apram dict for this model with the data products attached to this device to know which tag to use
             for model_stream_name, stream_info_dict  in streams_dict.items():
                 # read objects from cache to be compared
-                out_stream_def_obj = self.RR2.read(stream_def_id, RT.StreamDefinition)
-                agent_stream_def_obj = self.RR2.read(stream_info_dict.get('stream_def_id'), RT.StreamDefinition)
-                if PubsubManagementService.compare_stream_definition_objects(out_stream_def_obj, agent_stream_def_obj):
+
+                if psm.compare_stream_definition(stream_def_id, stream_info_dict.get('stream_def_id')):
                     #model_param_dict = self.RR2.find_resources_by_name(RT.ParameterDictionary,
                     #                                         stream_info_dict.get('param_dict_name'))[0]
-                    model_param_dict = self._get_param_dict_by_name(stream_info_dict.get('param_dict_name'))
-                    stream_route = self.RR2.read(product_stream_id).stream_route
-                    #model_param_dict = dsm.read_parameter_dictionary_by_name(stream_info_dict.get('param_dict_name'))
-                    #stream_route = psm.read_stream_route(stream_id=product_stream_id)
+                    #model_param_dict = self._get_param_dict_by_name(stream_info_dict.get('param_dict_name'))
+                    #stream_route = self.RR2.read(product_stream_id).stream_route
+                    model_param_dict = DatasetManagementService.get_parameter_dictionary_by_name(stream_info_dict.get('param_dict_name'))
+                    stream_route = psm.read_stream_route(stream_id=product_stream_id)
+
+                    log.info("stream_config[%s] matches product '%s'", model_stream_name, out_streams[product_stream_id])
 
                     if model_stream_name in stream_config:
                         log.warn("Overwiting stream_config[%s]", model_stream_name)

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -196,17 +196,17 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         # the following assert will not work without elasticsearch.
         #self.assertEqual( 1, len(extended_instrument.computed.user_notification_requests.value) )
-        self.assertEqual(extended_instrument.computed.communications_status_roll_up.value, StatusType.STATUS_WARNING)
-        self.assertEqual(extended_instrument.computed.data_status_roll_up.value, StatusType.STATUS_OK)
-        self.assertEqual(extended_instrument.computed.power_status_roll_up.value, StatusType.STATUS_WARNING)
+        self.assertEqual(StatusType.STATUS_WARNING, extended_instrument.computed.communications_status_roll_up.value)
+        self.assertEqual(StatusType.STATUS_OK, extended_instrument.computed.data_status_roll_up.value)
+        self.assertEqual(StatusType.STATUS_WARNING, extended_instrument.computed.power_status_roll_up.value)
 
         # Verify the computed attribute for user notification requests
         self.assertEqual( 1, len(extended_instrument.computed.user_notification_requests.value) )
         notifications = extended_instrument.computed.user_notification_requests.value
         notification = notifications[0]
-        self.assertEqual(notification.origin, expected_instrument_device_id)
-        self.assertEqual(notification.origin_type, "instrument")
-        self.assertEqual(notification.event_type, 'ResourceLifecycleEvent')
+        self.assertEqual(expected_instrument_device_id, notification.origin)
+        self.assertEqual("instrument", notification.origin_type)
+        self.assertEqual('ResourceLifecycleEvent', notification.event_type)
 
 
     def _check_computed_attributes_of_extended_product(self, expected_data_product_id = '', extended_data_product = None):
@@ -233,15 +233,15 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         self.assertIsInstance(extended_data_product.computed.data_datetime, ComputedListValue)
 
         # exact text here keeps changing to fit UI capabilities.  keep assertion general...
-        self.assertTrue( 'ok' in extended_data_product.computed.last_granule.value['quality_flag'] )
+        self.assertIn( 'ok', extended_data_product.computed.last_granule.value['quality_flag'] )
         self.assertEqual( 2, len(extended_data_product.computed.data_datetime.value) )
 
         notifications = extended_data_product.computed.user_notification_requests.value
 
         notification = notifications[0]
-        self.assertEqual(notification.origin, expected_data_product_id)
-        self.assertEqual(notification.origin_type, "data product")
-        self.assertEqual(notification.event_type, 'DetectionEvent')
+        self.assertEqual(expected_data_product_id, notification.origin)
+        self.assertEqual("data product", notification.origin_type)
+        self.assertEqual('DetectionEvent', notification.event_type)
 
 
     @attr('LOCOINT')
@@ -376,7 +376,7 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         parsed_pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
         parsed_stream_def_id = self.pubsubcli.create_stream_definition(name='parsed', parameter_dictionary_id=parsed_pdict_id)
 
-        raw_pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_raw_param_dict', id_only=True)
+        raw_pdict_id = self.dataset_management.read_parameter_dictionary_by_name('raw', id_only=True)
         raw_stream_def_id = self.pubsubcli.create_stream_definition(name='raw', parameter_dictionary_id=raw_pdict_id)
 
 
@@ -474,9 +474,9 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
             retval = self._ia_client.get_agent(['aggstatus'])['aggstatus']
             log.debug('TestActivateInstrument consume_event aggStatus: %s', retval)
             if event.sub_type == 'WARNING':
-                self.assertEqual(retval[AggregateStatusType.AGGREGATE_DATA], DeviceStatusEnum.STATUS_WARNING)
+                self.assertEqual(DeviceStatusEnum.STATUS_WARNING, retval[AggregateStatusType.AGGREGATE_DATA])
             elif event.sub_type == 'ALL_CLEAR':
-                self.assertEqual(retval[AggregateStatusType.AGGREGATE_DATA], DeviceStatusEnum.STATUS_OK)
+                self.assertEqual(DeviceStatusEnum.STATUS_OK, retval[AggregateStatusType.AGGREGATE_DATA])
 
             #once the alert is recived and the aggregate status is also received then finish
             if self._agg_event_recieved and self._alert_event_recieved:
@@ -528,14 +528,14 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         retval = self._ia_client.execute_agent(cmd)
         log.debug("test_activateInstrumentSample: initialize %s" , str(retval))
         state = self._ia_client.get_agent_state()
-        self.assertEqual(state, ResourceAgentState.INACTIVE)
+        self.assertEqual(ResourceAgentState.INACTIVE, state)
 
         log.debug("(L4-CI-SA-RQ-334): Sending go_active command ")
         cmd = AgentCommand(command=ResourceAgentEvent.GO_ACTIVE)
         reply = self._ia_client.execute_agent(cmd)
         log.debug("test_activateInstrument: return value from go_active %s" , str(reply))
         state = self._ia_client.get_agent_state()
-        self.assertEqual(state, ResourceAgentState.IDLE)
+        self.assertEqual(ResourceAgentState.IDLE, state)
 
         cmd = AgentCommand(command=ResourceAgentEvent.GET_RESOURCE_STATE)
         retval = self._ia_client.execute_agent(cmd)
@@ -546,27 +546,27 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         reply = self._ia_client.execute_agent(cmd)
         log.debug("test_activateInstrumentSample: run %s" , str(reply))
         state = self._ia_client.get_agent_state()
-        self.assertEqual(state, ResourceAgentState.COMMAND)
+        self.assertEqual(ResourceAgentState.COMMAND, state)
 
         cmd = AgentCommand(command=ResourceAgentEvent.PAUSE)
         retval = self._ia_client.execute_agent(cmd)
         state = self._ia_client.get_agent_state()
-        self.assertEqual(state, ResourceAgentState.STOPPED)
+        self.assertEqual(ResourceAgentState.STOPPED, state)
 
         cmd = AgentCommand(command=ResourceAgentEvent.RESUME)
         retval = self._ia_client.execute_agent(cmd)
         state = self._ia_client.get_agent_state()
-        self.assertEqual(state, ResourceAgentState.COMMAND)
+        self.assertEqual(ResourceAgentState.COMMAND, state)
 
         cmd = AgentCommand(command=ResourceAgentEvent.CLEAR)
         retval = self._ia_client.execute_agent(cmd)
         state = self._ia_client.get_agent_state()
-        self.assertEqual(state, ResourceAgentState.IDLE)
+        self.assertEqual(ResourceAgentState.IDLE, state)
 
         cmd = AgentCommand(command=ResourceAgentEvent.RUN)
         retval = self._ia_client.execute_agent(cmd)
         state = self._ia_client.get_agent_state()
-        self.assertEqual(state, ResourceAgentState.COMMAND)
+        self.assertEqual(ResourceAgentState.COMMAND, state)
 
         cmd = AgentCommand(command=SBE37ProtocolEvent.ACQUIRE_SAMPLE)
         for i in xrange(10):
@@ -587,9 +587,10 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         self.assertIsInstance(replay_data, Granule)
         rdt = RecordDictionaryTool.load_from_granule(replay_data)
         log.debug("test_activateInstrumentSample: RDT parsed: %s", str(rdt.pretty_print()) )
+        self.assertIn('temp', rdt)
         temp_vals = rdt['temp']
         pressure_vals  = rdt['pressure']
-        self.assertEquals(len(temp_vals) , 10)
+        self.assertEquals(10, len(temp_vals))
         log.debug("test_activateInstrumentSample: all temp_vals: %s", temp_vals )
         log.debug("test_activateInstrumentSample: all pressure_vals: %s", pressure_vals )
 
@@ -609,8 +610,9 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         rdt = RecordDictionaryTool.load_from_granule(replay_data)
         log.debug("RDT raw: %s", str(rdt.pretty_print()) )
 
+        self.assertIn('raw', rdt)
         raw_vals = rdt['raw']
-        self.assertEquals(len(raw_vals) , 10)
+        self.assertEquals(10, len(raw_vals))
 
 
         log.debug("l4-ci-sa-rq-138")


### PR DESCRIPTION
Less aggressive caching of resources in AgentConfigBuilder's stream_config generation means more service calls to pubsub management.  This adds about 40 seconds to TestPlatformLaunch.test_platform_hierarchy_with_some_instruments

In order to re-enable this cache, more classmethod functions will need to be added to the PubsubManagementService / DatasetManagementService classes so that ParameterDictionary and StreamDefinition objects can be compared by passing in the bare resources.  (Currently this is complicated by the fact that both of these comparisons involve building an object out of a cluster of resources first)
