### PR TITLE
Adds checksum verification to the downloaded eggs

### DIFF
--- a/ion/agents/instrument/test/test_instrument_agent.py
+++ b/ion/agents/instrument/test/test_instrument_agent.py
@@ -130,6 +130,7 @@ IA_CLS = 'InstrumentAgent'
 
 # A seabird driver.
 DRV_URI = 'http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.1.1-py2.7.egg'
+DRV_SHA = '28e1b59708d72e008b0aa68ea7392d3a2467f393'
 DRV_MOD = 'mi.instrument.seabird.sbe37smb.ooicore.driver'
 DRV_CLS = 'SBE37Driver'
 
@@ -150,6 +151,12 @@ if LAUNCH_FROM_EGG:
     # Dynamically load the egg into the test path
     launcher = ZMQEggDriverProcess(DVR_CONFIG)
     egg = launcher._get_egg(DRV_URI)
+    from hashlib import sha1
+    with open(egg,'r') as f:
+        doc = f.read()
+        sha = sha1(doc).hexdigest()
+        if sha != DRV_SHA:
+            raise ImportError('Failed to load driver %s: incorrect checksum.  (%s!=%s)' % (DRV_URI, DRV_SHA, sha))
     if not egg in sys.path: sys.path.insert(0, egg)
     DVR_CONFIG['process_type'] = (DriverProcessType.EGG,)
 


### PR DESCRIPTION
There is a certain situation where a partially downloaded or corrupted
egg file will remain in the filesystem and a container will fail to load
without any apparent reason other than an ImportError "Can't load
mi.core...".  The source of this problem stems from a corrupted egg.
This checksum comparison at least provides a more detailed message as to
what's going on.

The solution to get the container to load again is to delete the egg in
'/tmp' and try again. MI may want to add some special handling here to
try the download again or something.
