### PR TITLE
Adds breakpoint

### DIFF
--- a/ion/services/dm/test/dm_test_case.py
+++ b/ion/services/dm/test/dm_test_case.py
@@ -75,3 +75,59 @@ class DMTestCase(IonIntegrationTestCase):
         self.addCleanup(self.data_product_management.delete_data_product, data_product_id)
         return data_product_id
 
+def breakpoint(scope=None):
+    from IPython.config.loader import Config
+    ipy_config = Config()
+    ipy_config.PromptManager.in_template = '><> '
+    ipy_config.PromptManager.in2_template = '... '
+    ipy_config.PromptManager.out_template = '--> '
+    ipy_config.InteractiveShellEmbed.confirm_exit = False
+
+    # monkeypatch the ipython inputhook to be gevent-friendly
+    import gevent   # should be auto-monkey-patched by pyon already.
+    import select
+    import sys
+
+    def stdin_ready():
+        infds, outfds, erfds = select.select([sys.stdin], [], [], 0)
+        if infds:
+            return True
+        else:
+            return False
+
+    def inputhook_gevent():
+        try:
+            while not stdin_ready():
+                gevent.sleep(0.05)
+        except KeyboardInterrupt:
+            pass
+
+        return 0
+
+    # install the gevent inputhook
+    from IPython.lib.inputhook import inputhook_manager
+    inputhook_manager.set_inputhook(inputhook_gevent)
+    inputhook_manager._current_gui = 'gevent'
+
+    # First import the embeddable shell class
+    from IPython.frontend.terminal.embed import InteractiveShellEmbed
+    from mock import patch
+    if scope is not None:
+        from pyon.container.shell_api import get_shell_api
+        from pyon.container.cc import Container
+        locals().update(scope)
+        locals().update(get_shell_api(Container.instance))
+
+    # Update namespace of interactive shell
+    # TODO: Cleanup namespace even further
+    # Now create an instance of the embeddable shell. The first argument is a
+    # string with options exactly as you would type them if you were starting
+    # IPython at the system command line. Any parameters you want to define for
+    # configuration can thus be specified here.
+    with patch("IPython.core.interactiveshell.InteractiveShell.init_virtualenv"):
+        ipshell = InteractiveShellEmbed(config=ipy_config,
+                banner1="Entering Breakpoint Shell",
+            exit_msg = 'Returning...')
+
+        ipshell('Breakpoint')
+


### PR DESCRIPTION
I really don't know why this wasn't done at the very inception of R2.
By far the best utility I have ever even conceived of.
### Usage

``` python
# Inside any test

from ion.services.dm.test.dm_test_case import breakpoint
breakpoint(locals())

```

Run the test with -s (otherwise stdout is ignored)
