### PR TITLE
Fix memory leak related to stream associated with data product that is left around

### DIFF
--- a/ion/services/sa/product/data_product_management_service.py
+++ b/ion/services/sa/product/data_product_management_service.py
@@ -130,7 +130,8 @@ class DataProductManagementService(BaseDataProductManagementService):
         # remove stream associations
         #--------------------------------------------------------------------------------
         #self.remove_streams(data_product_id)
-
+        stream_ids = self.clients.resource_registry.find_objects(data_product_id, PRED.hasStream, RT.Stream)
+        self.clients.pubsub_management.delete_stream(stream_ids[0])
 
         self.RR2.retire(data_product_id, RT.DataProduct)
 

--- a/ion/services/sa/product/data_product_management_service.py
+++ b/ion/services/sa/product/data_product_management_service.py
@@ -130,9 +130,12 @@ class DataProductManagementService(BaseDataProductManagementService):
         # remove stream associations
         #--------------------------------------------------------------------------------
         #self.remove_streams(data_product_id)
-        stream_ids = self.clients.resource_registry.find_objects(data_product_id, PRED.hasStream, RT.Stream)
+        stream_ids, _ = self.clients.resource_registry.find_objects(data_product_id, PRED.hasStream, RT.Stream, True)
         self.clients.pubsub_management.delete_stream(stream_ids[0])
 
+        #--------------------------------------------------------------------------------
+        # retire the data product
+        #--------------------------------------------------------------------------------
         self.RR2.retire(data_product_id, RT.DataProduct)
 
 

--- a/ion/services/sa/product/test/test_data_product_management_service_integration.py
+++ b/ion/services/sa/product/test/test_data_product_management_service_integration.py
@@ -35,7 +35,7 @@ from interface.objects import LastUpdate, ComputedValueAvailability, Granule, Da
 from ion.services.dm.ingestion.test.ingestion_management_test import IngestionManagementIntTest
 
 from nose.plugins.attrib import attr
-from interface.objects import ProcessDefinition
+from interface.objects import ProcessDefinition, DataProducer, DataProcessProducerContext
 
 from coverage_model.basic_types import AxisTypeEnum, MutabilityEnum
 from coverage_model.coverage import CRS, GridDomain, GridShape
@@ -176,6 +176,14 @@ class TestDataProductManagementServiceIntegration(IonIntegrationTestCase):
 
         dp_id = self.dpsc_cli.create_data_product( data_product= dp_obj,
                                             stream_definition_id=ctd_stream_def_id)
+        # Assert that the data product has an associated stream at this stage
+        stream_ids, _ = self.rrclient.find_objects(dp_id, PRED.hasStream, RT.Stream, True)
+        self.assertNotEquals(len(stream_ids), 0)
+
+        # Assert that the data product has an associated stream def at this stage
+        stream_ids, _ = self.rrclient.find_objects(dp_id, PRED.hasStreamDefinition, RT.StreamDefinition, True)
+        self.assertNotEquals(len(stream_ids), 0)
+
         self.dpsc_cli.activate_data_product_persistence(dp_id)
 
         dp_obj = self.dpsc_cli.read_data_product(dp_id)
@@ -251,6 +259,11 @@ class TestDataProductManagementServiceIntegration(IonIntegrationTestCase):
         # now 'delete' the data product
         log.debug("deleting data product: %s" % dp_id)
         self.dpsc_cli.delete_data_product(dp_id)
+
+        # Assert that there are no associated streams leftover after deleting the data product
+        stream_ids, _ = self.rrclient.find_objects(dp_id, PRED.hasStream, RT.Stream, True)
+        self.assertEquals(len(stream_ids), 0)
+
         self.dpsc_cli.force_delete_data_product(dp_id)
 
         # now try to get the deleted dp object

--- a/ion/util/enhanced_resource_registry_client.py
+++ b/ion/util/enhanced_resource_registry_client.py
@@ -246,6 +246,17 @@ class EnhancedResourceRegistryClient(object):
 
         return
 
+    def assign_stream_definition_to_data_product_with_has_stream_definition(self, stream_definition_id='', data_product_id=''):
+
+        self.RR.create_association(subject=data_product_id, predicate=PRED.hasStream, obj=stream_definition_id)
+
+    def assign_stream_to_data_product_with_has_stream(stream_id ='', data_product_id=''):
+
+        self.RR.create_association(subject=data_product_id, predicate=PRED.hasStream, obj=stream_id)
+
+    def assign_dataset_to_data_product_with_has_dataset(self, dataset_id = '', data_product_id = ''):
+
+        self.RR.create_association(subject=data_product_id, predicate=PRED.hasDataset, obj=dataset_id)
 
     def delete(self, resource_id):
 

--- a/ion/util/enhanced_resource_registry_client.py
+++ b/ion/util/enhanced_resource_registry_client.py
@@ -250,7 +250,7 @@ class EnhancedResourceRegistryClient(object):
 
         self.RR.create_association(subject=data_product_id, predicate=PRED.hasStream, obj=stream_definition_id)
 
-    def assign_stream_to_data_product_with_has_stream(stream_id ='', data_product_id=''):
+    def assign_stream_to_data_product_with_has_stream(self, stream_id ='', data_product_id=''):
 
         self.RR.create_association(subject=data_product_id, predicate=PRED.hasStream, obj=stream_id)
 

--- a/ion/util/enhanced_resource_registry_client.py
+++ b/ion/util/enhanced_resource_registry_client.py
@@ -246,18 +246,6 @@ class EnhancedResourceRegistryClient(object):
 
         return
 
-    def assign_stream_definition_to_data_product_with_has_stream_definition(self, stream_definition_id='', data_product_id=''):
-
-        self.RR.create_association(subject=data_product_id, predicate=PRED.hasStreamDefinition, object=stream_definition_id)
-
-    def assign_stream_to_data_product_with_has_stream(self, stream_id ='', data_product_id=''):
-
-        self.RR.create_association(subject=data_product_id, predicate=PRED.hasStream, object=stream_id)
-
-    def assign_dataset_to_data_product_with_has_dataset(self, dataset_id = '', data_product_id = ''):
-
-        self.RR.create_association(subject=data_product_id, predicate=PRED.hasDataset, object=dataset_id)
-
     def delete(self, resource_id):
 
         raise NotImplementedError("TODO: remove me")

--- a/ion/util/enhanced_resource_registry_client.py
+++ b/ion/util/enhanced_resource_registry_client.py
@@ -248,15 +248,15 @@ class EnhancedResourceRegistryClient(object):
 
     def assign_stream_definition_to_data_product_with_has_stream_definition(self, stream_definition_id='', data_product_id=''):
 
-        self.RR.create_association(subject=data_product_id, predicate=PRED.hasStream, obj=stream_definition_id)
+        self.RR.create_association(subject=data_product_id, predicate=PRED.hasStreamDefinition, object=stream_definition_id)
 
     def assign_stream_to_data_product_with_has_stream(self, stream_id ='', data_product_id=''):
 
-        self.RR.create_association(subject=data_product_id, predicate=PRED.hasStream, obj=stream_id)
+        self.RR.create_association(subject=data_product_id, predicate=PRED.hasStream, object=stream_id)
 
     def assign_dataset_to_data_product_with_has_dataset(self, dataset_id = '', data_product_id = ''):
 
-        self.RR.create_association(subject=data_product_id, predicate=PRED.hasDataset, obj=dataset_id)
+        self.RR.create_association(subject=data_product_id, predicate=PRED.hasDataset, object=dataset_id)
 
     def delete(self, resource_id):
 


### PR DESCRIPTION
- Cleans up stream associated with data product in delete_data_product.
- Adds test code to verify that the stream is indeed cleaned up when delete_data_product is used.
