### PR TITLE
better error message

### DIFF
--- a/ion/processes/bootstrap/plugins/bootstrap_core.py
+++ b/ion/processes/bootstrap/plugins/bootstrap_core.py
@@ -20,7 +20,7 @@ class BootstrapCore(BootstrapPlugin):
         system_actor, _ = process.container.resource_registry.find_resources(
             restype=RT.ActorIdentity, id_only=True)
         if system_actor:
-            raise AbortBootstrap("System already initialized. Start with bootmode=restart or force_clean!")
+            raise AbortBootstrap("System already initialized. Start with bootmode=restart or force_clean (-fc)!")
 
         # Possibly start the event persister here
 


### PR DESCRIPTION
"System already initialized. Start with bootmode=restart or force_clean!"

`--bootmode=restart` works as a command line flag.
`--force_clean` does not.

This adds the hint for the proper command line switch.
