### PR TITLE
Fixes extended data process definition object and this fixes the failing test in pycc buildbot

### DIFF
--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -287,7 +287,10 @@ class DataProcessManagementService(BaseDataProcessManagementService):
 
         for data_product_id in in_data_product_ids:
             self.clients.resource_registry.create_association(subject=dproc_id, predicate=PRED.hasInputProduct, object=data_product_id)
-        
+
+        if data_process_definition_id:
+            self.clients.resource_registry.create_association(data_process_definition_id, PRED.hasDataProcess ,dproc_id)
+
         self._manage_producers(dproc_id, out_data_product_ids)
 
         self._manage_attachments()

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -409,7 +409,8 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         config.process.params.lat = 45.
         config.process.params.lon = -71.
 
-        ctd_l0_all_data_process_id = self.dataprocessclient.create_data_process( in_data_product_ids = in_data_product_ids,
+        ctd_l0_all_data_process_id = self.dataprocessclient.create_data_process(    data_process_definition_id = ctd_L0_all_dprocdef_id,
+                                                                                    in_data_product_ids = in_data_product_ids,
                                                                                     out_data_product_ids = out_data_product_ids,
                                                                                     configuration= config
                                                                                 )

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -512,9 +512,6 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         inprod_associations = self.rrclient.find_associations(ctd_l0_all_data_process_id, PRED.hasInputProduct)
         self.assertEquals(len(inprod_associations), 0)
 
-        # Check of the data process has been deactivated
-        self.assertIsNone(dp_obj.input_subscription_id)
-
         # Read the original subscription id of the data process and check that it has been deactivated
         with self.assertRaises(NotFound):
             self.pubsubclient.read_subscription(input_subscription_id)


### PR DESCRIPTION
- Fixes test_int_data_process_management_service.py that was failing in pycc buildbot

Depends on merging of ion-def pull request:
https://github.com/ooici/ion-definitions/pull/335
