### PR TITLE
Test to  show that the late_alert causes the rollup comms status to be set to warning when the extended instrument resource is retrieved

### DIFF
--- a/ion/services/sa/observatory/observatory_util.py
+++ b/ion/services/sa/observatory/observatory_util.py
@@ -187,7 +187,7 @@ class ObservatoryUtil(object):
         min_ts = str(int(time.time() - 3) * 1000)
         # Events come back as 3-tuples of (id, key, obj)
         pwr_events = self.container.event_repository.find_events(event_type=OT.DeviceStatusEvent, start_ts=min_ts, descending=True)
-        comm_events = self.container.event_repository.find_events(event_type=OT.DeviceCommsEvent, start_ts=min_ts, descending=True)
+        comm_events = self.container.event_repository.find_events(event_type=OT.StreamAlertEvent, start_ts=min_ts, descending=True)
         events = []
         events.extend(pwr_events)
         events.extend(comm_events)
@@ -323,7 +323,7 @@ class ObservatoryUtil(object):
             event_type = event._get_type()
             if event_type == OT.DeviceStatusEvent and event.status == DeviceStatusType.STATUS_WARNING:
                 status['power'] = StatusType.STATUS_WARNING
-            elif event_type == OT.DeviceCommsEvent and event.state == DeviceCommsType.DATA_DELIVERY_INTERRUPTION:
+            elif event_type == OT.StreamAlertEvent and event.name == 'late_data_warning':
                 status['comms'] = StatusType.STATUS_WARNING
             # @TODO data, loc
 

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -196,7 +196,6 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
         # the following assert will not work without elasticsearch.
         #self.assertEqual( 1, len(extended_instrument.computed.user_notification_requests.value) )
-        self.assertEqual(StatusType.STATUS_WARNING, extended_instrument.computed.communications_status_roll_up.value)
         self.assertEqual(StatusType.STATUS_OK, extended_instrument.computed.data_status_roll_up.value)
         self.assertEqual(StatusType.STATUS_WARNING, extended_instrument.computed.power_status_roll_up.value)
 

--- a/ion/services/sa/test/test_instrument_alerts.py
+++ b/ion/services/sa/test/test_instrument_alerts.py
@@ -16,7 +16,7 @@ from pyon.agent.agent import ResourceAgentClient
 from pyon.util.context import LocalContextMixin
 from pyon.event.event import EventSubscriber
 
-from interface.objects import StreamAlertType, AggregateStatusType
+from interface.objects import StreamAlertType, AggregateStatusType, StatusType
 from interface.services.sa.iinstrument_management_service import InstrumentManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
@@ -369,5 +369,7 @@ class TestInstrumentAlerts(IonIntegrationTestCase):
             elif c.name == 'late_data_warning':
                 self.assertEqual(c.message, 'Expected data has not arrived.')
 
+        extended_instrument = self.imsclient.get_instrument_device_extension(instrument_device_id=instDevice_id)
+        self.assertEqual(StatusType.STATUS_WARNING, extended_instrument.computed.communications_status_roll_up.value)
 
 


### PR DESCRIPTION
- Now the comms status roll up works. 
- added assertion in integration test for the extended instrument's computed attribute to check that it works
- removed the DeviceCommsEvent from aggregate status computation code. Will remove more instances of DeviceCommsEvent soon.
