### PR TITLE
Use explicit argument for process passed to resource agent client

### DIFF
--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -18,7 +18,6 @@ import time
 
 from ooi.logging import log
 
-from pyon.agent.agent import ResourceAgentClient
 from pyon.core.bootstrap import IonObject
 from pyon.core.exception import Inconsistent,BadRequest, NotFound, ServerError
 from pyon.ion.resource import ExtendedResourceContainer
@@ -63,7 +62,7 @@ class InstrumentManagementService(BaseInstrumentManagementService):
         self.extended_resource_handler = ExtendedResourceContainer(self)
 
         self.init_module_uploader()
-
+        self.agent_status_builder = AgentStatusBuilder(process=self)
 
         # set up all of the policy interceptions
         if self.container and self.container.governance_controller:
@@ -1611,7 +1610,7 @@ class InstrumentManagementService(BaseInstrumentManagementService):
             user_id=user_id)
 
         #retrieve the aggregate status for the instrument
-        AgentStatusBuilder.add_device_aggregate_status_to_resource_extension(instrument_device_id,
+        self.agent_status_builder.add_device_aggregate_status_to_resource_extension(instrument_device_id,
                                                                              'aggstatus',
                                                                              extended_instrument)
         log.debug('get_instrument_device_extension  extended_instrument.computed: %s', extended_instrument.computed)
@@ -1622,33 +1621,33 @@ class InstrumentManagementService(BaseInstrumentManagementService):
     #functions for INSTRUMENT computed attributes -- currently bogus values returned
 
     def get_firmware_version(self, instrument_device_id):
-        ia_client, ret = AgentStatusBuilder.obtain_agent_calculation(instrument_device_id, OT.ComputedFloatValue)
+        ia_client, ret = self.agent_status_builder.obtain_agent_calculation(instrument_device_id, OT.ComputedFloatValue)
         if ia_client:
             ret.value = 0.0 #todo: use ia_client
         return ret
 
 
     def get_last_data_received_datetime(self, instrument_device_id):
-        ia_client, ret = AgentStatusBuilder.obtain_agent_calculation(instrument_device_id, OT.ComputedFloatValue)
+        ia_client, ret = self.agent_status_builder.obtain_agent_calculation(instrument_device_id, OT.ComputedFloatValue)
         if ia_client:
             ret.value = 0.0 #todo: use ia_client
         return ret
 
 
     def get_operational_state(self, taskable_resource_id):   # from Device
-        ia_client, ret = AgentStatusBuilder.obtain_agent_calculation(taskable_resource_id, OT.ComputedStringValue)
+        ia_client, ret = self.agent_status_builder.obtain_agent_calculation(taskable_resource_id, OT.ComputedStringValue)
         if ia_client:
             ret.value = "" #todo: use ia_client
         return ret
 
     def get_last_calibration_datetime(self, instrument_device_id):
-        ia_client, ret = AgentStatusBuilder.obtain_agent_calculation(instrument_device_id, OT.ComputedFloatValue)
+        ia_client, ret = self.agent_status_builder.obtain_agent_calculation(instrument_device_id, OT.ComputedFloatValue)
         if ia_client:
             ret.value = 0 #todo: use ia_client
         return ret
 
     def get_uptime(self, device_id):
-        ia_client, ret = AgentStatusBuilder.obtain_agent_calculation(device_id, OT.ComputedStringValue)
+        ia_client, ret = self.agent_status_builder.obtain_agent_calculation(device_id, OT.ComputedStringValue)
 
         if ia_client:
             # Find events in the event repo that were published when changes of state occurred for the instrument or the platform
@@ -1758,12 +1757,12 @@ class InstrumentManagementService(BaseInstrumentManagementService):
 
 
         #retrieve the aggreate and rollup status from the platform agent
-        AgentStatusBuilder.add_device_aggregate_status_to_resource_extension(platform_device_id, 'rollup_status', extended_platform)
+        self.agent_status_builder.add_device_aggregate_status_to_resource_extension(platform_device_id, 'rollup_status', extended_platform)
         log.debug('get_platform_device_extension  extended_platform.computed: %s', extended_platform.computed)
 
         #retrieve the list of aggreate status for all children of this platform agent
         try:
-            pa_client = AgentStatusBuilder.obtain_agent_handle(platform_device_id, process=self)
+            pa_client = self.agent_status_builder.obtain_agent_handle(platform_device_id)
 
             child_agg_status = pa_client.get_agent(['child_agg_status'])['child_agg_status']
             log.debug('get_platform_device_extension child_agg_status : %s', child_agg_status)

--- a/ion/services/sa/instrument/status_builder.py
+++ b/ion/services/sa/instrument/status_builder.py
@@ -4,37 +4,42 @@
 @package  ion.util.enhanced_resource_registry_client
 @author   Ian Katz
 """
-from interface.objects import ComputedIntValue
 from ooi.logging import log
 from pyon.agent.agent import ResourceAgentClient
 from pyon.core.bootstrap import IonObject
 from pyon.core.exception import BadRequest, NotFound
 
 
-from interface.objects import AttachmentType, ComputedValueAvailability, ComputedIntValue, StatusType, ProcessDefinition
+from interface.objects import ComputedValueAvailability, ComputedIntValue
 from interface.objects import AggregateStatusType, DeviceStatusType
 
 
 class AgentStatusBuilder(object):
 
-    @classmethod
-    def add_device_aggregate_status_to_resource_extension(cls, device_id='', status_name='', extended_device_resource=None):
+    def __init__(self, process=None):
+        """
+        the process should be the "self" of a service instance
+        """
+        assert process
+        self.process = process
+
+    def add_device_aggregate_status_to_resource_extension(self, device_id='', status_name='', extended_device_resource=None):
 
         if not device_id or not status_name or not extended_device_resource :
             raise BadRequest("The device or extended resource parameter is empty")
 
         try:
-            ia_client = cls.obtain_agent_handle(device_id)
+            ia_client = self.obtain_agent_handle(device_id)
 
             aggstatus = ia_client.get_agent([status_name])[status_name]
             log.debug('add_device_aggregate_status_to_resource_extension status: %s', aggstatus)
 
             if aggstatus:
-                extended_device_resource.computed.communications_status_roll_up = cls._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_COMMS] )
-                extended_device_resource.computed.power_status_roll_up          = cls._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_POWER] )
-                extended_device_resource.computed.data_status_roll_up           = cls._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_DATA] )
-                extended_device_resource.computed.location_status_roll_up       = cls._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_LOCATION] )
-                extended_device_resource.computed.aggregated_status             = cls._compute_aggregated_status_overall(aggstatus)
+                extended_device_resource.computed.communications_status_roll_up = self._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_COMMS] )
+                extended_device_resource.computed.power_status_roll_up          = self._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_POWER] )
+                extended_device_resource.computed.data_status_roll_up           = self._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_DATA] )
+                extended_device_resource.computed.location_status_roll_up       = self._create_computed_status ( aggstatus[AggregateStatusType.AGGREGATE_LOCATION] )
+                extended_device_resource.computed.aggregated_status             = self._compute_aggregated_status_overall(aggstatus)
 
         except NotFound:
             reason = "Could not connect to instrument agent instance -- may not be running"
@@ -49,27 +54,24 @@ class AgentStatusBuilder(object):
 
         return
 
-    @classmethod
-    def get_aggregate_status_of_device(cls, device_id, status_name):
+    def get_aggregate_status_of_device(self, device_id, status_name):
         try:
-            ia_client = cls.obtain_agent_handle(device_id)
+            ia_client = self.obtain_agent_handle(device_id)
 
             aggstatus = ia_client.get_agent([status_name])[status_name]
             log.debug('get_aggregate_status_of_device status: %s', aggstatus)
-            return cls._compute_aggregated_status_overall(aggstatus)
+            return self._compute_aggregated_status_overall(aggstatus)
 
         except NotFound:
             reason = "Could not connect to instrument agent instance -- may not be running"
             return ComputedIntValue(status=ComputedValueAvailability.NOTAVAILABLE,
                                     value=DeviceStatusType.STATUS_UNKNOWN, reason=reason)
 
-    @classmethod
     def _create_computed_status(cls, status=DeviceStatusType.STATUS_UNKNOWN):
         return ComputedIntValue(status=ComputedValueAvailability.PROVIDED, value=status)
 
 
-    @classmethod
-    def _compute_aggregated_status_overall (cls, agg_status_dict=None):
+    def _compute_aggregated_status_overall (self, agg_status_dict=None):
         if agg_status_dict is None:
             agg_status_dict = {}
 
@@ -88,10 +90,11 @@ class AgentStatusBuilder(object):
 
 
     # TODO: this causes a problem because an instrument agent must be running in order to look up extended attributes.
-    @classmethod
-    def obtain_agent_handle(cls, device_id, process=None):
-        ia_client = ResourceAgentClient(device_id,  process=process)
-        log.debug("got the instrument agent client here: %s for the device id: %s and process: %s", ia_client, device_id, cls)
+    def obtain_agent_handle(self, device_id):
+
+        ia_client = ResourceAgentClient(device_id, process=self.process)
+        log.debug("got the instrument agent client here: %s for the device id: %s and process: %s",
+                  ia_client, device_id, self.process)
 
         #       #todo: any validation?
         #        cmd = AgentCommand(command='get_current_state')
@@ -102,12 +105,11 @@ class AgentStatusBuilder(object):
 
         return ia_client
 
-    @classmethod
-    def obtain_agent_calculation(cls, device_id, result_container):
+    def obtain_agent_calculation(self, device_id, result_container):
         ret = IonObject(result_container)
         a_client = None
         try:
-            a_client = cls.obtain_agent_handle(device_id)
+            a_client = self.obtain_agent_handle(device_id)
             ret.status = ComputedValueAvailability.PROVIDED
         except NotFound:
             ret.status = ComputedValueAvailability.NOTAVAILABLE


### PR DESCRIPTION
Should fix SMOKE tests.  Passes `bin/nosetests --with-pycc -a SMOKE` on localhost.
