### PR TITLE
remove obs dataset agent tests

### DIFF
--- a/ion/agents/data/handlers/test/test_instrument_end_to_end.py
+++ b/ion/agents/data/handlers/test/test_instrument_end_to_end.py
@@ -200,36 +200,6 @@ class TestBinaryCTD(BulkIngestBase, IonIntegrationTestCase):
         self.assertIsNotNone(rdt['temp'])
 
 @attr('INT', group='eoi')
-class TestBinaryCTD_DelegateAgent(TestBinaryCTD):
-    """ repeat same test using the simple_dataset_agent """
-    def setup_resources(self):
-        self.name = 'hypm_01_wpf_ctd'
-        self.description = 'ctd instrument test'
-        self.EDA_NAME = 'ExampleEDA'
-        self.EDA_MOD = 'ion.agents.data.simple_dataset_agent'
-        self.EDA_CLS = 'TwoDelegateDatasetAgent'
-    def get_dvr_config(self):
-        pdict = self.dataset_management.read_parameter_dictionary(self.pdict_id)
-        stream_def_obj = self.pubsub_management.read_stream_definition(self.stream_def_id)
-        DVR_CONFIG = {
-            'directory': 'test_data',
-            'pattern': 'C*.DAT',
-            'frequency': 5,
-            'max_records': 5,
-            'stream_id': self.stream_id,
-            'stream_route': { key: getattr(self.route, key) for key in self.route._schema },
-            'parser.module': 'ion.agents.data.handlers.sbe52_binary_handler',
-            'parser.class': 'SBE52BinaryCTDParser',
-            'poller.module': 'ion.agents.data.simple_dataset_agent',
-            'poller.class': 'AdditiveSequentialFilePoller',
-            'parameter_dict': stream_def_obj.parameter_dictionary,
-            'last_time': 0
-        }
-        return DVR_CONFIG
-
-
-
-@attr('INT', group='eoi')
 class TestHypm_WPF_CTD(BulkIngestBase, IonIntegrationTestCase):
 
     def setup_resources(self):

--- a/ion/agents/data/test/test_external_dataset_agent.py
+++ b/ion/agents/data/test/test_external_dataset_agent.py
@@ -754,7 +754,8 @@ class ExternalDatasetAgentTestBase(object):
 #            }
 
 
-@attr('INT', group='eoi')
+#DISABLED: attr('INT_LONG', group='eoi')
+# these tests rely on the original handler mechanism which had several shortcomings leading to the poller/parser rewrite
 class TestExternalDatasetAgent(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod': 'ion.agents.data.handlers.base_data_handler',

--- a/ion/agents/data/test/test_external_dataset_agent_netcdf.py
+++ b/ion/agents/data/test/test_external_dataset_agent_netcdf.py
@@ -32,9 +32,9 @@ from interface.services.dm.ipubsub_management_service import\
 import numpy
 
 
-@attr('INT_LONG', group='eoi')
-class TestExternalDatasetAgent_Netcdf(ExternalDatasetAgentTestBase,
-    IonIntegrationTestCase):
+#DISABLED: attr('INT_LONG', group='eoi')
+# these tests rely on the original handler mechanism which had several shortcomings leading to the poller/parser rewrite
+class TestExternalDatasetAgent_Netcdf(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod': 'ion.agents.data.handlers.netcdf_data_handler',
         'dvr_cls': 'NetcdfDataHandler', }

--- a/ion/agents/data/test/test_external_dataset_agent_ruv.py
+++ b/ion/agents/data/test/test_external_dataset_agent_ruv.py
@@ -30,7 +30,8 @@ from coverage_model.coverage import GridDomain, GridShape, CRS
 import numpy
 
 
-@attr('INT_LONG', group='eoi')
+#DISABLED: attr('INT_LONG', group='eoi')
+# these tests rely on the original handler mechanism which had several shortcomings leading to the poller/parser rewrite
 class TestExternalDatasetAgent_Ruv(ExternalDatasetAgentTestBase, IonIntegrationTestCase):
     DVR_CONFIG = {
         'dvr_mod': 'ion.agents.data.handlers.ruv_data_handler',

--- a/ion/agents/data/test/test_external_dataset_agent_slocum.py
+++ b/ion/agents/data/test/test_external_dataset_agent_slocum.py
@@ -29,7 +29,8 @@ from coverage_model.parameter_types import QuantityType
 import numpy
 
 
-@attr('INT_LONG', group='now')
+#DISABLED: attr('INT_LONG', group='eoi')
+# these tests rely on the original handler mechanism which had several shortcomings leading to the poller/parser rewrite
 class TestExternalDatasetAgent_Slocum(ExternalDatasetAgentTestBase,
     IonIntegrationTestCase):
     DVR_CONFIG = {

--- a/ion/services/sa/acquisition/test/test_int_data_acquisition_management_service.py
+++ b/ion/services/sa/acquisition/test/test_int_data_acquisition_management_service.py
@@ -299,9 +299,7 @@ class TestIntDataAcquisitionManagementService(IonIntegrationTestCase):
             print 'Creating new external data agent '
             datasetagent_obj = IonObject(RT.ExternalDatasetAgent,
                                name='ExternalDatasetAgent1',
-                               description='external data agent ',
-                                handler_module = 'module_name',
-                                handler_class = 'class_name')
+                               description='external data agent ')
             try:
                 datasetagent_id = self.client.create_external_dataset_agent(datasetagent_obj)
             except BadRequest as ex:


### PR DESCRIPTION
removes tests using obsolete dataset agent / handler
updates tests using resources not to set handle_class fields
