### PR TITLE
Adds function for repairing temporal geometry

### DIFF
--- a/ion/util/direct_coverage_utils.py
+++ b/ion/util/direct_coverage_utils.py
@@ -254,6 +254,10 @@ class DirectCoverageAccess(object):
         self.pause_ingestion(self.get_stream_id(dataset_id))
         DatasetManagementService._splice_coverage(dataset_id, gap_cov)
 
+    def repair_temporal_geometry(self, dataset_id):
+        with self.get_editable_coverage(dataset_id) as cov:
+            cov.repair_temporal_geometry()
+
 
 class SimpleDelimitedParser(object):
 


### PR DESCRIPTION
Exposes AbstractCoverage.repair_temporal_geometry via DirectCoverageAccess - allows an operator to \'repair\' the temporal geometry of a coverage by removing duplicates and reordering out-of-order timesteps

Adds test_repair_temporal_geometry to TestDirectCoverageAccess

Bumps coverage-model submodule
