### PR TITLE
Fixes the memory leak and segfaults

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,7 @@ For Mac, use homebrew
     Alternative: download generic Linux version and unpack into a suitable directory.
 - Install libevent, libyaml, zeromq, couchdb, python, rabbitmq, and pkg-config with Homebrew
 
-    > brew install libevent libyaml zeromq couchdb python rabbitmq hdf5 pkg-config netcdf spatialindex udunits
+    > brew install libevent libyaml zeromq couchdb python rabbitmq hdf5 pkg-config netcdf udunits
 
     You can even reinstall git using brew to clean up your /usr/local directory
     Be sure to read the pyon README for platform specific guidance to installing


### PR DESCRIPTION
A circular reference in the Coverage Model combined with overriding `__del__` prevented the garbage collection module from freeing the instances of the Coverage Model. This patch removes `__del__` and removes the dependency on RTree.

Note: RTree implements a libspatialindex python wrapper using ctypes.  No type checking can be performed on the pointers being passed into the library and as a consequence there are situations where `dynamic_cast<SpatialIndex::ISpatialIndex>` causes a SEGFAULT.  This library has been removed from the coverage model.
