### PR TITLE
skip platform tests involving launch of port agents and/or the RSN OMS s...

### DIFF
--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -55,9 +55,12 @@ from gevent import sleep
 from gevent.event import AsyncResult
 from mock import patch
 from pyon.public import CFG
+import unittest
+import os
 
 
 @patch.dict(CFG, {'endpoint': {'receive': {'timeout': 180}}})
+@unittest.skipIf((not os.getenv('PYCC_MODE', False)) and os.getenv('CEI_LAUNCH_TEST', False), 'Skip until tests support launch port agent configurations.')
 class TestPlatformAgent(BaseIntTestPlatform):
 
     def _create_network_and_start_root_platform(self, clean_up=None):

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -40,9 +40,12 @@ from pyon.agent.agent import ResourceAgentState
 from unittest import skip
 from mock import patch
 from pyon.public import log, CFG
+import unittest
+import os
 
 
 @patch.dict(CFG, {'endpoint': {'receive': {'timeout': 180}}})
+@unittest.skipIf((not os.getenv('PYCC_MODE', False)) and os.getenv('CEI_LAUNCH_TEST', False), 'Skip until tests support launch port agent configurations.')
 class TestPlatformLaunch(BaseIntTestPlatform):
 
     def _run_startup_commands(self):

--- a/ion/services/sa/observatory/test/test_platform_status.py
+++ b/ion/services/sa/observatory/test/test_platform_status.py
@@ -43,9 +43,12 @@ from gevent import sleep
 
 from mock import patch
 from pyon.public import CFG
+import unittest
+import os
 
 
 @patch.dict(CFG, {'endpoint': {'receive': {'timeout': 180}}})
+@unittest.skipIf((not os.getenv('PYCC_MODE', False)) and os.getenv('CEI_LAUNCH_TEST', False), 'Skip until tests support launch port agent configurations.')
 class Test(BaseIntTestPlatform):
 
     def setUp(self):


### PR DESCRIPTION
...imulator using given condition: (not os.getenv('PYCC_MODE', False)) and os.getenv('CEI_LAUNCH_TEST', False).
