### PR TITLE
Bumps coverage-model ref; unskips cov_dr test

### DIFF
--- a/ion/util/test/test_direct_coverage_utils.py
+++ b/ion/util/test/test_direct_coverage_utils.py
@@ -258,7 +258,6 @@ class TestDirectCoverageAccess(DMTestCase):
                     np.testing.assert_equal(cov.get_parameter_values(p, slice(None, 10)), want_vals[p])
 
     @attr('LOCOINT')
-    @unittest.skip('Breaking coi_nightly - skipping until solved')
     @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Host requires file-system access to coverage files, CEI mode does not support.')
     @unittest.skipIf(not_have_h5stat, 'h5stat is not accessible in current PATH')
     @unittest.skipIf(not not_have_h5stat and not h5stat_correct_version, 'HDF is the incorrect version: %s' % version_str)


### PR DESCRIPTION
Bumps the coverage-model submodule reference to obtain coverage doctor tweaks

Removes skip for test_run_coverage_doctor
