### PR TITLE
fix OOIION-1030, 	OOIION-1058

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -261,18 +261,20 @@ class PlatformAgent(ResourceAgent):
         self._plat_config = self.CFG.get("platform_config", None)
         self._plat_config_processed = False
 
+        platform_id = self.CFG.get_safe('platform_config.platform_id', '??')
+
         #######################################################################
         # CFG.endpoint.receive.timeout: adding a warning if the value is less
         # than the one we have been using successfully for a while, at least
         # against our RSN OMS simulator, both locally and on the buildbots.
         if self._timeout < 180:
-            log.warn("%r: CFG.endpoint.receive.timeout=%s < 180", self._timeout)
+            log.warn("%r: CFG.endpoint.receive.timeout=%s < 180",
+                     platform_id, self._timeout)
         #######################################################################
 
         self._launcher = Launcher(self._timeout)
 
         if log.isEnabledFor(logging.DEBUG):  # pragma: no cover
-            platform_id = self.CFG.get_safe('platform_config.platform_id', '')
             log.debug("%r: self._timeout = %s", platform_id, self._timeout)
             outname = "logs/platform_CFG_received_%s.txt" % platform_id
             try:

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -261,6 +261,14 @@ class PlatformAgent(ResourceAgent):
         self._plat_config = self.CFG.get("platform_config", None)
         self._plat_config_processed = False
 
+        #######################################################################
+        # CFG.endpoint.receive.timeout: adding a warning if the value is less
+        # than the one we have been using successfully for a while, at least
+        # against our RSN OMS simulator, both locally and on the buildbots.
+        if self._timeout < 180:
+            log.warn("%r: CFG.endpoint.receive.timeout=%s < 180", self._timeout)
+        #######################################################################
+
         self._launcher = Launcher(self._timeout)
 
         if log.isEnabledFor(logging.DEBUG):  # pragma: no cover
@@ -402,7 +410,7 @@ class PlatformAgent(ResourceAgent):
         Launches the sub-platform agents.
         Launches the associated instrument agents;
         """
-        log.info('_children_launch ...')
+        log.info("%r: _children_launch ...", self._platform_id)
 
         # launch the sub-platform agents:
         self._subplatforms_launch()
@@ -1054,16 +1062,12 @@ class PlatformAgent(ResourceAgent):
         @param async_res   As returned by call to _prepare_await_state
         @param sub         As returned by call to _prepare_await_state
         """
-        try:
-            # wait for the event:
-            async_res.get(timeout=self._timeout)
 
-        finally:
-            try:
-                sub.stop()
-            except Exception as ex:
-                log.warn("%r: error stopping event subscriber to wait for a state: %s",
-                         self._platform_id, ex)
+        # wait for the event:
+        async_res.get(timeout=self._timeout)
+
+        # no need to stop the subscriber because it is registered with the
+        # endpoint management API. See _create_event_subscriber.
 
     ##############################################################
     # supporting routines dealing with sub-platforms
@@ -1094,12 +1098,17 @@ class PlatformAgent(ResourceAgent):
         pid = None
         try:
             # try to connect:
+            log.debug("%r: [LL] trying to determine whether my child is already running: %r",
+                      self._platform_id, subplatform_id)
             pa_client = self._create_resource_agent_client(subplatform_id, sub_resource_id)
             # it is actually running.
 
             # get PID:
             # TODO is there a more public method to get the pid?
             pid = ResourceAgentClient._get_agent_process_id(sub_resource_id)
+
+            log.debug("%r: [LL] my child is already running: %r. pid=%s",
+                      self._platform_id, subplatform_id, pid)
 
         except NotFound:
             # not running.
@@ -1128,19 +1137,29 @@ class PlatformAgent(ResourceAgent):
                                                              PlatformAgentState.UNINITIALIZED)
 
             if log.isEnabledFor(logging.TRACE):  # pragma: no cover
-                log.trace("%r: launching sub-platform agent %r: CFG=%s",
+                log.trace("%r: [LL] launching sub-platform agent %r: CFG=%s",
                           self._platform_id, subplatform_id, self._pp.pformat(sub_agent_config))
             else:
-                log.debug("%r: launching sub-platform agent %r", self._platform_id, subplatform_id)
+                log.debug("%r: [LL] launching sub-platform agent %r",
+                          self._platform_id, subplatform_id)
 
             pid = self._launcher.launch_platform(subplatform_id, sub_agent_config)
-            log.debug("%r: DONE launching sub-platform agent %r", self._platform_id, subplatform_id)
+            log.debug("%r: [LL] DONE launching sub-platform agent %r",
+                      self._platform_id, subplatform_id)
 
             # create resource agent client:
             pa_client = self._create_resource_agent_client(subplatform_id, sub_resource_id)
 
             # wait until UNINITIALIZED:
+            log.debug("%r: [LL] Got pa_client for sub-platform agent %r. Waiting "
+                      "for UNINITIALIZED state...",
+                      self._platform_id, subplatform_id)
+
             self._await_state(asyn_res, subscriber)
+
+            log.debug("%r: [LL] ok, my sub-platform agent %r is now in "
+                      "UNINITIALIZED state",
+                      self._platform_id, subplatform_id)
 
         # here, sub-platform agent process is running.
 

--- a/ion/agents/platform/status_manager.py
+++ b/ion/agents/platform/status_manager.py
@@ -77,6 +77,8 @@ class StatusManager(object):
         assert pa._platform_id is not None
         assert pa._children_resource_ids is not None
 
+        self._agent = pa
+
         self._create_event_subscriber = pa._create_event_subscriber
 
         self._platform_id            = pa._platform_id
@@ -783,11 +785,13 @@ Published event: AGGREGATE_POWER -> STATUS_OK
                           self._platform_id, evt.sub_type, sub_type)
                 return
 
+            state = self._agent.get_agent_state()
+
             statuses = formatted_statuses(self.aparam_aggstatus,
                                           self.aparam_child_agg_status,
                                           self.aparam_rollup_status)
-            log.info("%r: (%s) status report triggered by diagnostic event:\n%s\n",
-                     self._platform_id, self.resource_id, statuses)
+            log.info("%r/%s: (%s) status report triggered by diagnostic event:\n%s\n",
+                     self._platform_id, state, self.resource_id, statuses)
 
         self._diag_sub = self._create_event_subscriber(event_type=event_type,
                                                        origin=origin,

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -51,20 +51,11 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         self._run()
 
     def _run_shutdown_commands(self):
-        self._go_inactive()
-        self._reset()
-        self._shutdown()
-
-    def _run_commands(self):
-        """
-        A common sequence of commands for the root platform in some of the
-        tests below.
-        """
-        self._run_startup_commands()
-
-        #####################
-        # done
-        self._run_shutdown_commands()
+        try:
+            self._go_inactive()
+            self._reset()
+        finally:  # attempt shutdown anyway
+            self._shutdown()
 
     def test_single_platform(self):
         #
@@ -73,8 +64,9 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         p_root = self._create_single_platform()
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._run_shutdown_commands)
 
-        self._run_commands()
+        self._run_startup_commands()
 
     def test_hierarchy(self):
         #
@@ -83,8 +75,9 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         p_root = self._create_small_hierarchy()
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._run_shutdown_commands)
 
-        self._run_commands()
+        self._run_startup_commands()
 
     def test_single_platform_with_an_instrument(self):
         #
@@ -94,8 +87,9 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         p_root = self._set_up_single_platform_with_some_instruments(['SBE37_SIM_01'])
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._run_shutdown_commands)
 
-        self._run_commands()
+        self._run_startup_commands()
 
     def test_instrument_first_then_platform(self):
         #
@@ -125,6 +119,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         # start the platform:
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._run_shutdown_commands)
 
         self._run_startup_commands()
 
@@ -132,9 +127,6 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         instr_state = ia_client.get_agent_state()
         log.debug("instrument state: %s", instr_state)
         self.assertEquals(ResourceAgentState.COMMAND, instr_state)
-
-        # done
-        self._run_shutdown_commands()
 
     def test_13_platforms_and_2_instruments(self):
         #
@@ -145,8 +137,9 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         p_root = self._set_up_platform_hierarchy_with_some_instruments(instr_keys)
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._run_shutdown_commands)
 
-        self._run_commands()
+        self._run_startup_commands()
 
     @skip("Runs fine but waiting for comments to enable in general")
     @patch.dict(CFG, {'endpoint': {'receive': {'timeout': 420}}})
@@ -159,8 +152,9 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         p_root = self._set_up_platform_hierarchy_with_some_instruments(instr_keys)
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._run_shutdown_commands)
 
-        self._run_commands()
+        self._run_startup_commands()
 
     def test_platform_device_extended_attributes(self):
 
@@ -169,6 +163,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._run_shutdown_commands)
 
         self._run_startup_commands()
 
@@ -272,5 +267,3 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
         print "\n%s\n" % all_vals
         #if True: self.fail(all_vals)
-
-        self._run_shutdown_commands()

--- a/ion/services/sa/observatory/test/test_platform_status.py
+++ b/ion/services/sa/observatory/test/test_platform_status.py
@@ -48,6 +48,13 @@ class Test(BaseIntTestPlatform):
         self._received_events = []
         self._last_checked_status = None
 
+    def _done(self):
+        try:
+            self._go_inactive()
+            self._reset()
+        finally:  # attempt shutdown anyway
+            self._shutdown()
+
     def _start_agg_status_event_subscriber(self, p_root):
         """
         Start the event subscriber to the given root platform. Upon reception
@@ -248,6 +255,7 @@ class Test(BaseIntTestPlatform):
         # start up the network
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._done)
         self._initialize()
         self._go_active()
         self._run()
@@ -359,12 +367,6 @@ class Test(BaseIntTestPlatform):
         self._verify_with_get_agent(AggregateStatusType.AGGREGATE_COMMS,
                                     DeviceStatusType.STATUS_OK)
 
-        #####################################################################
-        # done
-        self._go_inactive()
-        self._reset()
-        self._shutdown()
-
     def test_platform_status_small_network_5(self):
         #
         # Test of status propagation in a small network of 5 platforms with
@@ -414,6 +416,7 @@ class Test(BaseIntTestPlatform):
         # start up the network
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._done)
         self._initialize()
         self._go_active()
         self._run()
@@ -465,12 +468,6 @@ class Test(BaseIntTestPlatform):
         self._wait_root_event_and_verify(AggregateStatusType.AGGREGATE_COMMS,
                                          DeviceStatusType.STATUS_OK)
 
-        #####################################################################
-        # done
-        self._go_inactive()
-        self._reset()
-        self._shutdown()
-
     def test_platform_status_small_network_5_1(self):
         #
         # Test of status propagation in a small network of 5 platforms with
@@ -508,6 +505,7 @@ class Test(BaseIntTestPlatform):
         # start up the network
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._done)
         self._initialize()
         self._go_active()
         self._run()
@@ -559,12 +557,6 @@ class Test(BaseIntTestPlatform):
         # confirm root gets updated to STATUS_OK
         self._wait_root_event_and_verify(AggregateStatusType.AGGREGATE_COMMS,
                                          DeviceStatusType.STATUS_OK)
-
-        #####################################################################
-        # done
-        self._go_inactive()
-        self._reset()
-        self._shutdown()
 
     def test_platform_status_launch_instruments_first_2_3(self):
         #


### PR DESCRIPTION
- fix https://jira.oceanobservatories.org/tasks/browse/OOIION-1030: use stream_config's stream_def_dict entry (instead of stream_definition_ref).
- fix https://jira.oceanobservatories.org/tasks/browse/OOIION-1058: also put "shutdown" actions in addCleanup to prevent the process leaks upon failing tests. Although this should cover errors during normal commanding to the root platform and its children after the nework is running, this adjustment may not work when the error happens during the launch itself of the network. It would be rather complicated to add logic to cover this error case.
