### PR TITLE
fix OOIION-1095

### DIFF
--- a/ion/agents/platform/rsn/oms_event_listener.py
+++ b/ion/agents/platform/rsn/oms_event_listener.py
@@ -53,11 +53,12 @@ class OmsEventListener(object):
         self._notifications = None
 
         # _no_notifications: flag only intended for developing purposes
+        # see ion.agents.platform.rsn.simulator.oms_events
         self._no_notifications = os.getenv("NO_OMS_NOTIFICATIONS") is not None
         if self._no_notifications:  # pragma: no cover
             log.warn("%r: NO_OMS_NOTIFICATIONS env variable defined: "
                      "no notifications will be done", self._platform_id)
-            self._url = "http://_disabled.by.env.var"
+            self._url = "http://NO_OMS_NOTIFICATIONS"
 
     @property
     def url(self):

--- a/ion/agents/platform/rsn/rsn_platform_driver.py
+++ b/ion/agents/platform/rsn/rsn_platform_driver.py
@@ -75,9 +75,9 @@ class RSNPlatformDriver(PlatformDriver):
         # CIOMSClient instance created by connect() and destroyed by disconnect():
         self._rsn_oms = None
 
-        # external event listener: we can instantiate this here as the the
+        # external event listener: we can instantiate this here as the
         # actual http server is started via corresponding method.
-        self._event_listener = OmsEventListener(self._notify_driver_event)
+        self._event_listener = OmsEventListener(self._platform_id, self._notify_driver_event)
 
     def _filter_capabilities(self, events):
         """

--- a/ion/agents/platform/rsn/simulator/oms_events.py
+++ b/ion/agents/platform/rsn/simulator/oms_events.py
@@ -97,6 +97,10 @@ class EventNotifier(object):
         """
         Notifies event to given listener.
         """
+        if url == "http://NO_OMS_NOTIFICATIONS":
+            # developer convenience -see ion.agents.platform.rsn.oms_event_listener
+            return
+
         log.debug("Notifying event_instance=%s to listener=%s", str(event_instance), url)
 
         # include url in event instance:

--- a/ion/agents/platform/rsn/simulator/oms_simulator.py
+++ b/ion/agents/platform/rsn/simulator/oms_simulator.py
@@ -371,7 +371,7 @@ class CIOMSSimulator(CIOMSClient):
             # create entry for this new url
             reg_time = self._event_notifier.add_listener(url, event_type)
             self._reg_event_listeners[url] = reg_time
-            log.info("%r registered url=%r", url)
+            log.info("registered url=%r", url)
         else:
             # already registered:
             reg_time = self._reg_event_listeners[url]
@@ -399,7 +399,7 @@ class CIOMSSimulator(CIOMSClient):
         unreg_time = self._event_notifier.remove_listener(url, event_type)
         del self._reg_event_listeners[url]
 
-        log.info("%r unregistered url=%r", url)
+        log.info("unregistered url=%r", url)
 
         self._stop_event_generator_if_no_listeners()
 

--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -74,6 +74,8 @@ class TestPlatformAgent(BaseIntTestPlatform):
 
         @param clean_up    Not None to override default pre-cleanUp calls.
         """
+        self._set_receive_timeout()
+
         self.p_root = None
 
         # NOTE The tests expect to use values set up by HelperTestMixin for
@@ -676,7 +678,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         with self.assertRaises(Conflict):
             self._pa_client.get_resource_state()
 
-        self._async_event_result.get(timeout=CFG.endpoint.receive.timeout)
+        self._async_event_result.get(timeout=self._receive_timeout)
         self.assertGreaterEqual(len(self._events_received), 2)
 
     def test_lost_connection_and_reconnect(self):
@@ -718,7 +720,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._simulator_disable()
 
         # verify a ResourceAgentConnectionLostErrorEvent was published:
-        async_event_result.get(timeout=CFG.endpoint.receive.timeout)
+        async_event_result.get(timeout=self._receive_timeout)
         self.assertEquals(len(events_received), 1)
 
         # verify the platform is now in LOST_CONNECTION:
@@ -768,7 +770,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
             log.info("registered DeviceStatusAlertEvent subscriber: %s", kwargs)
 
             self._event_subscribers.append(sub)
-            sub._ready_event.wait(timeout=CFG.endpoint.receive.timeout)
+            sub._ready_event.wait(timeout=self._receive_timeout)
 
             return async_event_result
 

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -62,6 +62,8 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #
         # Tests the launch and shutdown of a single platform (no instruments).
         #
+        self._set_receive_timeout()
+
         p_root = self._create_single_platform()
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
@@ -73,6 +75,8 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #
         # Tests the launch and shutdown of a small platform topology (no instruments).
         #
+        self._set_receive_timeout()
+
         p_root = self._create_small_hierarchy()
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
@@ -84,6 +88,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #
         # basic test of launching a single platform with an instrument
         #
+        self._set_receive_timeout()
 
         p_root = self._set_up_single_platform_with_some_instruments(['SBE37_SIM_01'])
         self._start_platform(p_root)
@@ -100,6 +105,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         # continue operating normally.
         # See PlatformAgent._launch_instrument_agent
         #
+        self._set_receive_timeout()
 
         # create instrument but do not start associated port agent ...
         instr_key = 'SBE37_SIM_01'
@@ -135,6 +141,8 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         # This test added while investigating OOIION-1095.
         # With one instrument the test runs fine even --with-pycc.
         #
+        self._set_receive_timeout()
+
         instr_keys = ["SBE37_SIM_02", ]
 
         p_root = self._set_up_platform_hierarchy_with_some_instruments(instr_keys)
@@ -144,14 +152,12 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
         self._run_startup_commands()
 
-    @skip("Used to pass in general, but now not --with-pycc when more "
-          "than one instrument is associated. Skipped while investigating. OOIION-1095")
-    # Note: it's the same test as above but with more than one instrument.
-    # TODO reenable. what has changed in the launching of port/instrument agents?
     def test_13_platforms_and_2_instruments(self):
         #
         # Test with network of 13 platforms and 2 instruments.
         #
+        self._set_receive_timeout()
+
         instr_keys = ["SBE37_SIM_01", "SBE37_SIM_02", ]
 
         p_root = self._set_up_platform_hierarchy_with_some_instruments(instr_keys)
@@ -168,6 +174,8 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         # Test with network of 13 platforms and 8 instruments (the current
         # number of enabled instrument simulator instances).
         #
+        self._set_receive_timeout()
+
         instr_keys = sorted(instruments_dict.keys())
         p_root = self._set_up_platform_hierarchy_with_some_instruments(instr_keys)
         self._start_platform(p_root)
@@ -177,6 +185,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         self._run_startup_commands()
 
     def test_platform_device_extended_attributes(self):
+        self._set_receive_timeout()
 
         instr_keys = ["SBE37_SIM_01", "SBE37_SIM_02", ]
         p_root = self._set_up_platform_hierarchy_with_some_instruments(instr_keys)

--- a/ion/services/sa/observatory/test/test_platform_status.py
+++ b/ion/services/sa/observatory/test/test_platform_status.py
@@ -245,6 +245,8 @@ class Test(BaseIntTestPlatform):
         #
         # The updates are triggered from direct event publications done on
         # behalf of the leaf platforms.
+        #
+        self._set_receive_timeout()
 
         # create the network:
         p_objs = {}
@@ -407,6 +409,8 @@ class Test(BaseIntTestPlatform):
         # In the tests below, we can verify the expected root status with
         # either the received event or via explicit request via get_agent.
         #
+        #
+        self._set_receive_timeout()
 
         # create the network:
         p_objs = {}
@@ -491,6 +495,8 @@ class Test(BaseIntTestPlatform):
         # here also assign an instrument to a platform and trigger all
         # updates from that instrument.
         #
+        #
+        self._set_receive_timeout()
 
         # create the network:
         p_objs = {}
@@ -587,6 +593,8 @@ class Test(BaseIntTestPlatform):
         # The test also includes some explicitly triggered updates via
         # publication on behalf of the instruments.
         #
+        #
+        self._set_receive_timeout()
 
         # create the network:
         p_objs = {}
@@ -853,6 +861,7 @@ class Test(BaseIntTestPlatform):
         #   platform='LJ01D'
         #   instrument=SBE37_SIM_01
         #
+        self._set_receive_timeout()
 
         # create the network:
         self.p_root = p_root = self._create_platform('LJ01D')


### PR DESCRIPTION
https://jira.oceanobservatories.org/tasks/browse/OOIION-1095
- if endpoint.receive.timeout given to PlatformAgent is less than the value we have been using
  successfully, then it uses that larger value (180). A major cause of the failing tests was the use
  of the value coming from pyon.yml (30) and not (as it used to be the case) from the patched value in the annotation for the test class. (This particular overall misbehavior is still to be clarified.)
- the three test that were failing here (which were also failing locally) are now passing again
- this PR also fixes some regressions caused by changes in the base class for tests when functionality for OOIION-1077 was added
- other minor adjustments including logging and conveniences for development

I've done reasonably extensive testing. Please **merge as soon as possible to see how it goes on builbot** before I go on vacation ;).
