### PR TITLE
Fixes to buildbot, caused when suspending persistence of deleted data product

### DIFF
--- a/ion/util/enhanced_resource_registry_client.py
+++ b/ion/util/enhanced_resource_registry_client.py
@@ -89,6 +89,8 @@ class EnhancedResourceRegistryClient(object):
         #raise BadRequest(str(mults))
         #
 
+        self._cached_dynamics = {}
+
         self._cached_predicates = {}
         self._cached_resources  = {}
 
@@ -100,6 +102,10 @@ class EnhancedResourceRegistryClient(object):
         """
         anything we can't puzzle out gets passed along to the real RR client
         """
+
+        # don't waste time looking up function names twice
+        if item in self._cached_dynamics:
+            return self._cached_dynamics[item]
 
         dynamic_fns = [
             self._make_dynamic_assign_function,   # understand assign_x_x_to_y_y_with_some_predicate(o, s) functions
@@ -123,6 +129,7 @@ class EnhancedResourceRegistryClient(object):
                 log.trace("dynamic function match fail")
             else:
                 log.trace("dynamic function match for %s", item)
+                self._cached_dynamics[item] = fn
                 return fn
 
         log.trace("Getting %s attribute from self.RR", item)
@@ -132,6 +139,7 @@ class EnhancedResourceRegistryClient(object):
         ret = getattr(self.RR, item)
         log.trace("Got attribute from self.RR: %s", type(ret).__name__)
 
+        self._cached_dynamics[item] = ret
         return ret
 
 


### PR DESCRIPTION
The fix maxes suspend_data_product_persistence idempotent across the delete operation, causing it to log an error if the data product has been retired.

This PR includes some logging updates to the enhanced RR client.

All SMOKE, ion/services/sa/product/ and ion/util/test/test_enhanced_resource_registry_client.py tests pass.
