### PR TITLE
Set multi flag on prepare inst device agent association

### DIFF
--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1921,6 +1921,9 @@ class InstrumentManagementService(BaseInstrumentManagementService):
             'unassign_sensor_device_from_instrument_device', { "sensor_device_id":  "$(sensor_device_id)",
                                                                 "instrument_device_id":  instrument_device_id })
 
+        # the 'InstrumentAgent' association, correct or not here, needs to be multiple
+        resource_data.associations['InstrumentAgent'].multiple_associations = True
+
         return resource_data
 
     def prepare_instrument_agent_instance_support(self, instrument_agent_instance_id=''):


### PR DESCRIPTION
Despite the fact we can't really do these associations properly yet, at least give the hint to the UI so it doesn't try to treat it like a singleton.
