### PR TITLE
Special processing for devices that use hasNetworkParent

### DIFF
--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -65,6 +65,7 @@ class AgentConfigurationBuilder(object):
                 PRED.hasAgentDefinition,
                 PRED.hasDataset,
                 PRED.hasDevice,
+                PRED.hasNetworkParent,
                 #PRED.hasParameterContext,
                 ]
 
@@ -557,22 +558,46 @@ class PlatformAgentConfigurationBuilder(AgentConfigurationBuilder):
         return platform_agent_lookup_means
 
 
+    def _use_network_parent(self):
+        """
+        return True if there are any hasNewtorkParent links involved
+        """
+        dev_id = self._get_device()._id
+
+        network_parents = self.RR2.find_objects(dev_id, PRED.hasNetworkParent, RT.PlatformDevice)
+        if 0 < len(network_parents):
+            return True
+
+        network_children = self.RR2.find_subjects(RT.PlatformDevice, PRED.hasNetworkParent, dev_id)
+        if 0 < len(network_children):
+            return True
+
+        return False
+
+
     def _generate_children(self):
         """
         Generate the configuration for child devices
         """
-        log.debug("_generate_children for %s", self.agent_instance_obj.name)
-        log.debug("Getting child platform device ids")
-        child_pdevice_ids = self.RR2.find_platform_device_ids_of_device_using_has_device(self._get_device()._id)
-        log.debug("found platform device ids: %s", child_pdevice_ids)
 
-        log.debug("Getting child instrument device ids")
-        child_idevice_ids = self.RR2.find_instrument_device_ids_of_device_using_has_device(self._get_device()._id)
-        log.debug("found instrument device ids: %s", child_idevice_ids)
+        dev_id = self._get_device()._id
 
-        child_device_ids = child_idevice_ids + child_pdevice_ids
+        if self._use_network_parent():
+            assocs = self.RR2.filter_cached_associations(PRED.hasNetworkParent, lambda a: dev_id == a.o)
+            child_device_ids = [a.s for a in assocs]
+        else:
+            log.debug("_generate_children for %s", self.agent_instance_obj.name)
+            log.debug("Getting child platform device ids")
+            child_pdevice_ids = self.RR2.find_platform_device_ids_of_device_using_has_device(self._get_device()._id)
+            log.debug("found platform device ids: %s", child_pdevice_ids)
 
-        log.debug("combined device ids: %s", child_device_ids)
+            log.debug("Getting child instrument device ids")
+            child_idevice_ids = self.RR2.find_instrument_device_ids_of_device_using_has_device(self._get_device()._id)
+            log.debug("found instrument device ids: %s", child_idevice_ids)
+
+            child_device_ids = child_idevice_ids + child_pdevice_ids
+
+            log.debug("combined device ids: %s", child_device_ids)
 
         ConfigurationBuilder_factory = AgentConfigurationBuilderFactory(self.clients, self.RR2)
 

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -579,25 +579,27 @@ class PlatformAgentConfigurationBuilder(AgentConfigurationBuilder):
         """
         Generate the configuration for child devices
         """
+        log.debug("_generate_children for %s", self.agent_instance_obj.name)
 
         dev_id = self._get_device()._id
 
+        log.debug("Getting child platform device ids")
         if self._use_network_parent():
+            log.debug("Using hasNetworkParnet")
             assocs = self.RR2.filter_cached_associations(PRED.hasNetworkParent, lambda a: dev_id == a.o)
-            child_device_ids = [a.s for a in assocs]
+            child_pdevice_ids = [a.s for a in assocs]
         else:
-            log.debug("_generate_children for %s", self.agent_instance_obj.name)
-            log.debug("Getting child platform device ids")
+            log.debug("Using hasDevice")
             child_pdevice_ids = self.RR2.find_platform_device_ids_of_device_using_has_device(self._get_device()._id)
-            log.debug("found platform device ids: %s", child_pdevice_ids)
+        log.debug("found platform device ids: %s", child_pdevice_ids)
 
-            log.debug("Getting child instrument device ids")
-            child_idevice_ids = self.RR2.find_instrument_device_ids_of_device_using_has_device(self._get_device()._id)
-            log.debug("found instrument device ids: %s", child_idevice_ids)
+        log.debug("Getting child instrument device ids")
+        child_idevice_ids = self.RR2.find_instrument_device_ids_of_device_using_has_device(self._get_device()._id)
+        log.debug("found instrument device ids: %s", child_idevice_ids)
 
-            child_device_ids = child_idevice_ids + child_pdevice_ids
+        child_device_ids = child_idevice_ids + child_pdevice_ids
 
-            log.debug("combined device ids: %s", child_device_ids)
+        log.debug("combined device ids: %s", child_device_ids)
 
         ConfigurationBuilder_factory = AgentConfigurationBuilderFactory(self.clients, self.RR2)
 

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -457,7 +457,27 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         self.assertEqual(1, len(self.RR2.find_data_producer_ids_of_platform_device_using_has_data_producer(pdevice_id)))
 
 
-    def test_agent_instance_config(self):
+    def test_agent_instance_config_hasDevice(self):
+        def assign_fn(child_device_id, parent_device_id):
+            self.RR2.create_association(parent_device_id, PRED.hasDevice, child_device_id)
+
+        def find_fn(parent_device_id):
+            ret, _ = self.RR.find_objects(subject=parent_device_id, predicate=PRED.hasDevice, id_only=True)
+            return ret
+
+        self.base_agent_instance_config(assign_fn, find_fn)
+
+    def test_agent_instance_config_hasNetworkParent(self):
+        def assign_fn(child_device_id, parent_device_id):
+            self.RR2.create_association(child_device_id, PRED.hasNetworkParent, parent_device_id)
+
+        def find_fn(parent_device_id):
+            ret, _ = self.RR.find_subjects(object=parent_device_id, predicate=PRED.hasNetworkParent, id_only=True)
+            return ret
+
+        self.base_agent_instance_config(assign_fn, find_fn)
+
+    def base_agent_instance_config(self, assign_child_device_to_parent_device_fn, find_child_device_ids_of_parent_device_fn):
         """
         Verify that agent configurations are being built properly
         """
@@ -661,9 +681,9 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         verify_child_config(parent_config, platform_device_parent_id)
 
         log.debug("assigning child platform to parent")
-        self.RR2.assign_platform_device_to_platform_device_with_has_device(platform_device_child_id,
-                                                                           platform_device_parent_id)
-        child_device_ids = self.RR2.find_platform_device_ids_of_device_using_has_device(platform_device_parent_id)
+        assign_child_device_to_parent_device_fn(platform_device_child_id, platform_device_parent_id)
+
+        child_device_ids = find_child_device_ids_of_parent_device_fn(platform_device_parent_id)
         self.assertNotEqual(0, len(child_device_ids))
 
         log.debug("Testing parent + child as parent config")
@@ -684,9 +704,9 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         verify_instrument_config(instrument_config, instrument_device_id)
 
         log.debug("assigning instrument to platform")
-        self.RR2.assign_instrument_device_to_platform_device_with_has_device(instrument_device_id,
-                                                                             platform_device_child_id)
-        child_device_ids = self.RR2.find_instrument_device_ids_of_device_using_has_device(platform_device_child_id)
+        assign_child_device_to_parent_device_fn(instrument_device_id, platform_device_child_id)
+
+        child_device_ids = find_child_device_ids_of_parent_device_fn(platform_device_child_id)
         self.assertNotEqual(0, len(child_device_ids))
 
         log.debug("Testing entire config")

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -477,7 +477,9 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
 
         self.base_agent_instance_config(assign_fn, find_fn)
 
-    def base_agent_instance_config(self, assign_child_device_to_parent_device_fn, find_child_device_ids_of_parent_device_fn):
+    def base_agent_instance_config(self, 
+                                   assign_child_platform_to_parent_platform_fn, 
+                                   find_child_platform_ids_of_parent_platform_fn):
         """
         Verify that agent configurations are being built properly
         """
@@ -681,9 +683,9 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         verify_child_config(parent_config, platform_device_parent_id)
 
         log.debug("assigning child platform to parent")
-        assign_child_device_to_parent_device_fn(platform_device_child_id, platform_device_parent_id)
+        assign_child_platform_to_parent_platform_fn(platform_device_child_id, platform_device_parent_id)
 
-        child_device_ids = find_child_device_ids_of_parent_device_fn(platform_device_parent_id)
+        child_device_ids = find_child_platform_ids_of_parent_platform_fn(platform_device_parent_id)
         self.assertNotEqual(0, len(child_device_ids))
 
         log.debug("Testing parent + child as parent config")
@@ -704,9 +706,9 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         verify_instrument_config(instrument_config, instrument_device_id)
 
         log.debug("assigning instrument to platform")
-        assign_child_device_to_parent_device_fn(instrument_device_id, platform_device_child_id)
+        self.RR2.assign_instrument_device_to_platform_device_with_has_device(instrument_device_id, platform_device_child_id)
 
-        child_device_ids = find_child_device_ids_of_parent_device_fn(platform_device_child_id)
+        child_device_ids = self.RR2.find_instrument_device_ids_of_platform_device_using_has_device(platform_device_child_id)
         self.assertNotEqual(0, len(child_device_ids))
 
         log.debug("Testing entire config")


### PR DESCRIPTION
This patch alters the behavior of the AgentConfigBuilder to follow hasNetworkParent when available, instead of hasDevice.  Tests included.  SMOKE tests pass.
