### PR TITLE
retry checking published conv 5 times; OOIION-1044

### DIFF
--- a/ion/processes/conversation/test/test_conversation_persister.py
+++ b/ion/processes/conversation/test/test_conversation_persister.py
@@ -33,9 +33,14 @@ class TestConversations(IonIntegrationTestCase):
 
         # give at least 2 seconds for the persister to save in the repository
         # test may fail if it does not wait long enough for the persister
-        time.sleep(2)
+        no_of_conv = 0
+        retried = 0
 
-        # assert that the 2 messages have been persisted
-        no_of_conv = len(ds.list_objects())
+        while (no_of_conv != 2 and retried < 5):
+            time.sleep(2)
+            # assert that the 2 messages have been persisted
+            no_of_conv = len(ds.list_objects())
+            retried = retried + 1
+
         self.assertEquals(no_of_conv, 2)
 


### PR DESCRIPTION
fix for: https://jira.oceanobservatories.org/tasks/browse/OOIION-1044

test used to wait 2 seconds before checking datastore for published conversation; this has been changed so that the check is retried 5 times before declaring failure since the problem is not seen on local machines.
