### PR TITLE
new method of status rollups, half implemented

### DIFF
--- a/ion/services/sa/instrument/status_builder.py
+++ b/ion/services/sa/instrument/status_builder.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+"""
+@package  ion.util.enhanced_resource_registry_client
+@author   Ian Katz
+"""
+from interface.objects import ComputedIntValue
+from ooi.logging import log
+from pyon.agent.agent import ResourceAgentClient
+from pyon.core.bootstrap import IonObject
+from pyon.core.exception import BadRequest, NotFound
+
+
+from interface.objects import AttachmentType, ComputedValueAvailability, ComputedIntValue, StatusType, ProcessDefinition
+from interface.objects import AggregateStatusType, DeviceStatusType
+
+
+class AgentStatusBuilder(object):
+
+    @classmethod
+    def add_device_aggregate_status_to_resource_extension(cls, device_id='', status_name='', extended_device_resource=None):
+
+        if not device_id or not status_name or not extended_device_resource :
+            raise BadRequest("The device or extended resource parameter is empty")
+
+        try:
+            ia_client = cls.obtain_agent_handle(device_id)
+
+            aggstatus = ia_client.get_agent([status_name])[status_name]
+            log.debug('add_device_aggregate_status_to_resource_extension status: %s', aggstatus)
+
+            if aggstatus:
+                extended_device_resource.computed.communications_status_roll_up = cls._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_COMMS] )
+                extended_device_resource.computed.power_status_roll_up          = cls._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_POWER] )
+                extended_device_resource.computed.data_status_roll_up           = cls._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_DATA] )
+                extended_device_resource.computed.location_status_roll_up       = cls._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_LOCATION] )
+                extended_device_resource.computed.aggregated_status             = cls._compute_aggregated_status_overall(aggstatus)
+
+        except NotFound:
+            reason = "Could not connect to instrument agent instance -- may not be running"
+            extended_device_resource.computed.communications_status_roll_up =\
+            extended_device_resource.computed.power_status_roll_up =\
+            extended_device_resource.computed.data_status_roll_up =\
+            extended_device_resource.computed.location_status_roll_up =\
+            extended_device_resource.computed.aggregated_status = ComputedIntValue(status=ComputedValueAvailability.NOTAVAILABLE,
+                                                                                   value=DeviceStatusType.STATUS_UNKNOWN, reason=reason)
+        except Exception as e:
+            raise e
+
+        return
+
+    @classmethod
+    def get_aggregate_status_of_device(cls, device_id, status_name):
+        try:
+            ia_client = cls.obtain_agent_handle(device_id)
+
+            aggstatus = ia_client.get_agent([status_name])[status_name]
+            log.debug('get_aggregate_status_of_device status: %s', aggstatus)
+            return cls._compute_aggregated_status_overall(aggstatus)
+
+        except NotFound:
+            reason = "Could not connect to instrument agent instance -- may not be running"
+            return ComputedIntValue(status=ComputedValueAvailability.NOTAVAILABLE,
+                                    value=DeviceStatusType.STATUS_UNKNOWN, reason=reason)
+
+    @classmethod
+    def _create_computed_status(cls, status=DeviceStatusType.STATUS_UNKNOWN):
+        return ComputedIntValue(status=ComputedValueAvailability.PROVIDED, value=status)
+
+
+    @classmethod
+    def _compute_aggregated_status_overall (cls, agg_status_dict=None):
+        if agg_status_dict is None:
+            agg_status_dict = {}
+
+        status = DeviceStatusType.STATUS_UNKNOWN
+
+        values_list = agg_status_dict.values()
+        if DeviceStatusType.STATUS_CRITICAL in values_list:
+            status = DeviceStatusType.STATUS_CRITICAL
+        elif DeviceStatusType.STATUS_WARNING in values_list:
+            status = DeviceStatusType.STATUS_WARNING
+        elif DeviceStatusType.STATUS_OK  in values_list:
+            status = DeviceStatusType.STATUS_OK
+
+        return ComputedIntValue(status=ComputedValueAvailability.PROVIDED, value=status)
+
+
+
+    # TODO: this causes a problem because an instrument agent must be running in order to look up extended attributes.
+    @classmethod
+    def obtain_agent_handle(cls, device_id, process=None):
+        ia_client = ResourceAgentClient(device_id,  process=process)
+        log.debug("got the instrument agent client here: %s for the device id: %s and process: %s", ia_client, device_id, cls)
+
+        #       #todo: any validation?
+        #        cmd = AgentCommand(command='get_current_state')
+        #        retval = cls._ia_client.execute_agent(cmd)
+        #        state = retval.result
+        #        cls.assertEqual(state, InstrumentAgentState.UNINITIALIZED)
+        #
+
+        return ia_client
+
+    @classmethod
+    def obtain_agent_calculation(cls, device_id, result_container):
+        ret = IonObject(result_container)
+        a_client = None
+        try:
+            a_client = cls.obtain_agent_handle(device_id)
+            ret.status = ComputedValueAvailability.PROVIDED
+        except NotFound:
+            ret.status = ComputedValueAvailability.NOTAVAILABLE
+            ret.reason = "Could not connect to instrument agent instance -- may not be running"
+        except Exception as e:
+            raise e
+
+        return a_client, ret

--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -4,6 +4,7 @@
 and the relationships between them"""
 
 import time
+from ion.services.sa.instrument.status_builder import AgentStatusBuilder
 from ion.services.sa.observatory.deployment_activator import DeploymentActivatorFactory, DeploymentResourceCollectorFactory
 from ion.util.enhanced_resource_registry_client import EnhancedResourceRegistryClient
 
@@ -822,44 +823,26 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
         extended_site.platform_models   = retrieve_model_objs(extended_site.platform_devices, RT.PlatformDevice)
 
 
-        s_unknown = StatusType.STATUS_UNKNOWN
-
         # Status computation
-        extended_site.computed.instrument_status = [s_unknown] * len(extended_site.instrument_devices)
-        extended_site.computed.platform_status   = [s_unknown] * len(extended_site.platform_devices)
-        extended_site.computed.site_status       = [s_unknown] * len(extended_site.sites)
+        extended_site.computed.instrument_status = [AgentStatusBuilder.get_aggregate_status_of_device(idev._id, "aggstatus")
+                                                    for idev in extended_site.instrument_devices]
+        extended_site.computed.platform_status   = [AgentStatusBuilder.get_aggregate_status_of_device(pdev._id, "aggstatus")
+                                                    for pdev in extended_site.platform_devices]
 
+#            AgentStatusBuilder.add_device_aggregate_status_to_resource_extension(device_id,
+#                                                                                    'aggstatus',
+#                                                                                    extended_site)
         def status_unknown():
             return ComputedIntValue(status=ComputedValueAvailability.PROVIDED, value=StatusType.STATUS_UNKNOWN)
-
         extended_site.computed.communications_status_roll_up = status_unknown()
         extended_site.computed.power_status_roll_up          = status_unknown()
         extended_site.computed.data_status_roll_up           = status_unknown()
         extended_site.computed.location_status_roll_up       = status_unknown()
         extended_site.computed.aggregated_status             = status_unknown()
 
-        try:
-            status_rollups = self.outil.get_status_roll_ups(site_id, extended_site.resource._get_type())
-
-            extended_site.computed.instrument_status = [status_rollups.get(idev._id,{}).get("agg", s_unknown)
-                                                        for idev in extended_site.instrument_devices]
-            extended_site.computed.platform_status   = [status_rollups.get(pdev._id,{}).get("agg", s_unknown)
-                                                        for pdev in extended_site.platform_devices]
-            extended_site.computed.site_status       = [status_rollups.get(site._id,{}).get("agg", s_unknown)
-                                                        for site in extended_site.sites]
+        extended_site.computed.site_status = [StatusType.STATUS_UNKNOWN] * len(extended_site.sites)
 
 
-            def short_status_rollup(key):
-                return ComputedIntValue(status=ComputedValueAvailability.PROVIDED,
-                                        value=status_rollups[site_id].get(key, s_unknown))
-
-            extended_site.computed.communications_status_roll_up = short_status_rollup("comms")
-            extended_site.computed.power_status_roll_up          = short_status_rollup("power")
-            extended_site.computed.data_status_roll_up           = short_status_rollup("data")
-            extended_site.computed.location_status_roll_up       = short_status_rollup("loc")
-            extended_site.computed.aggregated_status             = short_status_rollup("agg")
-        except Exception as ex:
-            log.exception("Computed attribute failed for site %s" % site_id)
 
         return extended_site, RR2
 


### PR DESCRIPTION
This request switches the status rollups from an old style to a new style.  They are implemented in observatory extensions, but not site extensions, because it's not clear what the structure (if any) is supposed to be for get_sites_devices_status( ).  
