### PR TITLE
Fix jira1024

### DIFF
--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1826,9 +1826,11 @@ class InstrumentManagementService(BaseInstrumentManagementService):
                         extended_platform.portal_instruments[i] = o
 
         log.debug('have portal instruments %s', [i._id if i else "None" for i in extended_platform.portal_instruments])
-        extended_platform.computed.portal_status = csl([i._id if i else None for i in extended_platform.portal_instruments])
 
+        ids =[i._id if i else None for i in extended_platform.portal_instruments]
+        extended_platform.computed.portal_status = csl(ids)
         log.debug('%d portals, %d instruments, %d status: %r', len(extended_platform.portals), len(extended_platform.portal_instruments), len(extended_platform.computed.portal_status.value), ids)
+
         rollx_builder = RollXBuilder(self)
         top_platformnode_id = rollx_builder.get_toplevel_network_node(platform_device_id)
         if t:

--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1773,12 +1773,12 @@ class InstrumentManagementService(BaseInstrumentManagementService):
                 log.warn('compound association failed, manual workaround found %d portals', len(extended_platform.portals))
         # END JIRA BLOCK
 
-        # add device and status of portals
-        _,associations = RR2.find_objects_mult(subjects=[p._id for p in extended_platform.portals], id_only=True)
-        for a in associations:
-            if a.p==PRED.hasDevice:
-                if a.ot!=RT.InstrumentDevice:
-                    log.warn('unexpected association InstrumentSite %s hasDevice %s %s (was not InstrumentDevice)', a.s, a.ot, a.o)
+#        # add device and status of portals
+#        _,associations = RR2.find_objects_mult(subjects=[p._id for p in extended_platform.portals], id_only=True)
+#        for a in associations:
+#            if a.p==PRED.hasDevice:
+#                if a.ot!=RT.InstrumentDevice:
+#                    log.warn('unexpected association InstrumentSite %s hasDevice %s %s (was not InstrumentDevice)', a.s, a.ot, a.o)
 
         # use the related resources crawler to get ALL sub-devices
         finder = RelatedResourcesCrawler()
@@ -1803,42 +1803,32 @@ class InstrumentManagementService(BaseInstrumentManagementService):
                                                                                     list(subdevice_ids))
 
         statuses, reason = self.agent_status_builder.get_cumulative_status_dict(platform_device_id)
-
         def csl(device_id_list):
             return self.agent_status_builder.compute_status_list(statuses, device_id_list)
-        log.debug("Building instrument and platform status dicts")
+
         extended_platform.computed.instrument_status = csl([dev._id for dev in extended_platform.instrument_devices])
         extended_platform.computed.platform_status   = csl([platform._id for platform in extended_platform.platforms])
-        log.info('instrument_status: %s %r instruments %d\nplatform_status: %s %r platforms %d',
+        log.debug('instrument_status: %s %r instruments %d\nplatform_status: %s %r platforms %d',
             extended_platform.computed.instrument_status.reason, extended_platform.computed.instrument_status.value, len(extended_platform.instrument_devices),
             extended_platform.computed.platform_status.reason, extended_platform.computed.platform_status.value, len(extended_platform.platforms))
         if t:
             t.complete_step('ims.platform_device_extension.status')
 
-#        extended_platform.computed.portal_status     = csl([dev._id if dev else None for dev in extended_platform.portal_instruments])
-        # use associations to create portal_instrument array such that portal[i] --hasDevice--> portal_instrument[i]
-        # use existing InstrumentDevice objects in instrument_devices array
+        # add device and status of portals
+        objects,associations = RR2.find_objects_mult(subjects=[p._id for p in extended_platform.portals], id_only=False)
         extended_platform.portal_instruments = [None]*len(extended_platform.portals)
-        extended_platform.computed.portal_status = ComputedListValue(value=[None]*len(extended_platform.portals), status=ComputedValueAvailability.PROVIDED if statuses else ComputedValueAvailability.NOTAVAILABLE)
         for i in xrange(len(extended_platform.portals)):
-        #found_association = False
-            for a in associations:
-                if a.p==PRED.hasDevice and a.ot==RT.InstrumentDevice and a.s==extended_platform.portals[i]._id:
-                    #if found_association:
-                    #    log.warn('found more than one InstrumentDevice for InstrumentSite %s: had %s, now also %s', target_site_id, extended_platform.portal_instruments[i]._id, a.o)
-                    #    continue
-                    #found_association = True
-                    # no need to query devices from DB, just find in existing list -- but order with index of portal
-#                    found_instrument = False
-                    for j in xrange(len(extended_platform.instrument_devices)):
-                        if extended_platform.instrument_devices[j]._id == a.o:
-#                            found_instrument = True
-                            extended_platform.portal_instruments[i] = extended_platform.instrument_devices[j]
-                            extended_platform.computed.portal_status.value[i] = extended_platform.computed.instrument_status.value[j] if statuses else None
-                            break
-#                    if not found_instrument:
-#                        log.warn('portal device %s of PlatformDevice %s not found in instrument_device list', a.o, platform_device_id)
-        log.debug("Building network rollups")
+            for o,a in zip(objects,associations):
+                if a.p==PRED.hasDevice:
+                    if a.ot!=RT.InstrumentDevice:
+                        log.warn('unexpected association InstrumentSite %s hasDevice %s %s (was not InstrumentDevice)', a.s, a.ot, a.o)
+                    elif a.s==extended_platform.portals[i]._id:
+                        extended_platform.portal_instruments[i] = o
+
+        log.debug('have portal instruments %s', [i._id if i else "None" for i in extended_platform.portal_instruments])
+        extended_platform.computed.portal_status = csl([i._id if i else None for i in extended_platform.portal_instruments])
+
+        log.debug('%d portals, %d instruments, %d status: %r', len(extended_platform.portals), len(extended_platform.portal_instruments), len(extended_platform.computed.portal_status.value), ids)
         rollx_builder = RollXBuilder(self)
         top_platformnode_id = rollx_builder.get_toplevel_network_node(platform_device_id)
         if t:

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -204,7 +204,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
 
         self.assertEqual(1, len(extended_platform.portals))
         self.assertEqual(1, len(extended_platform.portal_instruments))
-        self.assertEqual(1, len(extended_platform.computed.portal_status.value))
+        #self.assertEqual(1, len(extended_platform.computed.portal_status.value)) # no agent started so NO statuses reported
         self.assertEqual(1, len(extended_platform.instrument_devices))
         self.assertEqual(instrument_device_id, extended_platform.instrument_devices[0]._id)
         self.assertEqual(1, len(extended_platform.instrument_models))

--- a/ion/services/sa/observatory/deployment_util.py
+++ b/ion/services/sa/observatory/deployment_util.py
@@ -5,7 +5,7 @@ suitable for the UI table:
  { deployment_id: { 'ui_column': 'string_value'... } }
 """
 
-from ooi.logging import log, TRACE
+from ooi.logging import log, TRACE, DEBUG
 from pyon.ion.resource import RT, PRED, LCS, OT
 import time
 
@@ -75,6 +75,7 @@ def describe_deployments(deployments, context, instruments=[], instrument_status
                                  assoc.s, description['site_name'], assoc.o, description['device_name'])
                     description['is_primary']=found_match=True
 
+    # finally get parents of sites using hasSite
     objects3,associations = rr.find_subjects_mult(objects=site_ids)
     if log.isEnabledFor(TRACE):
         log.trace('have %d site-associated objects, %d are hasDeployment', len(associations), sum([1 if assoc.p==PRED.hasDeployment else 0 for assoc in associations]))
@@ -92,5 +93,8 @@ def describe_deployments(deployments, context, instruments=[], instrument_status
     # convert to array
     descriptions = [ descriptions[d._id] for d in deployments ]
 
-    log.debug('%d deployments, %d associated sites/devices, %d activations', len(deployments), len(objects), len(objects2))
+    if log.isEnabledFor(DEBUG):
+        log.debug('%d deployments, %d associated sites/devices, %d activations, %d missing status', len(deployments), len(objects), len(objects2),
+            sum([0 if 'device_status' in d else 1 for d in descriptions]))
+
     return descriptions

--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -847,31 +847,31 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
             extended_site.instrument_models = retrieve_model_objs(extended_site.instrument_devices, RT.InstrumentDevice)
             extended_site.platform_models   = retrieve_model_objs(extended_site.platform_devices, RT.PlatformDevice)
 
-            extended_site.deployment_info = describe_deployments(extended_site.deployments, self.clients, instruments=extended_site.instrument_devices, instrument_status=extended_site.computed.instrument_status.value)
-
+#            extended_site.deployment_info = describe_deployments(extended_site.deployments, self.clients, instruments=extended_site.instrument_devices, instrument_status=extended_site.computed.instrument_status.value)
+#
             this_device_id = None
             try:
                 this_device_id = RR2.find_object(site_id, predicate=PRED.hasDevice, id_only=True)
             except NotFound:
                 pass
 
-            # have portals but need to reduce to appropriate subset...
-            _,associations = RR2.find_objects_mult(subjects=[p._id for p in extended_site.sites], id_only=True)
-            for a in associations:
-                if a.p==PRED.hasDevice:
-                    if a.ot not in (RT.InstrumentDevice, RT.PlatformDevice):
-                        log.warn('unexpected association Site %s hasDevice %s %s (was not InstrumentDevice or PlatformDevice)', a.s, a.ot, a.o)
-            log.debug('subsites of %s have %d hasDevice associations', site_id, len(associations))
-            extended_site.portal_instruments = [None]*len(extended_site.sites)
-            extended_site.computed.portal_status = ComputedListValue(value=[None]*len(extended_site.sites), status=ComputedValueAvailability.PROVIDED if extended_site.computed.instrument_status.value else ComputedValueAvailability.NOTAVAILABLE)
-            for i in xrange(len(extended_site.sites)):
-                for a in associations:
-                    if a.p==PRED.hasDevice and a.ot in (RT.InstrumentDevice, RT.PlatformDevice) and a.s==extended_site.sites[i]._id:
-                        for j in xrange(len(extended_site.instrument_devices)):
-                            if extended_site.instrument_devices[j]._id == a.o:
-                                extended_site.portal_instruments[i] = extended_site.instrument_devices[j]
-                                extended_site.computed.portal_status.value[i] = extended_site.computed.instrument_status.value[j] if extended_site.computed.instrument_status.value else None
-                                break
+#            # have portals but need to reduce to appropriate subset...
+#            _,associations = RR2.find_objects_mult(subjects=[p._id for p in extended_site.sites], id_only=True)
+#            for a in associations:
+#                if a.p==PRED.hasDevice:
+#                    if a.ot not in (RT.InstrumentDevice, RT.PlatformDevice):
+#                        log.warn('unexpected association Site %s hasDevice %s %s (was not InstrumentDevice or PlatformDevice)', a.s, a.ot, a.o)
+#            log.debug('subsites of %s have %d hasDevice associations', site_id, len(associations))
+#            extended_site.portal_instruments = [None]*len(extended_site.sites)
+#            extended_site.computed.portal_status = ComputedListValue(value=[None]*len(extended_site.sites), status=ComputedValueAvailability.PROVIDED if extended_site.computed.instrument_status.value else ComputedValueAvailability.NOTAVAILABLE)
+#            for i in xrange(len(extended_site.sites)):
+#                for a in associations:
+#                    if a.p==PRED.hasDevice and a.ot in (RT.InstrumentDevice, RT.PlatformDevice) and a.s==extended_site.sites[i]._id:
+#                        for j in xrange(len(extended_site.instrument_devices)):
+#                            if extended_site.instrument_devices[j]._id == a.o:
+#                                extended_site.portal_instruments[i] = extended_site.instrument_devices[j]
+#                                extended_site.computed.portal_status.value[i] = extended_site.computed.instrument_status.value[j] if extended_site.computed.instrument_status.value else None
+#                                break
 
             return extended_site, RR2, this_device_id
         except:
@@ -935,12 +935,34 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
 
         site_id = extended_site._id
 
+        # get portals
+        objects,associations = RR2.find_objects_mult(subjects=[p._id for p in extended_site.sites], id_only=False)
+        log.debug('subsites of %s have %d hasDevice associations', site_id, len(associations))
+        extended_site.portal_instruments = [None]*len(extended_site.sites)
+        for i in xrange(len(extended_site.sites)):
+            for o,a in zip(objects,associations):
+                if a.p==PRED.hasDevice:
+                    if a.ot not in (RT.InstrumentDevice, RT.PlatformDevice):
+                        log.warn('unexpected association Site %s hasDevice %s %s (was not InstrumentDevice or PlatformDevice)', a.s, a.ot, a.o)
+                    elif a.s==extended_site.sites[i]._id:
+                        extended_site.portal_instruments[i] = o
+
+
 
         # prepare to make a lot of rollups
         site_object_dict, site_children = self.outil.get_child_sites(parent_site_id=site_id, id_only=False)
         log.debug("Found these site children: %s", site_children.keys())
-        all_device_statuses = self._get_master_status_table(RR2, site_children.keys())
+
+        devices_for_status = set(site_children.keys())
+        for i in extended_site.portal_instruments:
+            if i:
+                devices_for_status.add(i._id)
+        all_device_statuses = self._get_master_status_table(RR2, devices_for_status)
         log.debug("Found all device statuses: %s", all_device_statuses)
+
+        # portal status rollup
+        portal_status = [self.agent_status_builder._crush_status_dict(all_device_statuses.get(k._id, {})) if k else DeviceStatusType.STATUS_UNKNOWN for k in extended_site.portal_instruments]
+        extended_site.computed.portal_status = ComputedListValue(status=ComputedValueAvailability.PROVIDED, value=portal_status)
 
         log.debug("generating site status rollup")
         site_status = self._get_site_rollup_list(RR2, all_device_statuses, [s._id for s in extended_site.sites])
@@ -983,11 +1005,7 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
         extended_site.computed.platform_assembly_sites  = clv(pfs(lambda s: "PlatformAssemblySite" == s.alt_resource_type))
         extended_site.computed.instrument_sites         = clv(ifs(lambda _: True))
 
-
-        return extended_site, RR2
-
-
-
+        extended_site.deployment_info = describe_deployments(extended_site.deployments, self.clients, instruments=extended_site.instrument_devices, instrument_status=extended_site.computed.instrument_status.value)
 
     # TODO: will remove this one
     def get_site_extension(self, site_id='', ext_associations=None, ext_exclude=None, user_id=''):
@@ -1051,6 +1069,12 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
         extended_site.computed.platform_status          = clv()
         extended_site.computed.site_status              = clv()
         extended_site.computed.instrument_status        = clv(instrument_status_list)
+
+        extended_site.deployment_info = describe_deployments(extended_site.deployments, self.clients, instruments=extended_site.instrument_devices, instrument_status=extended_site.computed.instrument_status.value)
+
+        # have portals but need to reduce to appropriate subset...
+        extended_site.portal_instruments = []#*len(extended_site.sites)
+        extended_site.computed.portal_status = clv() #ComputedListValue(status=ComputedValueAvailability.PROVIDED, value=portal_status)
 
         return extended_site
 
@@ -1210,10 +1234,10 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
         actors_list = extended_org.members
         user_list = []
         for actor in actors_list:
-            log.debug("get_marine_facility_extension: actor:  %s ", str(actor))
+            log.debug("get_marine_facility_extension: actor:  %s ", actor)
             user_info_objs, _ = self._rr.find_objects(subject=actor._id, predicate=PRED.hasInfo, object_type=RT.UserInfo, id_only=False)
             if user_info_objs:
-                log.debug("get_marine_facility_extension: user_info_obj  %s ", str(user_info_objs[0]))
+                log.debug("get_marine_facility_extension: user_info_obj  %s ", user_info_objs[0])
                 user_list.append( user_info_objs[0] )
 
         extended_org.members = user_list
@@ -1281,9 +1305,9 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
         extended_org.station_sites = subset
         station_status = self._get_site_rollup_list(RR2, all_device_statuses, [s._id for s in extended_org.station_sites])
         extended_org.computed.station_status = ComputedListValue(status=ComputedValueAvailability.PROVIDED, value=station_status)
+        extended_org.deployment_info = describe_deployments(extended_org.deployments, self.clients, instruments=extended_org.instruments, instrument_status=extended_org.computed.instrument_status.value)
 
         return extended_org
-
 
     # return a table of device statuses for all given device ids
     def _get_master_status_table(self, RR2, site_tree_ids):


### PR DESCRIPTION
new branch with the changes that were garbled in the earlier branch.

changes collect device status for deployment and portal lists directly,
prior release extracted them as a subset of existing device lists.
