### PR TITLE
Deployment ui info

### DIFF
--- a/ion/services/sa/instrument/status_builder.py
+++ b/ion/services/sa/instrument/status_builder.py
@@ -110,7 +110,6 @@ class AgentStatusBuilder(object):
         try:
             agg = self.get_status_of_device(device_id, status_name)
             log.debug('add_device_aggregate_status_to_resource_extension status: %s', agg)
-            print 'add_device_aggregate_status_to_resource_extension status: %s', agg
 
             if agg:
                 self.set_status_computed_attributes(extended_resource.computed, agg, ComputedValueAvailability.PROVIDED)

--- a/ion/services/sa/observatory/deployment_util.py
+++ b/ion/services/sa/observatory/deployment_util.py
@@ -1,0 +1,59 @@
+"""
+for a list of deployment IDs,
+generate a dict of dicts with information about the deployments
+suitable for the UI table:
+ { deployment_id: { 'ui_column': 'string_value'... } }
+"""
+
+from ooi.logging import log
+from pyon.ion.resource import RT, PRED, LCS, OT
+
+def describe_deployments(deployments, context):
+    if not deployments:
+        return {}
+    rr=context.resource_registry
+    deployment_ids = [ d._id for d in deployments ]
+    descriptions = { d._id: { 'is_primary': 'False' } for d in deployments }
+
+    # first get the all site and instrument objects
+    site_ids = []
+    objects,associations = rr.find_objects_mult(subjects=deployment_ids, id_only=False)
+    for obj,assoc in zip(objects,associations):
+        # if this is a hasDeployment association...
+        if assoc.p!=PRED.hasDeployment:
+            log.warn('unexpected association: %s %s %s %s %s', assoc.st, assoc.s, assoc.p, assoc.ot, assoc.o)
+            continue
+        id = assoc.s
+        description = descriptions[id]
+
+        # then save site or device info in the description
+        type = obj.type_
+        if type==RT.InstrumentSite or type==RT.PlatformSite:
+            description['site_id'] = obj._id
+            description['site_name'] = obj.name
+            description['site_type'] = type
+            if obj._id not in site_ids:
+                site_ids.append(obj._id)
+        elif type==RT.InstrumentDevice or type==RT.PlatformDevice:
+            description['device_id'] = obj._id
+            description['device_name'] = obj.name
+            description['device_type'] = type
+        else:
+            log.warn('unexpected association: %s %s %s %s %s', assoc.st, assoc.s, assoc.p, assoc.ot, assoc.o)
+            continue
+
+    # now look for hasDevice associations to determine which deployments are "primary" or "active"
+    objects2,associations = rr.find_objects_mult(subjects=site_ids)
+    for obj,assoc in zip(objects2,associations):
+        if assoc.p!=PRED.hasDevice:
+            # not a warning now -- other associations should exist
+            continue
+        found_match = False
+        for description in descriptions.itervalues():
+            if description['site_id']==assoc.s and description['device_id']==assoc.o:
+                if found_match:
+                    log.warn('more than one primary deployment for site %s (%s) and device %s (%s)',
+                             assoc.s, description['site_name'], assoc.o, description['device_name'])
+                description['is_primary']=found_match=True
+    log.trace('%d deployments, %d associated sites/devices, %d activations', len(deployments), len(objects), len(objects2))
+    return descriptions


### PR DESCRIPTION
UI shows table of deployments on site and device pages.
this PR adds a list of dict values to the corresponding extension objects.
each deployment represents one dict in the list,
each dict contains name, type and ID of associated site and device,
and if this deployment is currently active/primary.
