### PR TITLE
integrate AgentAlertManager services in PlatformAgent

### DIFF
--- a/ion/agents/agent_alert_manager.py
+++ b/ion/agents/agent_alert_manager.py
@@ -176,7 +176,7 @@ class AgentAlertManager(object):
     def stop_all(self):
         """
         """
-        [a.stop for a in self._agent.aparam_alerts]
+        [a.stop() for a in self._agent.aparam_alerts]
         
     def aparam_set_aggstatus(self, params):
         return -1

--- a/ion/agents/agent_alert_manager.py
+++ b/ion/agents/agent_alert_manager.py
@@ -47,15 +47,16 @@ class AgentAlertManager(object):
         
     def _update_aggstatus(self, aggregate_type, new_status):
         """
-        Called to set a new status value for an aggstatus type.
+        Called by this manager to set a new status value for an aggstatus type.
 
         Here the method simple assigns the new value and publishes a
         DeviceAggregateStatusEvent event. This is the standard behavior
-        for InstrumentAgents (this method was introduced for refactoring
-        purposes -- no changes in functionality at all).
+        for InstrumentAgents (this method was introduced for refactoring and
+        integration purposes -- no changes in functionality at all).
 
         This method can be overwritten as appropriate, in particular the
-        handling is a bit different for PlatformAgents.
+        handling is a bit different for platform agents,
+        which also handle other statuses (child status and rollup status).
 
         @param aggregate_type    type of status to be updated
         @param new_status        The new status value

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -1430,9 +1430,16 @@ class PlatformAgent(ResourceAgent):
 
             try:
                 self._execute_platform_agent(pa_client, cmd, subplatform_id)
-            except:
-                err_msg = "%r: exception executing command %r in subplatform %r" % (
-                          self._platform_id, command, subplatform_id)
+
+            except FSMStateError as e:
+                err_msg = "%r: subplatform %r: FSMStateError for command %r: %s" % (
+                          self._platform_id, subplatform_id, command, e)
+                log.warn(err_msg)
+                return err_msg
+
+            except Exception as e:
+                err_msg = "%r: exception executing command %r in subplatform %r: %s" % (
+                          self._platform_id, command, subplatform_id, e)
                 log.exception(err_msg) #, exc_Info=True)
                 return err_msg
 
@@ -1444,9 +1451,9 @@ class PlatformAgent(ResourceAgent):
                               self._platform_id, expected_state, state)
                     log.error(err_msg)
                     return err_msg
-            except:
-                err_msg = "%r: exception while calling get_agent_state to subplatform %r" % (
-                          self._platform_id, subplatform_id)
+            except Exception as e:
+                err_msg = "%r: exception while calling get_agent_state to subplatform %r: %s" % (
+                          self._platform_id, subplatform_id, e)
                 log.exception(err_msg) #, exc_Info=True)
                 return err_msg
 
@@ -1918,15 +1925,21 @@ class PlatformAgent(ResourceAgent):
             ia_client = self._ia_clients[instrument_id].ia_client
 
             try:
-                retval = self._execute_instrument_agent(ia_client, cmd,
-                                                        instrument_id)
-            except:
-                err_msg = "%r: exception executing command %r in instrument %r" % (
-                          self._platform_id, command, instrument_id)
+                self._execute_instrument_agent(ia_client, cmd,
+                                               instrument_id)
+            except FSMStateError as e:
+                err_msg = "%r: instrument %r: FSMStateError for command %r: %s" % (
+                          self._platform_id, instrument_id, command, e)
+                log.warn(err_msg)
+                return err_msg
+
+            except Exception as e:
+                err_msg = "%r: exception executing command %r in instrument %r: %s" % (
+                          self._platform_id, command, instrument_id, e)
                 log.exception(err_msg) #, exc_Info=True)
                 return err_msg
 
-            # verify state:
+            # verify expected_state if given:
             try:
                 state = ia_client.get_agent_state()
                 if expected_state and expected_state != state:
@@ -1935,9 +1948,9 @@ class PlatformAgent(ResourceAgent):
                     log.error(err_msg)
                     return err_msg
 
-            except:
-                err_msg = "%r: exception while calling get_agent_state to instrument %r" % (
-                          self._platform_id, instrument_id)
+            except Exception as e:
+                err_msg = "%r: exception while calling get_agent_state to instrument %r: %s" % (
+                          self._platform_id, instrument_id, e)
                 log.exception(err_msg) #, exc_Info=True)
                 return err_msg
 


### PR DESCRIPTION
This is now working for the most part, with all platform tests passing (also tested with a couple of the tests in test_instrument_agent).

One visible difference wrt to the code before this integration is that all platform statuses (aggstatus and rollup_status) get to the OK value by the time the platform is in COMMAND mode. Previously, that status was UNKNOWN. Tests adjusted accordingly.

A pending element of the integration is the updates needed upon values received during resource monitoring. 
