### PR TITLE
properly handling the agent parameters aparam_rollup_status and aparam_child_agg_status

### DIFF
--- a/ion/agents/platform/status_util.py
+++ b/ion/agents/platform/status_util.py
@@ -125,7 +125,8 @@ class StatusUtil(object):
             return
 
         # Here, rollup status has changed: update rollup_status for this
-        # device and status category, and publish event to notify parent:
+        # device and status category, and publish event to notify all
+        # interested ancestors:
 
         self.aparam_rollup_status[status_name] = new_rollup_status
 

--- a/ion/agents/platform/status_util.py
+++ b/ion/agents/platform/status_util.py
@@ -6,6 +6,7 @@
 @author  Carlos Rueda
 @brief   Helper class for aggregate and rollup status handling.
          Some basic algorithms adapted from observatory_util.py
+@see     https://confluence.oceanobservatories.org/display/CIDev/Platform+agent+statuses
 """
 
 __author__ = 'Carlos Rueda'
@@ -49,6 +50,8 @@ def _consolidate_status(statuses, warn_if_unknown=False):
 class StatusUtil(object):
     """
     Helper class for aggregate and rollup status handling.
+
+    @see https://confluence.oceanobservatories.org/display/CIDev/Platform+agent+statuses
     """
 
     def __init__(self, pa):
@@ -59,6 +62,7 @@ class StatusUtil(object):
         self._platform_id            = pa._platform_id
         self.aparam_child_agg_status = pa.aparam_child_agg_status
         self.aparam_aggstatus        = pa.aparam_aggstatus
+        self.aparam_rollup_status    = pa.aparam_rollup_status
         self.resource_id             = pa.resource_id
         self._event_publisher        = pa._event_publisher
 
@@ -66,8 +70,8 @@ class StatusUtil(object):
         """
         Reacts to a DeviceAggregateStatusEvent from a platform's child.
         It updates the local image of the child status for the corresponding
-        status name, then updates the consolidated for that status name. If this
-        consolidated status changes, then a subsequent DeviceAggregateStatusEvent
+        status name, then updates the rollup status for that status name.
+        If this rollup status changes, then a subsequent DeviceAggregateStatusEvent
         is published.
         The consolidation operation is adapted from observatory_util.py to
         work on DeviceStatusType (instead of StatusType).
@@ -105,22 +109,25 @@ class StatusUtil(object):
         # update the specific status
         self.aparam_child_agg_status[child_origin][status_name] = child_status
 
-        # calculate new aggstatus:
-        new_aggstatus = _consolidate_status(
-            [s[status_name] for s in self.aparam_child_agg_status.values()])
+        # get all status values for the status name, that is,
+        # all from the children and from the platform itself ...
+        all_status_values = [s[status_name] for s in self.aparam_child_agg_status.values()]
+        all_status_values.append(self.aparam_aggstatus[status_name])
+        # ... to calculate the new rollup_status:
+        new_rollup_status = _consolidate_status(all_status_values)
 
-        old_aggstatus = self.aparam_aggstatus[status_name]
-        if old_aggstatus == new_aggstatus:
+        old_rollup_status = self.aparam_rollup_status[status_name]
+        if old_rollup_status == new_rollup_status:
             #
-            # The specific status changed, but the consolidated one did not;
-            # no need to propagate any event up the tree:
+            # The specific status changed, but the rollup one did not;
+            # no need to propagate any event up the tree from here:
             #
             return
 
-        # Here, consolidated status has changed: update aggstatus for this
+        # Here, rollup status has changed: update rollup_status for this
         # device and status category, and publish event to notify parent:
 
-        self.aparam_aggstatus[status_name] = new_aggstatus
+        self.aparam_rollup_status[status_name] = new_rollup_status
 
         description = "event generated from platform_id=%r" % self._platform_id
         description += " triggered by event from origin=%r" % child_origin
@@ -128,12 +135,13 @@ class StatusUtil(object):
                        origin_type="PlatformDevice",
                        origin=self.resource_id,
                        status_name=status_name,
-                       status=new_aggstatus,
-                       prev_status=old_aggstatus,
+                       status=new_rollup_status,
+                       prev_status=old_rollup_status,
+                       roll_up_status=True,
                        description=description)
 
         if log.isEnabledFor(logging.TRACE):  # pragma: no cover
-            self._log_agg_status_update(log.trace, evt, new_aggstatus)
+            self._log_agg_status_update(log.trace, evt, new_rollup_status)
 
         log.debug("%r: publishing event: %s", self._platform_id, evt_out)
         self._event_publisher.publish_event(**evt_out)
@@ -147,49 +155,53 @@ class StatusUtil(object):
         #
         pass
 
-    def _log_agg_status_update(self, logfun, evt, new_aggstatus):  # pragma: no cover
+    def _log_agg_status_update(self, logfun, evt, new_rollup_status):  # pragma: no cover
         """
         Logs formatted statuses for easier inspection; looks like:
 
-2013-04-08 22:22:25,436 DEBUG Dummy-160 ion.agents.platform.status_util:163 'LV01B': event published triggered by event from origin='05c78de65bf7400fac9d56e5d69a72ef'.
-Got from child AGGREGATE_COMMS = STATUS_WARNING
-updated statuses:
-        4fffa3db5a6440c19dbb8b7d975598de : {'AGGREGATE_COMMS': 'STATUS_UNKNOWN  ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
-        05c78de65bf7400fac9d56e5d69a72ef : {'AGGREGATE_COMMS': 'STATUS_WARNING  ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
-                            consolidated : {'AGGREGATE_COMMS': 'STATUS_WARNING  ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
-                                     agg : STATUS_WARNING
-Published AGGREGATE_COMMS = STATUS_WARNING
-
+013-04-10 21:10:24,193 TRACE Dummy-174 ion.agents.platform.status_util:204 'LV01A': event published triggered by event from child '6c9ed2a39e2b426890e14de986c48db9': AGGREGATE_COMMS -> STATUS_CRITICAL
+                               aggstatus : {'AGGREGATE_COMMS': 'STATUS_UNKNOWN  ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
+        12977248dd594e0ca4048bfbd28cfb56 : {'AGGREGATE_COMMS': 'STATUS_UNKNOWN  ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
+        a583e69d83e549088764757d7beaa9a4 : {'AGGREGATE_COMMS': 'STATUS_UNKNOWN  ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
+        6c9ed2a39e2b426890e14de986c48db9 : {'AGGREGATE_COMMS': 'STATUS_CRITICAL ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
+        42301443895f4f038845f772c4af437d : {'AGGREGATE_COMMS': 'STATUS_UNKNOWN  ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
+                           rollup_status : {'AGGREGATE_COMMS': 'STATUS_CRITICAL ', 'AGGREGATE_POWER': 'STATUS_UNKNOWN  ', 'AGGREGATE_DATA': 'STATUS_UNKNOWN  ', 'AGGREGATE_LOCATION': 'STATUS_UNKNOWN  '}
+Published event: AGGREGATE_COMMS -> STATUS_CRITICAL
         """
+
         status_name = evt.status_name
         child_origin = evt.origin
         child_status = evt.status
 
-        msg = "Got from child %s = %s\n" % (
+        # show the event from the child:
+        msg = "%s -> %s\n" % (
             AggregateStatusType._str_map[status_name],
             DeviceStatusType._str_map[child_status])
 
-        msg += "updated statuses:\n"
+        # show aparam_aggstatus:
+        vs = dict((AggregateStatusType._str_map[k2],
+                   "%-16s" % DeviceStatusType._str_map[v2]) for
+                  (k2, v2) in self.aparam_aggstatus.items())
+        msg += "%40s : %s\n" % ("aggstatus", vs)
+
+        # show updated aparam_child_agg_status:
         for k, v in self.aparam_child_agg_status.iteritems():
             vs = dict((AggregateStatusType._str_map[k2],
                        "%-16s" % DeviceStatusType._str_map[v2]) for
                       (k2, v2) in v.items())
             msg += "%40s : %s\n" % (k, vs)
 
+        # show updated aparam_rollup_status:
         vs = dict((AggregateStatusType._str_map[k2],
                    "%-16s" % DeviceStatusType._str_map[v2]) for
-                  (k2, v2) in self.aparam_aggstatus.items())
-        msg += "%40s : %s\n" % ("consolidated", vs)
+                  (k2, v2) in self.aparam_rollup_status.items())
+        msg += "%40s : %s\n" % ("rollup_status", vs)
 
-        # 'agg" is the consolidated across the status categories; similar
-        # to _rollup_statuses in observatory_util.py.
-        agg = _consolidate_status(self.aparam_aggstatus.values())
-        msg += "%40s : %s\n" % ("agg", DeviceStatusType._str_map[agg])
-
-        msg += "Published %s = %s\n" % (
+        # show published event with the specific new_rollup_status:
+        msg += "Published event: %s -> %s\n" % (
             AggregateStatusType._str_map[status_name],
-            DeviceStatusType._str_map[new_aggstatus]
+            DeviceStatusType._str_map[new_rollup_status]
         )
 
-        logfun("%r: event published triggered by event from origin=%r.\n%s",
+        logfun("%r: event published triggered by event from child %r: %s",
                self._platform_id, child_origin, msg)

--- a/ion/services/sa/observatory/test/test_platform_status.py
+++ b/ion/services/sa/observatory/test/test_platform_status.py
@@ -15,7 +15,8 @@ __license__ = 'Apache 2.0'
 # the base class BaseTestPlatform.
 #
 
-# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_status.py:Test.test_platform_status_small_network
+# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_status.py:Test.test_platform_status_small_network_3
+# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_status.py:Test.test_platform_status_small_network_5
 
 from pyon.public import log
 
@@ -39,18 +40,24 @@ class Test(BaseIntTestPlatform):
     def setUp(self):
         super(Test, self).setUp()
         self._event_publisher = EventPublisher()
+        self._expected_events = 1
+        self._received_events = []
         self._last_checked_status = None
 
     def _start_agg_status_event_subscriber(self, p_root):
         """
         Start the event subscriber to the given root platform. Upon reception
-        of event, the callback only sets the async result with the event.
+        of event, the callback only sets the async result if the number of
+        expected event has been reached.
         """
 
         event_type = "DeviceAggregateStatusEvent"
 
         def consume_event(evt, *args, **kwargs):
-            self._async_result.set(evt)
+            self._received_events.append(evt)
+            assert len(self._received_events) <= self._expected_events
+            if len(self._received_events) == self._expected_events:
+                self._async_result.set(evt)
 
         sub = EventSubscriber(event_type=event_type,
                               origin=p_root.platform_device_id,
@@ -62,6 +69,15 @@ class Test(BaseIntTestPlatform):
 
         log.debug("registered for DeviceAggregateStatusEvent")
 
+    def _expect_from_root(self, number_of_events):
+        """
+        Sets the number of expected events for the subscriber,
+        to be called right before any publication in the test.
+        """
+        self._expected_events = number_of_events
+        self._received_events = []
+        self._async_result = AsyncResult()
+
     def _publish_for_child(self, origin, status_name, status):
         """
         Publishes a DeviceAggregateStatusEvent from the given origin
@@ -70,9 +86,6 @@ class Test(BaseIntTestPlatform):
         the child itself are *not* set. This is OK for these tests; we just
         need that child's parent to react to the event.
         """
-
-        # create new AsyncResult for the subsequent event reception:
-        self._async_result = AsyncResult()
 
         # create and publish event from the given origin:
         evt = dict(event_type='DeviceAggregateStatusEvent',
@@ -85,10 +98,14 @@ class Test(BaseIntTestPlatform):
         log.debug("publishing for child %r: evt=%s", origin, evt)
         self._event_publisher.publish_event(**evt)
 
+    def _wait_root_event(self):
+        root_evt = self._async_result.get(timeout=CFG.endpoint.receive.timeout)
+        return root_evt
+
     def _wait_root_event_and_verify(self, status_name, status):
         """
-        Waits for event from root and verifies that the root status has been
-        updated as expected.
+        Waits for the expected event from root and verifies that the root
+        status, as indicated in the received event, has been updated as expected.
 
         @param status_name   Entry in AggregateStatusType
         @param status        Entry in DeviceStatusType
@@ -101,8 +118,7 @@ class Test(BaseIntTestPlatform):
                              "published in the second case. Fix the test!")
         self._last_checked_status = (status_name, status)
 
-        # wait for event from root:
-        root_evt = self._async_result.get(timeout=CFG.endpoint.receive.timeout)
+        root_evt = self._wait_root_event()
 
         self.assertEquals(root_evt.origin, self.p_root.platform_device_id)
         self.assertEquals(root_evt.type_, 'DeviceAggregateStatusEvent')
@@ -123,17 +139,33 @@ class Test(BaseIntTestPlatform):
                           DeviceStatusType._str_map[status],
                           DeviceStatusType._str_map[root_evt.status]))
 
-    def test_platform_status_small_network(self):
+    def _verify_with_get_agent(self, status_name, status):
+        """
+        Verifies the expected rollup_status against the reported status from the
+        agent using get_agent.
+        """
+        self._last_checked_status = (status_name, status)
+
+        rollup_status = self._pa_client.get_agent(['rollup_status'])['rollup_status']
+
+        retrieved_status = rollup_status[status_name]
+        self.assertEquals(status, retrieved_status,
+                          "Expected: %s, Got: %s" % (
+                          DeviceStatusType._str_map[status],
+                          DeviceStatusType._str_map[retrieved_status]))
+
+    def test_platform_status_small_network_3(self):
         #
-        # Test of status propagation in a small platform network (no instruments)
+        # Test of status propagation in a small platform network of 3
+        # platforms (one parent and two direct children). No instruments.
         #
+        #   LV01B
+        #       LJ01B
+        #       MJ01B
 
         # create the network:
         p_objs = {}
         self.p_root = p_root = self._create_hierarchy("LV01B", p_objs)
-        #   LV01B
-        #       LJ01B
-        #       MJ01B
 
         self.assertEquals(3, len(p_objs))
         for platform_id in ["LV01B", "LJ01B", "MJ01B"]:
@@ -150,6 +182,14 @@ class Test(BaseIntTestPlatform):
         self._initialize()
         self._go_active()
         self._run()
+
+        #####################################################################
+        # verify the root platform has set its aparam_child_agg_status with
+        # all its descendant nodes:
+        all_origins = [p_obj.platform_device_id for p_obj in p_objs.values()]
+        all_origins.remove(p_root.platform_device_id)
+        child_agg_status = self._pa_client.get_agent(['child_agg_status'])['child_agg_status']
+        self.assertItemsEqual(all_origins, child_agg_status.keys())
 
         #####################################################################
         # do the actual stuff and verifications: we "set" a particular status
@@ -174,6 +214,7 @@ class Test(BaseIntTestPlatform):
 
         # -------------------------------------------------------------------
         # LJ01B publishes a STATUS_WARNING for AGGREGATE_COMMS
+        self._expect_from_root(1)
         self._publish_for_child(p_LJ01B.platform_device_id,
                                 AggregateStatusType.AGGREGATE_COMMS,
                                 DeviceStatusType.STATUS_WARNING)
@@ -184,6 +225,7 @@ class Test(BaseIntTestPlatform):
 
         # -------------------------------------------------------------------
         # MJ01B publishes a STATUS_CRITICAL for AGGREGATE_COMMS
+        self._expect_from_root(1)
         self._publish_for_child(p_MJ01B.platform_device_id,
                                 AggregateStatusType.AGGREGATE_COMMS,
                                 DeviceStatusType.STATUS_CRITICAL)
@@ -194,6 +236,7 @@ class Test(BaseIntTestPlatform):
 
         # -------------------------------------------------------------------
         # MJ01B publishes a STATUS_OK for AGGREGATE_COMMS
+        self._expect_from_root(1)
         self._publish_for_child(p_MJ01B.platform_device_id,
                                 AggregateStatusType.AGGREGATE_COMMS,
                                 DeviceStatusType.STATUS_OK)
@@ -204,6 +247,7 @@ class Test(BaseIntTestPlatform):
 
         # -------------------------------------------------------------------
         # LJ01B publishes a STATUS_OK for AGGREGATE_COMMS
+        self._expect_from_root(1)
         self._publish_for_child(p_LJ01B.platform_device_id,
                                 AggregateStatusType.AGGREGATE_COMMS,
                                 DeviceStatusType.STATUS_OK)
@@ -214,6 +258,7 @@ class Test(BaseIntTestPlatform):
 
         # -------------------------------------------------------------------
         # LJ01B publishes a STATUS_UNKNOWN for AGGREGATE_COMMS
+        self._expect_from_root(0)
         self._publish_for_child(p_LJ01B.platform_device_id,
                                 AggregateStatusType.AGGREGATE_COMMS,
                                 DeviceStatusType.STATUS_UNKNOWN)
@@ -221,13 +266,16 @@ class Test(BaseIntTestPlatform):
         # Note that the root platform should continue in STATUS_OK, but we are
         # not verifying that via reception of event because there's no
         # such event to be published. We verify this with explicit call to
-        # the agent to get its aggstatus dict:
-        aggstatus = self._pa_client.get_agent(['aggstatus'])['aggstatus']
-        self.assertEquals(aggstatus[AggregateStatusType.AGGREGATE_COMMS],
-                          DeviceStatusType.STATUS_OK)
+        # the agent to get its rollup_status dict:
+        # rollup_status = self._pa_client.get_agent(['rollup_status'])['rollup_status']
+        # self.assertEquals(rollup_status[AggregateStatusType.AGGREGATE_COMMS],
+        #                   DeviceStatusType.STATUS_OK)
+        self._verify_with_get_agent(AggregateStatusType.AGGREGATE_COMMS,
+                                    DeviceStatusType.STATUS_OK)
 
         # -------------------------------------------------------------------
         # MJ01B publishes a STATUS_UNKNOWN for AGGREGATE_COMMS
+        self._expect_from_root(1)
         self._publish_for_child(p_MJ01B.platform_device_id,
                                 AggregateStatusType.AGGREGATE_COMMS,
                                 DeviceStatusType.STATUS_UNKNOWN)
@@ -236,6 +284,116 @@ class Test(BaseIntTestPlatform):
         # root), so confirm root gets updated to STATUS_UNKNOWN;
         self._wait_root_event_and_verify(AggregateStatusType.AGGREGATE_COMMS,
                                          DeviceStatusType.STATUS_UNKNOWN)
+
+        #####################################################################
+        # done
+        self._go_inactive()
+        self._reset()
+
+    def test_platform_status_small_network_5(self):
+        #
+        # Test of status propagation in a small network of 5 platforms with
+        # multiple levels. No instruments.
+        #
+        #   LV01A
+        #       LJ01A
+        #       PC01A
+        #           SC01A
+        #               SF01A
+        #
+        # This test is similar to test_platform_status_small_network_3 but
+        # here we verify that the multiple level case is handled properly.
+        # In particular, note that the root platform will get multiple
+        # notifications arising from a single update in a device that
+        # is *not* a direct child. This test uses the leaf SF01A, which is 3
+        # levels below the root, to trigger the status updates.
+        #
+        # So, for each status update in that leaf, the root platform should get
+        # 3 event notifications:
+        #  - one from the leaf itself, SF01A
+        #  - one from SC01A
+        #  - one from PC01A
+        #
+        # However, only one of those will actually generate a change in the
+        # rollup status of the root, so only one publication will come from it.
+        #
+        # BTW Note that the order in which the root platform gets those 3
+        # events is in general unpredictable.
+        #
+        # In the tests below, we can verify the expected root status with
+        # either the received event or via explicit request via get_agent.
+        #
+
+        # create the network:
+        p_objs = {}
+        self.p_root = p_root = self._create_hierarchy("LV01A", p_objs)
+
+        self.assertEquals(5, len(p_objs))
+        for platform_id in ["LV01A", "LJ01A", "PC01A", "SC01A", "SF01A"]:
+            self.assertIn(platform_id, p_objs)
+
+        # the leaf that is 3 levels below the root:
+        p_SF01A = p_objs["SF01A"]
+
+        #####################################################################
+        # start up the network
+        self._start_platform(p_root)
+        self.addCleanup(self._stop_platform, p_root)
+        self._initialize()
+        self._go_active()
+        self._run()
+
+        #####################################################################
+        # verify the root platform has set its aparam_child_agg_status with
+        # all its descendant nodes:
+        all_origins = [p_obj.platform_device_id for p_obj in p_objs.values()]
+        all_origins.remove(p_root.platform_device_id)
+        child_agg_status = self._pa_client.get_agent(['child_agg_status'])['child_agg_status']
+        self.assertItemsEqual(all_origins, child_agg_status.keys())
+
+        #####################################################################
+        # trigger status updates
+
+        # -------------------------------------------------------------------
+        # start the only event subscriber for this test:
+        self._start_agg_status_event_subscriber(p_root)
+
+        # -------------------------------------------------------------------
+        # SF01A publishes a STATUS_CRITICAL for AGGREGATE_COMMS
+        self._expect_from_root(1)
+        self._publish_for_child(p_SF01A.platform_device_id,
+                                AggregateStatusType.AGGREGATE_COMMS,
+                                DeviceStatusType.STATUS_CRITICAL)
+
+        # confirm root gets updated to STATUS_CRITICAL
+        self._wait_root_event()
+        self._verify_with_get_agent(AggregateStatusType.AGGREGATE_COMMS,
+                                    DeviceStatusType.STATUS_CRITICAL)
+
+        # -------------------------------------------------------------------
+        # SF01A publishes a STATUS_OK for AGGREGATE_COMMS
+        self._expect_from_root(1)
+        self._publish_for_child(p_SF01A.platform_device_id,
+                                AggregateStatusType.AGGREGATE_COMMS,
+                                DeviceStatusType.STATUS_OK)
+
+        # confirm root gets updated to STATUS_OK
+        self._wait_root_event_and_verify(AggregateStatusType.AGGREGATE_COMMS,
+                                         DeviceStatusType.STATUS_OK)
+
+        # -------------------------------------------------------------------
+        # -------------------------------------------------------------------
+        # SF01A publishes a STATUS_UNKNOWN for AGGREGATE_COMMS
+        self._expect_from_root(1)
+        self._publish_for_child(p_SF01A.platform_device_id,
+                                AggregateStatusType.AGGREGATE_COMMS,
+                                DeviceStatusType.STATUS_UNKNOWN)
+
+        # now, all descendants are back in STATUS_UNKNOWN, so confirm root
+        # gets updated to STATUS_UNKNOWN
+        self._wait_root_event()
+        self._verify_with_get_agent(AggregateStatusType.AGGREGATE_COMMS,
+                                    DeviceStatusType.STATUS_UNKNOWN)
 
         #####################################################################
         # done


### PR DESCRIPTION
- Now properly handling the agent parameters aparam_rollup_status and aparam_child_agg_status for propagation of updates triggered by a DeviceAggregateStatusEvent from a child (sub-platform or instrument).
- New test test_platform_status_small_network_5 to verify the propagation with a multi-level 5-platform network, with all updates triggered from a leaf platform 3 level below the root.
- New test test_platform_status_small_network_5_1 to verify the status propagation in a multi-level 5-platform network and 1 instrument, with all updates triggered from the instrument.
