### PR TITLE
CIDEVSA-489 and OOIION-791 - deployment activation

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -98,7 +98,7 @@ CANDIDATE_UI_ASSETS = 'https://userexperience.oceanobservatories.org/database-ex
 MASTER_DOC = "https://docs.google.com/spreadsheet/pub?key=0AttCeOvLP6XMdG82NHZfSEJJOGdQTkgzb05aRjkzMEE&output=xls"
 
 ### the URL below should point to a COPY of the master google spreadsheet that works with this version of the loader
-TESTED_DOC = "https://docs.google.com/spreadsheet/pub?key=0AgGScp7mjYjydGIzUEdZQUZGeHJaRWVFbTBHMkpuUGc&output=xls"
+TESTED_DOC = "https://docs.google.com/spreadsheet/pub?key=0AiJoHeWBzmnAdDJwUHdxdjBnOGxnMW5wRndQQ2tjcUE&output=xls"
 #
 ### while working on changes to the google doc, use this to run test_loader.py against the master spreadsheet
 #TESTED_DOC=MASTER_DOC
@@ -2383,11 +2383,17 @@ Reason: %s
     def _load_Deployment(self,row):
         constraints = self._get_constraints(row, type='Deployment')
         coordinate_name = row['coordinate_system']
+        context_type = row['context_type']
+
+        context = IonObject(context_type)
+
 
         deployment_id = self._basic_resource_create(row, "Deployment", "d/",
                                              "observatory_management", "create_deployment",
                                              constraints=constraints, constraint_field='constraint_list',
-                                             set_attributes=dict(coordinate_reference_system=self.resource_ids[coordinate_name]) if coordinate_name else None)
+                                             set_attributes={"coordinate_reference_system": self.resource_ids[coordinate_name] if coordinate_name else None,
+                                                             "context": context})
+
 
         device_id = self.resource_ids[row['device_id']]
         site_id = self.resource_ids[row['site_id']]

--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -2268,13 +2268,7 @@ Reason: %s
             else:
                 svc_client = self._get_service_client("data_acquisition_management")
                 svc_client.assign_data_product(res_id, dp_id, headers=self._get_system_actor_headers())
-        elif type=='InstrumentSite':
-            if self.bulk and do_bulk:
-                # Why create a site data product here???
-                pass
-            else:
-                svc_client = self._get_service_client('observatory_management')
-                svc_client.create_site_data_product(res_id, dp_id, headers=self._get_system_actor_headers())
+
 
     def _load_DataProductLink_OOI(self):
         ooi_objs = self.ooi_loader.get_type_assets("instrument")

--- a/ion/services/sa/observatory/deployment_activator.py
+++ b/ion/services/sa/observatory/deployment_activator.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python
+
+"""
+@package  ion.services.sa.instrument.deployment_activator
+@author   Ian Katz
+"""
+import copy
+
+from ion.util.enhanced_resource_registry_client import EnhancedResourceRegistryClient
+from pyon.core.exception import BadRequest, NotFound
+from pyon.ion.resource import PRED, RT, OT
+
+from ooi.logging import log
+from pyon.util.containers import get_ion_ts
+
+import constraint
+
+CSP_DEVICE_PREFIX = "Csp-Device"
+def mk_csp_var(label):
+    return "%s_%s" % (CSP_DEVICE_PREFIX, label)
+
+def unpack_csp_var(var):
+    return var.split("_")[1]
+
+class DeploymentOperatorFactory(object):
+    def __init__(self, clients, RR2=None):
+        self.clients = clients
+        self.RR2 = RR2 #enhanced resource registry client
+
+    def creation_type(self):
+        raise NotImplementedError("this function should be overridden, and return the class to be instantiated")
+
+    def create(self, deployment_obj):
+        deployment_context_type = type(deployment_obj.context).__name__
+
+        new_object_type = self.creation_type()
+
+        # a bundled, integrated platform
+        if OT.RemotePlatformDeploymentContext == deployment_context_type:
+            return new_object_type(self.clients,
+                                   deployment_obj,
+                                   allow_children=True,
+                                   include_children=True,
+                                   RR2=self.RR2)
+
+        # a one-to-one deployment of an instrument onto an RSN platform
+        if OT.CabledInstrumentDeploymentContext == deployment_context_type:
+            return new_object_type(self.clients,
+                                   deployment_obj,
+                                   allow_children=False,
+                                   include_children=False,
+                                   RR2=self.RR2)
+
+        # single node, with instruments optionally
+        if OT.CabledNodeDeploymentContext == deployment_context_type:
+            return new_object_type(self.clients,
+                                   deployment_obj,
+                                   allow_children=True,
+                                   include_children=False,
+                                   RR2=self.RR2)
+
+class DeploymentActivatorFactory(DeploymentOperatorFactory):
+
+    def creation_type(self):
+        return DeploymentActivator
+
+
+class DeploymentResourceCollectorFactory(DeploymentOperatorFactory):
+
+    def creation_type(self):
+        return DeploymentResourceCollector
+
+
+
+
+
+
+class DeploymentOperator(object):
+
+    def __init__(self, clients, deployment_obj, allow_children, include_children, RR2=None):
+        """
+        @param clients dict of clients from a service
+        @param deployment_obj the deployment to activate
+        @param allow_children whether to allow children of a device to be provided
+        @param include_children whether to search for child devices from root device
+        @param RR2 a reference to an enhanced RR client
+        """
+
+        self.clients = clients
+        self.RR2 = RR2
+
+        #sanity
+        if include_children: assert allow_children
+        self.allow_children = allow_children
+        self.include_children = include_children
+
+        if None is self.RR2:
+            self.RR2 = EnhancedResourceRegistryClient(self.clients.resource_registry)
+
+        if not isinstance(self.RR2, EnhancedResourceRegistryClient):
+            raise AssertionError("Type of self.RR2 is %s not %s" %
+                                 (type(self.RR2), type(EnhancedResourceRegistryClient)))
+
+        self.deployment_obj = deployment_obj
+
+        self.on_init()
+
+    def on_init(self):
+        pass
+
+
+class DeploymentResourceCollector(DeploymentOperator):
+
+    def on_init(self):
+        self._device_models = {}
+        self._site_models = {}
+
+        self._model_lookup = {}
+        self._type_lookup = {}
+
+        self._typecache_hits = 0
+        self._typecache_miss = 0
+
+        self._modelcache_hits = 0
+        self._modelcache_miss = 0
+
+
+    def collected_device_ids(self):
+        return self._device_models.keys()
+
+    def collected_site_ids(self):
+        return self._site_models.keys()
+
+    def collected_models_by_site(self):
+        return copy.copy(self._site_models)
+
+    def collected_models_by_device(self):
+        return copy.copy(self._device_models)
+
+    def typecache_add(self, resource_id, resource_type):
+        assert resource_type in RT
+        log.debug("typecache_add type %s", resource_type)
+        self._type_lookup[resource_id] = resource_type
+
+    def read_using_typecache(self, resource_id):
+        """
+        RR2.read needs a type to do a cache lookup... so keep a cache of object types, because
+        sometimes we don't know if an ID is for a platform or instrument model/device/site
+        """
+        if resource_id in self._type_lookup:
+            self._typecache_hits += 1
+            log.trace("Typeache HIT/miss = %s / %s", self._typecache_hits, self._typecache_miss)
+            return self.RR2.read(resource_id, self._type_lookup[resource_id])
+
+        self._typecache_miss += 1
+        log.trace("Typeache hit/MISS = %s / %s", self._typecache_hits, self._typecache_miss)
+        rsrc_obj = self.RR2.read(resource_id)
+        self.typecache_add(resource_id, rsrc_obj._get_type())
+        return rsrc_obj
+
+
+    def get_resource_type(self, resource_id):
+        return self.read_using_typecache(resource_id)._get_type()
+
+    def find_models_fromcache(self, resource_id):
+        if resource_id in self._type_lookup:
+            self._modelcache_hits += 1
+            log.trace("Modelcache HIT/miss = %s / %s", self._modelcache_hits, self._modelcache_miss)
+            return self._model_lookup[resource_id]
+
+        self._modelcache_miss += 1
+        log.trace("Modelcache hit/MISS = %s / %s", self._modelcache_hits, self._modelcache_miss)
+
+        rsrc_type = self.get_resource_type(resource_id)
+        if RT.PlatformDevice == rsrc_type:
+            model = self.RR2.find_platform_model_id_of_platform_device_using_has_model(resource_id)
+        elif RT.PlatformSite == rsrc_type:
+            model = self.RR2.find_platform_model_ids_of_platform_site_using_has_model(resource_id)
+        elif RT.InstrumentDevice == rsrc_type:
+            model = self.RR2.find_instrument_model_id_of_instrument_device_using_has_model(resource_id)
+        elif RT.InstrumentSite == rsrc_type:
+            model = self.RR2.find_instrument_model_ids_of_instrument_site_using_has_model(resource_id)
+        else:
+            raise AssertionError("Got unexpected type from which to find a model: %s" % rsrc_type)
+
+        self._model_lookup[resource_id] = model
+
+        return model
+
+
+    
+    def _predicates_to_cache(self):
+        return [
+            PRED.hasDeployment,
+            PRED.hasDevice,
+            PRED.hasSite,
+            PRED.hasModel,
+            ]
+
+    def _resources_to_cache(self):
+        return [
+            RT.InstrumentDevice,
+            RT.InstrumentSite,
+            RT.PlatformDevice,
+            RT.PlatformSite,
+        ]
+
+    def _update_cached_predicates(self):
+        # cache some predicates for in-memory lookups
+        preds = self._predicates_to_cache()
+        log.debug("updating cached predicates: %s" % preds)
+        time_caching_start = get_ion_ts()
+        for pred in preds:
+            log.debug(" - %s", pred)
+            self.RR2.cache_predicate(pred)
+        time_caching_stop = get_ion_ts()
+
+        total_time = int(time_caching_stop) - int(time_caching_start)
+
+        log.info("Cached %s predicates in %s seconds", len(preds), total_time / 1000.0)
+
+    def _update_cached_resources(self):
+        # cache some resources for in-memory lookups
+        rsrcs = self._resources_to_cache()
+        log.debug("updating cached resources: %s" % rsrcs)
+        time_caching_start = get_ion_ts()
+        for r in rsrcs:
+            log.debug(" - %s", r)
+            self.RR2.cache_resources(r)
+        time_caching_stop = get_ion_ts()
+
+        total_time = int(time_caching_stop) - int(time_caching_start)
+
+        log.info("Cached %s resource types in %s seconds", len(rsrcs), total_time / 1000.0)
+
+    def _fetch_caches(self):
+        if any([not self.RR2.has_cached_prediate(x) for x in self._predicates_to_cache()]):
+            self._update_cached_predicates()
+
+        if any([not self.RR2.has_cached_resource(x) for x in self._resources_to_cache()]):
+            self._update_cached_resources()
+
+
+    def _clear_caches(self):
+        log.warn("Clearing caches")
+        for r in self._resources_to_cache():
+            self.RR2.clear_cached_resource(r)
+
+        for p in self._predicates_to_cache():
+            self.RR2.clear_cached_predicate(p)
+
+
+    def _build_tree(self, root_id, assn_type, leaf_types, known_leaves):
+
+        leftover_leaves = known_leaves[:]
+        if root_id in leftover_leaves:
+            leftover_leaves.remove(root_id)
+
+        root_obj = self.read_using_typecache(root_id)
+
+        log.debug("building base values")
+        # the base value
+        tree = {}
+        tree["_id"] = root_id
+        tree["name"] = root_obj.name
+        tree["children"] = {}
+        if PRED.hasDevice == assn_type:
+            tree["model"] = self.find_models_fromcache(root_id)
+            tree["model_name"] = self.RR2.read(tree["model"]).name
+            assert type("") == type(tree["model"]) == type(tree["model_name"])
+        elif PRED.hasSite == assn_type:
+            log.debug("making models")
+            tree["models"] = self.find_models_fromcache(root_id)
+            log.debug("making model_names")
+            tree["model_names"] = [self.read_using_typecache(m).name for m in tree["models"]]
+            log.debug("making uplink port")
+            tree["uplink_port"] = root_obj.planned_uplink_port.reference_designator
+            assert type([]) == type(tree["models"]) == type(tree["model_names"])
+        else:
+            raise AssertionError("Got unexpected predicate %s" % assn_type)
+
+        children  = []
+        for lt in leaf_types:
+            immediate_children = self.RR2.find_objects(root_id, assn_type, lt, True)
+
+            # filter list to just the allowed stuff if we aren't meant to find new all children
+            if not self.include_children:
+                immediate_children = filter(lambda x: x in known_leaves, immediate_children)
+
+            children += immediate_children
+
+        for c in children:
+            child_tree, leftover_leaves = self._build_tree(c, assn_type, leaf_types, leftover_leaves)
+            tree["children"][c] = child_tree
+
+        return tree, leftover_leaves
+
+
+    def _attempt_site_tree_build(self, site_ids):
+        log.debug("Attempting site tree build")
+        for d in site_ids:
+            tree, leftovers = self._build_tree(d, PRED.hasSite, [RT.InstrumentSite, RT.PlatformSite], site_ids)
+            if 0 == len(leftovers):
+                return tree
+        return None
+
+
+    def _attempt_device_tree_build(self, device_ids):
+        log.debug("Attempting device tree build")
+        for d in device_ids:
+            tree, leftovers = self._build_tree(d, PRED.hasDevice, [RT.InstrumentDevice, RT.PlatformDevice], device_ids)
+            if 0 == len(leftovers):
+                return tree
+        return None
+
+
+    def collect(self):
+        # fetch caches just in time
+        self._fetch_caches()
+
+        deployment_id = self.deployment_obj._id
+
+        device_models = {}
+        site_models = {}
+
+        # collect all devices in this deployment
+
+        def add_sites(site_ids, model_type):
+            for s in site_ids:
+                models = self.RR2.find_objects(s, PRED.hasModel, model_type, id_only=True)
+                for m in models: self.typecache_add(m, model_type)
+                log.trace("Found %s %s objects of site", len(models), model_type)
+                if s in site_models:
+                    log.warn("Site '%s' was already collected in deployment '%s'", s, deployment_id)
+                site_models[s] = models
+                self._model_lookup[s] = models
+
+        def add_devices(device_ids, model_type):
+            for d in device_ids:
+                model = self.RR2.find_object(d, PRED.hasModel, model_type, id_only=True)
+                self.typecache_add(model, model_type)
+                log.trace("Found 1 %s object of device", model_type)
+                if d in device_models:
+                    log.warn("Device '%s' was already collected in deployment '%s'", d, deployment_id)
+                device_models[d] = model
+                self._model_lookup[d] = model
+
+
+        def collect_specific_resources(site_type, device_type, model_type):
+            # check this deployment -- specific device types -- for validity
+            # return a list of pairs (site, device) to be associated
+            log.debug("Collecting resources: site=%s device=%s model=%s", site_type, device_type, model_type)
+            new_site_ids = self.RR2.find_subjects(site_type,
+                                                    PRED.hasDeployment,
+                                                    deployment_id,
+                                                    True)
+            log.debug("Found %s %s", len(new_site_ids), site_type)
+
+            new_device_ids = self.RR2.find_subjects(device_type,
+                                                      PRED.hasDeployment,
+                                                      deployment_id,
+                                                      True)
+            log.debug("Found %s %s", len(new_device_ids), device_type)
+
+            add_sites(new_site_ids, model_type)
+            add_devices(new_device_ids, model_type)
+
+            for s in new_site_ids:   self.typecache_add(s, site_type)
+            for d in new_device_ids: self.typecache_add(d, device_type)
+
+        # collect platforms, verify that only one platform device exists in the deployment
+        collect_specific_resources(RT.PlatformSite, RT.PlatformDevice, RT.PlatformModel)
+        collect_specific_resources(RT.InstrumentSite, RT.InstrumentDevice, RT.InstrumentModel)
+
+        site_tree   = self._attempt_site_tree_build(site_models.keys())
+        device_tree = self._attempt_device_tree_build(device_models.keys())
+
+        log.info("Got site tree: %s" % site_tree)
+        log.info("Got device tree: %s" % device_tree)
+
+
+        self._device_models = device_models
+        self._site_models = site_models
+
+
+
+class DeploymentActivator(DeploymentOperator):
+
+    def on_init(self):
+        resource_collector_factory = DeploymentResourceCollectorFactory(self.clients, self.RR2)
+        self.resource_collector = resource_collector_factory.create(self.deployment_obj)
+
+        self._hasdevice_associations_to_delete = []
+        self._hasdevice_associations_to_create = []
+
+    def hasdevice_associations_to_delete(self):
+        return self._hasdevice_associations_to_delete[:]
+
+    def hasdevice_associations_to_create(self):
+        return self._hasdevice_associations_to_create[:]
+
+    def _csp_solution_to_string(self, soln):
+        ret = "%s" % type(soln).__name__
+
+        for k, s in soln.iteritems():
+            d = unpack_csp_var(k)
+            log.trace("reading device %s", d)
+            dev_obj = self.resource_collector.read_using_typecache(d)
+            log.trace("reading site %s", s)
+            site_obj = self.resource_collector.read_using_typecache(s)
+            ret = "%s, %s '%s' -> %s '%s'" % (ret, dev_obj._get_type(), d, site_obj._get_type(), s)
+        return ret
+
+
+    def prepare(self, will_launch=True):
+        """
+        Prepare (validate) an agent for launch, fetching all associated resources
+
+        @param will_launch - whether the running status should be checked -- set false if just generating config
+        """
+
+        #TODO: check for already deployed?
+
+
+        self.resource_collector.collect()
+
+        log.debug("about to collect deployment components")
+        device_models = self.resource_collector.collected_models_by_device()
+        site_models = self.resource_collector.collected_models_by_site()
+
+        log.debug("Collected %s device models, %s site models", len(device_models), len(site_models))
+
+        solutions = self._get_deployment_csp_solutions(device_models, site_models)
+
+        pairs_add = []
+        pairs_rem = []
+
+        if 1 > len(solutions):
+            raise BadRequest("The set of devices could not be mapped to the set of sites, based on matching " +
+                             "models") # and streamdefs")
+        elif 1 < len(solutions):
+            log.info("Found %d possible ways to map device and site", len(solutions))
+            log.trace("Here is the %s of all of them:", type(solutions).__name__)
+            for i, s in enumerate(solutions):
+                log.trace("Option %d: %s" , i+1, self._csp_solution_to_string(s))
+        else:
+            log.info("Found one possible way to map devices and sites.  Best case scenario!")
+
+            #figure out if any of the devices in the new mapping are already mapped and need to be removed
+            #then add the new mapping to the output array
+            for device_id in device_models.keys():
+                site_id = solutions[0][mk_csp_var(device_id)]
+                old_pair = self._find_existing_relationship(site_id, device_id)
+                if old_pair:
+                    pairs_rem.append(old_pair)
+                new_pair = (site_id, device_id)
+                pairs_add.append(new_pair)
+
+
+
+        log.debug("falling back on port assignments")
+
+        self._hasdevice_associations_to_create = sorted(pairs_add)
+        self._hasdevice_associations_to_delete = sorted(pairs_rem)
+
+
+
+
+    def _find_existing_relationship(self, site_id, device_id, site_type=None, device_type=None):
+        assert(type("") == type(site_id) == type(device_id))
+
+        log.debug("checking %s/%s pair for deployment", site_type, device_type)
+        #return a pair that should be REMOVED, or None
+
+        if site_type is None:
+            site_type = self.resource_collector.get_resource_type(site_id)
+
+        if device_type is None:
+            device_type = self.resource_collector.get_resource_type(device_id)
+
+
+        log.debug("checking existing hasDevice links from site")
+
+        ret = None
+
+        try:
+            found_device_id = self.RR2.find_object(site_id, PRED.hasDevice, device_type, True)
+
+            if found_device_id != device_id:
+                ret = (site_id, found_device_id)
+                log.info("%s '%s' is already hasDevice with a %s", site_type, site_id, device_type)
+
+        except NotFound:
+            pass
+
+        return ret
+
+
+    def _get_deployment_csp_solutions(self, device_models, site_models):
+
+        log.debug("creating a CSP solver to match devices and sites")
+        problem = constraint.Problem()
+
+        log.debug("adding variables to CSP - the devices to be assigned, and their range (possible sites)")
+        for device_id in device_models.keys():
+            device_model = device_models[device_id]
+            assert type(device_model) == type('')
+            assert all([type('') == type(s) for s in site_models])
+            possible_sites = [s for s in site_models.keys()
+                              if device_model in site_models[s]]
+
+            if not possible_sites:
+                log.info("Device model: %s", device_model)
+                log.info("Site models: %s", site_models)
+                raise BadRequest("No sites were found in the deployment")
+
+            problem.addVariable(mk_csp_var(device_id), possible_sites)
+
+        log.debug("adding the constraint that all the variables have to pick their own site")
+        problem.addConstraint(constraint.AllDifferentConstraint(),
+            [mk_csp_var(device_id) for device_id in device_models.keys()])
+
+        log.debug("performing CSP solve")
+        # this will be a list of solutions, each a dict of var -> value
+        return problem.getSolutions()
+
+
+
+

--- a/ion/services/sa/observatory/deployment_activator.py
+++ b/ion/services/sa/observatory/deployment_activator.py
@@ -425,6 +425,12 @@ class DeploymentResourceCollector(DeploymentOperator):
         site_tree   = self._attempt_site_tree_build(site_models.keys())
         device_tree = self._attempt_device_tree_build(device_models.keys())
 
+        if len(device_models) > len(site_models):
+            raise BadRequest("Devices in this deployment outnumber sites (%s to %s)" % (len(device_models), len(site_models)))
+
+        if 0 == len(device_models):
+            raise BadRequest("No devices were found in the deployment")
+
         if not site_tree:
             raise BadRequest("Sites in this deployment were not all part of the same tree")
 

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -266,6 +266,8 @@ class TestDeployment(IonIntegrationTestCase):
         log.debug("activating deployment, expecting success")
         self.omsclient.activate_deployment(res.deployment_id)
 
+        log.debug("deactivatin deployment, expecting success")
+        self.omsclient.deactivate_deployment(res.deployment_id)
 
     #@unittest.skip("targeting")
     def test_activate_deployment_nomodels(self):
@@ -335,7 +337,8 @@ class TestDeployment(IonIntegrationTestCase):
         instrument_device_id = [self.RR2.create(any_old(RT.InstrumentDevice)) for _ in range(9)]
         platform_device_id   = [self.RR2.create(any_old(RT.PlatformDevice)) for _ in range(4)]
 
-        deployment_id = self.RR2.create(any_old(RT.Deployment))
+        deployment_id = self.RR2.create(any_old(RT.Deployment,
+                                        {"context": IonObject(OT.RemotePlatformDeploymentContext)}))
 
         def instrument_model_at(platform_idx, instrument_idx):
             m = platform_idx * 2

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -331,11 +331,20 @@ class TestDeployment(IonIntegrationTestCase):
         instrument_model_id  = [self.RR2.create(any_old(RT.InstrumentModel)) for _ in range(6)]
         platform_model_id    = [self.RR2.create(any_old(RT.PlatformModel)) for _ in range(3)]
 
-        instrument_site_id   = [self.RR2.create(any_old(RT.InstrumentSite)) for _ in range(9)]
-        platform_site_id     = [self.RR2.create(any_old(RT.PlatformSite)) for _ in range(4)]
-
         instrument_device_id = [self.RR2.create(any_old(RT.InstrumentDevice)) for _ in range(9)]
         platform_device_id   = [self.RR2.create(any_old(RT.PlatformDevice)) for _ in range(4)]
+
+        instrument_site_id   = [self.RR2.create(any_old(RT.InstrumentSite,
+                                                {"planned_uplink_port":
+                                                     IonObject(OT.PlatformPort,
+                                                               reference_designator="instport_%d" % (i+1))}))
+                                for i in range(9)]
+
+        platform_site_id     = [self.RR2.create(any_old(RT.PlatformSite,
+                                                {"planned_uplink_port":
+                                                    IonObject(OT.PlatformPort,
+                                                              reference_designator="platport_%d" % (i+1))}))
+                                for i in range(4)]
 
         deployment_id = self.RR2.create(any_old(RT.Deployment,
                                         {"context": IonObject(OT.RemotePlatformDeploymentContext)}))
@@ -380,6 +389,9 @@ class TestDeployment(IonIntegrationTestCase):
         self.RR2.assign_deployment_to_platform_device_with_has_deployment(deployment_id, platform_device_id[3])
         self.RR2.assign_deployment_to_platform_site_with_has_deployment(deployment_id, platform_site_id[3])
 
+
+
+
         # verify structure
         for p in range(3):
             parent_id = self.RR2.find_platform_device_id_by_platform_device_using_has_device(platform_device_id[p])
@@ -395,6 +407,14 @@ class TestDeployment(IonIntegrationTestCase):
             self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_instrument_device_using_has_deployment(i))
         for i in instrument_site_id:
             self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_instrument_site_using_has_deployment(i))
+
+        for i in range(len(platform_site_id)):
+            self.assertEqual(self.RR2.find_platform_model_of_platform_device_using_has_model(platform_device_id[i]),
+                             self.RR2.find_platform_model_of_platform_site_using_has_model(platform_site_id[i]))
+
+        for i in range(len(instrument_site_id)):
+            self.assertEqual(self.RR2.find_instrument_model_of_instrument_device_using_has_model(instrument_device_id[i]),
+                             self.RR2.find_instrument_model_of_instrument_site_using_has_model(instrument_site_id[i]))
 
 
         self.omsclient.activate_deployment(deployment_id)

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -354,54 +354,54 @@ class TestDeployment(IonIntegrationTestCase):
         # set up the structure
         for p in range(3):
             m = platform_model_at(p)
-            self.RR2.assign_platform_model_to_platform_site(platform_model_id[m], platform_site_id[p])
-            self.RR2.assign_platform_model_to_platform_device(platform_model_id[m], platform_device_id[p])
-            self.RR2.assign_platform_device_to_platform_device(platform_device_id[p], platform_device_id[3])
+            self.RR2.assign_platform_model_to_platform_site_with_has_model(platform_model_id[m], platform_site_id[p])
+            self.RR2.assign_platform_model_to_platform_device_with_has_model(platform_model_id[m], platform_device_id[p])
+            self.RR2.assign_platform_device_to_platform_device_with_has_device(platform_device_id[p], platform_device_id[3])
             self.RR2.assign_platform_site_to_platform_site_with_has_site(platform_site_id[p], platform_site_id[3])
-            self.RR2.assign_deployment_to_platform_device(deployment_id, platform_device_id[p])
-            self.RR2.assign_deployment_to_platform_site(deployment_id, platform_site_id[p])
+            self.RR2.assign_deployment_to_platform_device_with_has_deployment(deployment_id, platform_device_id[p])
+            self.RR2.assign_deployment_to_platform_site_with_has_deployment(deployment_id, platform_site_id[p])
 
             for i in range(3):
                 m = instrument_model_at(p, i)
                 idx = instrument_at(p, i)
-                self.RR2.assign_instrument_model_to_instrument_site(instrument_model_id[m], instrument_site_id[idx])
-                self.RR2.assign_instrument_model_to_instrument_device(instrument_model_id[m], instrument_device_id[idx])
-                self.RR2.assign_instrument_device_to_platform_device(instrument_device_id[idx], platform_device_id[p])
+                self.RR2.assign_instrument_model_to_instrument_site_with_has_model(instrument_model_id[m], instrument_site_id[idx])
+                self.RR2.assign_instrument_model_to_instrument_device_with_has_model(instrument_model_id[m], instrument_device_id[idx])
+                self.RR2.assign_instrument_device_to_platform_device_with_has_device(instrument_device_id[idx], platform_device_id[p])
                 self.RR2.assign_instrument_site_to_platform_site_with_has_site(instrument_site_id[idx], platform_site_id[p])
-                self.RR2.assign_deployment_to_instrument_device(deployment_id, instrument_device_id[idx])
-                self.RR2.assign_deployment_to_instrument_site(deployment_id, instrument_site_id[idx])
+                self.RR2.assign_deployment_to_instrument_device_with_has_deployment(deployment_id, instrument_device_id[idx])
+                self.RR2.assign_deployment_to_instrument_site_with_has_deployment(deployment_id, instrument_site_id[idx])
 
         # top level models
-        self.RR2.assign_platform_model_to_platform_device(platform_model_id[2], platform_device_id[3])
-        self.RR2.assign_platform_model_to_platform_site(platform_model_id[2], platform_site_id[3])
-        self.RR2.assign_deployment_to_platform_device(deployment_id, platform_device_id[3])
-        self.RR2.assign_deployment_to_platform_site(deployment_id, platform_site_id[3])
+        self.RR2.assign_platform_model_to_platform_device_with_has_model(platform_model_id[2], platform_device_id[3])
+        self.RR2.assign_platform_model_to_platform_site_with_has_model(platform_model_id[2], platform_site_id[3])
+        self.RR2.assign_deployment_to_platform_device_with_has_deployment(deployment_id, platform_device_id[3])
+        self.RR2.assign_deployment_to_platform_site_with_has_deployment(deployment_id, platform_site_id[3])
 
         # verify structure
         for p in range(3):
-            parent_id = self.RR2.find_platform_device_id_by_platform_device(platform_device_id[p])
+            parent_id = self.RR2.find_platform_device_id_by_platform_device_using_has_device(platform_device_id[p])
             self.assertEqual(platform_device_id[3], parent_id)
 
             parent_id = self.RR2.find_platform_site_id_by_platform_site_using_has_site(platform_site_id[p])
             self.assertEqual(platform_site_id[3], parent_id)
         for p in platform_device_id:
-            self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_platform_device(p))
+            self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_platform_device_using_has_deployment(p))
         for p in platform_site_id:
-            self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_platform_site(p))
+            self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_platform_site_using_has_deployment(p))
         for i in instrument_device_id:
-            self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_instrument_device(i))
+            self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_instrument_device_using_has_deployment(i))
         for i in instrument_site_id:
-            self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_instrument_site(i))
+            self.assertEqual(deployment_id, self.RR2.find_deployment_id_of_instrument_site_using_has_deployment(i))
 
 
         self.omsclient.activate_deployment(deployment_id)
 
         # verify proper associations
         for i, d in enumerate(platform_device_id):
-            self.assertEqual(d, self.RR2.find_platform_device_id_of_platform_site(platform_site_id[i]))
+            self.assertEqual(d, self.RR2.find_platform_device_id_of_platform_site_using_has_device(platform_site_id[i]))
 
         for i, d in enumerate(instrument_device_id):
-            self.assertEqual(d, self.RR2.find_instrument_device_id_of_instrument_site(instrument_site_id[i]))
+            self.assertEqual(d, self.RR2.find_instrument_device_id_of_instrument_site_using_has_device(instrument_site_id[i]))
 
         pass
 

--- a/ion/services/sa/test/test_assembly.py
+++ b/ion/services/sa/test/test_assembly.py
@@ -1,5 +1,6 @@
 #from interface.services.icontainer_agent import ContainerAgentClient
 #from pyon.ion.endpoint import ProcessRPCClient
+import unittest
 from interface.services.sa.idata_process_management_service import DataProcessManagementServiceClient
 from ion.agents.port.port_agent_process import PortAgentProcessType
 
@@ -769,20 +770,24 @@ class TestAssembly(GenericIntHelperTestCase):
 
 
     # test all 4 deployment contexts.  can fill in these context when their fields get defined
-    def test_deployment_buoy(self):
+    def test_deployment_remoteplatform(self):
         context = IonObject(OT.RemotePlatformDeploymentContext)
         self.template_tst_deployment_context(context)
 
-    def test_deployment_mooring(self):
+    def test_deployment_cablednode(self):
         context = IonObject(OT.CabledNodeDeploymentContext)
         self.template_tst_deployment_context(context)
+
+    def test_deployment_cabledinstrument(self):
         context = IonObject(OT.CabledInstrumentDeploymentContext)
         self.template_tst_deployment_context(context)
 
-    def test_deployment_glider(self):
+    @unittest.skip("mobile deployments are unimplemented")
+    def test_deployment_mobile(self):
         context = IonObject(OT.MobileAssetDeploymentContext)
         self.template_tst_deployment_context(context)
 
+    @unittest.skip("cruise deployments are unimplemented")
     def test_deployment_cruise(self):
         context = IonObject(OT.CruiseDeploymentContext)
         self.template_tst_deployment_context(context)

--- a/ion/services/sa/test/test_assembly.py
+++ b/ion/services/sa/test/test_assembly.py
@@ -6,7 +6,7 @@ from ion.agents.port.port_agent_process import PortAgentProcessType
 from ion.util.enhanced_resource_registry_client import EnhancedResourceRegistryClient
 from pyon.public import IonObject
 from pyon.util.containers import DotDict
-from pyon.util.int_test import IonIntegrationTestCase
+#from pyon.util.int_test import IonIntegrationTestCase
 from pyon.util.containers import create_unique_identifier
 from pyon.ion.resource import LCS
 
@@ -514,18 +514,19 @@ class TestAssembly(GenericIntHelperTestCase):
         c.DAMS.assign_data_product(input_resource_id=instrument_device_id,
                                    data_product_id=inst_data_product_id)
 
-        deployment_id = self.perform_fcruf_script(RT.Deployment, "deployment", c.OMS, actual_obj=None,
+        deployment_obj = any_old(RT.Deployment, {"context": IonObject(OT.CabledNodeDeploymentContext)})
+        deployment_id = self.perform_fcruf_script(RT.Deployment, "deployment", c.OMS, actual_obj=deployment_obj,
                                                   extra_fn=add_to_org_fn)
 
         c.OMS.deploy_platform_site(platform_site_id, deployment_id)
-        self.RR2.find_deployment_id_of_platform_site(platform_site_id)
+        self.RR2.find_deployment_id_of_platform_site_using_has_deployment(platform_site_id)
         c.IMS.deploy_platform_device(platform_device_id, deployment_id)
-        self.RR2.find_deployment_of_platform_device(platform_device_id)
+        self.RR2.find_deployment_of_platform_device_using_has_deployment(platform_device_id)
 
         c.OMS.deploy_instrument_site(instrument_site_id, deployment_id)
-        self.RR2.find_deployment_id_of_instrument_site(instrument_site_id)
+        self.RR2.find_deployment_id_of_instrument_site_using_has_deployment(instrument_site_id)
         c.IMS.deploy_instrument_device(instrument_device_id, deployment_id)
-        self.RR2.find_deployment_id_of_instrument_device(instrument_device_id)
+        self.RR2.find_deployment_id_of_instrument_device_using_has_deployment(instrument_device_id)
 
 
         c.OMS.activate_deployment(deployment_id, True)
@@ -570,7 +571,8 @@ class TestAssembly(GenericIntHelperTestCase):
                                    data_product_id=inst_data_product_id2)
 
         # create a new deployment for the new device
-        deployment_id2 = self.perform_fcruf_script(RT.Deployment, "deployment", c.OMS, actual_obj=None,
+        deployment_obj = any_old(RT.Deployment, {"context": IonObject(OT.CabledNodeDeploymentContext)})
+        deployment_id2 = self.perform_fcruf_script(RT.Deployment, "deployment", c.OMS, actual_obj=deployment_obj,
                                                    extra_fn=add_to_org_fn)
         log.debug("Associating instrument site with new deployment")
         c.OMS.deploy_instrument_site(instrument_site_id, deployment_id2)


### PR DESCRIPTION
OK TO MERGE.  All SMOKE, UNIT, and sa-related INT tests pass.

This code replaces (nearly completely) the functionality of deployment activation.  
- Site data products have been completely eliminated.  They are still in the service spec but will be removed in a separate PR (combining ion-defs) to keep it manageable.
- Matching devices to sites in a deployment by CSP solving is now only done as a fallback.
- "reference_designator"/PlatformPort is now the preferred method of matching sites.
- Different deployment contexts are supported, with different behavior concerning how child sites/devices are treated.  Are they allowed?  Are they included?  Depends on context.

Old test cases have been updated (for backwards compatibility, use `context=IonObject(OT.CabledNodeDeploymentContext)` when constructing deployment objects).

New test cases create a hierarchy of 1 platform with 3 subplatforms, each subplatform having 3 instruments.  2 devices/sites in each set of 3 have an identical model, which makes the old method of model-based matching impossible.  The tests demonstrate that this structure can still be deployed using the `port_assignments` field appropriately.
