### PR TITLE
Fixes [None]*len publishing in InstrumentAgent

### DIFF
--- a/ion/services/dm/utility/granule/record_dictionary.py
+++ b/ion/services/dm/utility/granule/record_dictionary.py
@@ -321,19 +321,18 @@ class RecordDictionaryTool(object):
             return None
         if self._available_fields and name not in self._available_fields:
             raise KeyError(name)
-        if self._rd[name] is not None:
-            context = self._pdict.get_context(name)
-            if isinstance(context.param_type, ParameterFunctionType):
-                return self._rd[name].memoized_values[:]
-            return self._rd[name][:]
         ptype = self._pdict.get_context(name).param_type
         if isinstance(ptype, ParameterFunctionType):
+            if self._rd[name] is not None and getattr(self._rd[name],'memoized_values',None) is not None:
+                return self._rd[name].memoized_values[:]
             try:
                 pfv = get_value_class(ptype, self.domain)
                 pfv._pval_callback = self._pval_callback
                 return pfv[:]
             except ParameterFunctionException:
                 log.debug('failed to get parameter function field: %s (%s)', name, self._pdict.keys(), exc_info=True)
+        if self._rd[name] is not None:
+            return self._rd[name][:]
         return None
 
     def iteritems(self):


### PR DESCRIPTION
InstrumentAgent would publish an array of Nones for all variables in the
RDT.  This patch limits the variables being published to only those in
the tomato and the rdt. It avoids the parameter function variables like
'salinity' from being published as all Nones and the GRTs.  When a
client receives a granule with actual content [None] != None it uses the
received value in lieu of calculating it.

This may potentionally fix a bug with gaps (unlikely).
