### PR TITLE
Adds UDUNITS to coi-services

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,7 @@ For Mac, use homebrew
     Alternative: download generic Linux version and unpack into a suitable directory.
 - Install libevent, libyaml, zeromq, couchdb, python, rabbitmq, and pkg-config with Homebrew
 
-    > brew install libevent libyaml zeromq couchdb python rabbitmq hdf5 pkg-config netcdf spatialindex
+    > brew install libevent libyaml zeromq couchdb python rabbitmq hdf5 pkg-config netcdf spatialindex udunits
 
     You can even reinstall git using brew to clean up your /usr/local directory
     Be sure to read the pyon README for platform specific guidance to installing

--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -53,6 +53,7 @@ import csv
 import re
 import requests
 import time
+from udunitspy.udunits2 import Unit, UdunitsError
 
 from pyon.core.bootstrap import get_service_registry
 from pyon.core.exception import NotFound
@@ -1489,11 +1490,19 @@ Reason: %s
         lookup_value = row['Lookup Value']
 
         dataset_management = self._get_service_client('dataset_management')
+        
+        #validate unit of measure
+
+        #validate parameter type
         try:
             tm = TypesManager(dataset_management)
             param_type = tm.get_parameter_type(ptype, encoding,code_set,pfid, pmap)
             context = ParameterContext(name=name, param_type=param_type)
             context.uom = uom
+            try:
+                tm.get_unit(uom)
+            except UdunitsError as e:
+                log.warning('Parameter %s (%s) has invalid units: %s', name,param_id, uom)
             context.fill_value = tm.get_fill_value(fill_value, encoding, param_type)
             context.reference_urls = references
             context.internal_name = name

--- a/ion/services/dm/utility/test/test_types.py
+++ b/ion/services/dm/utility/test/test_types.py
@@ -25,6 +25,8 @@ from pyon.ion.stream import StandaloneStreamPublisher
 from interface.objects import DataProduct
 from coverage_model import ArrayType, QuantityType, ConstantRangeType, RecordType, ConstantType, CategoryType, create_guid, CRS, AxisTypeEnum, GridDomain, GridShape, MutabilityEnum, SimplexCoverage, ParameterFunctionType, NumexprFunction
 
+from udunitspy.udunits2 import UdunitsError
+
 import numpy as np
 import gevent
 import shutil
@@ -58,7 +60,6 @@ class TestTypes(PyonTestCase):
 
         testval = comp_val if comp_val is not None else value_array
         actual = rdt2['test']
-
 
         if isinstance(testval, basestring):
             self.assertEquals(testval, actual)
@@ -169,6 +170,8 @@ class TestTypes(PyonTestCase):
 
         self.rdt_to_granule(context, [[1,2,3]] * 20, testval)
         self.cov_io(context, testval)
+
+
 
     def test_category_type(self):
         ptype      = 'category<int8:str>'
@@ -329,8 +332,6 @@ class TestTypes(PyonTestCase):
 
         self.assertRaises(TypeError, self.types_manager.get_fill_value,fill_value, encoding, ptype)
 
-
-
     def test_record_type(self):
         ptype = 'record<>'
         encoding = ''
@@ -362,6 +363,11 @@ class TestTypes(PyonTestCase):
         tm.parameter_lookups['LV_coeff_a'] = 'abc123'
         self.assertEquals(tm.get_lookup_value_ids(test_context), ['abc123'])
 
+
+    def test_bad_units(self):
+        tm = TypesManager(None)
+        self.assertRaises(UdunitsError,tm.get_unit, 'something')
+    
 
 
 @attr('EXHAUSTIVE')

--- a/ion/services/dm/utility/types.py
+++ b/ion/services/dm/utility/types.py
@@ -14,6 +14,7 @@ from coverage_model.parameter_types import ConstantType, ConstantRangeType
 from coverage_model import ParameterFunctionType, ParameterContext, SparseConstantType, ConstantType
 
 from copy import deepcopy
+from udunitspy.udunits2 import Unit
 
 import ast
 import numpy as np
@@ -226,4 +227,8 @@ class TypesManager(object):
 
     def get_string_type(self):
         return self.get_array_type()
+
+    def get_unit(self, uom):
+        return Unit(uom)
+
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(  name = 'coi-services',
         packages = find_packages(),
         dependency_links = [
             'http://sddevrepo.oceanobservatories.org/releases/',
+            'https://github.com/lukecampbell/udunitspy/tarball/master#egg=udunitspy-0.0.5',
         ],
         test_suite = 'pyon',
         install_requires = [
@@ -48,7 +49,7 @@ setup(  name = 'coi-services',
             'xlrd==0.8.0',
             'apscheduler==2.1.0',
             'pyproj==1.9.3',
-            'udunitspy==0.0.4',
+            'udunitspy==0.0.5',
         ],
         entry_points = """
             [pydap.handler]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(  name = 'coi-services',
             'ntplib',
             'xlrd==0.8.0',
             'apscheduler==2.1.0',
-            'pyproj==1.9.3'
+            'pyproj==1.9.3',
+            'udunitspy==0.0.4',
         ],
         entry_points = """
             [pydap.handler]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(  name = 'coi-services',
         packages = find_packages(),
         dependency_links = [
             'http://sddevrepo.oceanobservatories.org/releases/',
-            'https://github.com/lukecampbell/udunitspy/tarball/master#egg=udunitspy-0.0.5',
+            'https://github.com/lukecampbell/udunitspy/tarball/master#egg=udunitspy-0.0.6',
         ],
         test_suite = 'pyon',
         install_requires = [
@@ -49,7 +49,7 @@ setup(  name = 'coi-services',
             'xlrd==0.8.0',
             'apscheduler==2.1.0',
             'pyproj==1.9.3',
-            'udunitspy==0.0.5',
+            'udunitspy==0.0.6',
         ],
         entry_points = """
             [pydap.handler]


### PR DESCRIPTION
# Buildout Required

This merge will require a buildout to be performed by developers. 

We have had some Undefined Symbol errors on Linux systems.  This stemmed from the fact that the `udunitspy` library wasn't linked with `libexpat` which is the XML parsing library the `libudunits2` uses to parse XML files. I updated the library to include `libexpat` but I can't regenerate the problem on my local linux boxes, this is indicative of the problem being resolved but I'm using `ubuntu` and CentOS has it's own issues.  I verified that the buildbot VMs that I have access to are good to go but other developers will need to verify.
# ImportError

If you experience an `ImportError` with the undefined symbol, please let me know as soon as possible so I can try to fix it.  This simple patch has been an incredibly tedious task to ensure cross-platform compatibility and I want to ensure that it's complete.

Thanks~
