### PR TITLE
Fixes discovery

### DIFF
--- a/ion/services/dm/presentation/discovery_service.py
+++ b/ion/services/dm/presentation/discovery_service.py
@@ -813,7 +813,8 @@ class DiscoveryService(BaseDiscoveryService):
           }
         }
 
-        response = IndexManagementService._es_call(es.raw_query,'%s/_search' % index.index_name,method='POST', data=query)
+        
+        response = IndexManagementService._es_call(es.raw_query,'%s/_search' % index.index_name,method='POST', data=query, host=self.elasticsearch_host, port=self.elasticsearch_port)
         IndexManagementService._check_response(response)
         return self._results_from_response(response, id_only)
  
@@ -900,7 +901,7 @@ class DiscoveryService(BaseDiscoveryService):
           }
         }
 
-        response = IndexManagementService._es_call(es.raw_query,'%s/_search' % index.index_name,method='POST', data=query)
+        response = IndexManagementService._es_call(es.raw_query,'%s/_search' % index.index_name,method='POST', data=query, host=self.elasticsearch_host, port=self.elasticsearch_port)
         IndexManagementService._check_response(response)
         return self._results_from_response(response, id_only)
 


### PR DESCRIPTION
raw_query in elasticpy is a static method and requires host and port to
be explicitly specified, which is why these two tests fail.
