### PR TITLE
Re-orders QC Filter and some work on OOI preload ver

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -1898,31 +1898,36 @@ Reason: %s
                     else:
                         context.lookup_value = name
                         context.document_key = lookup_value
+            
+            qc_map = {
+                    'Global Range Test (GLBLRNG) QC'                         : 'glblrng_qc',
+                    'Stuck Value Test (STUCKVL) QC'                          : 'stuckvl_qc',
+                    'Spike Test (SPKETST) QC'                                : 'spketst_qc',
+                    'Trend Test (TRNDTST) QC'                                : 'trndtst_qc',
+                    'Gradient Test (GRADTST) QC'                             : 'gradtst_qc',
+                    'Local Range Test (LOCLRNG) QC'                          : 'loclrng_qc',
+                    'Modulus (MODULUS) QC'                                   : 'modulus_qc',
+                    'Evaluate Polynomial (POLYVAL) QC'                       : 'polyval_qc',
+                    'Solar Elevation (SOLAREL) QC'                           : 'solarel_qc',
+                    'Conductivity Compressibility Compensation (CONDCMP) QC' : 'condcmp_qc',
+                    '1-D Interpolation (INTERP1) QC'                         : 'interp1_qc',
+                    'Combine QC Flags (CMBNFLG) QC'                          : 'cmbnflg_qc',
+                    }
+            
+            qc_fields = None
+            if self.ooi_loader._extracted:
+                # Yes, OOI Assets were parsed
+                dps = self.ooi_loader.get_type_assets('data_product')
+                if context.ooi_short_name in dps:
+                    dp = dps[context.ooi_short_name]
+                    qc_fields = [v for k,v in qc_map.iteritems() if dp[k] == 'applicable']
+                    if qc_fields and not qc: # If the column wasn't filled out but SAF says it should be there, just use the OOI Short Name
+                        log.warning("Enabling QC for %s (%s) based on SAF requirement but QC-identifier wasn't specified.", name, row[COL_ID])
+                        qc = sname
+                    
+
 
             if qc:
-                qc_map = {
-                        'Global Range Test (GLBLRNG) QC'                         : 'glblrng_qc',
-                        'Stuck Value Test (STUCKVL) QC'                          : 'stuckvl_qc',
-                        'Spike Test (SPKETST) QC'                                : 'spketst_qc',
-                        'Trend Test (TRNDTST) QC'                                : 'trndtst_qc',
-                        'Gradient Test (GRADTST) QC'                             : 'gradtst_qc',
-                        'Local Range Test (LOCLRNG) QC'                          : 'loclrng_qc',
-                        'Modulus (MODULUS) QC'                                   : 'modulus_qc',
-                        'Evaluate Polynomial (POLYVAL) QC'                       : 'polyval_qc',
-                        'Solar Elevation (SOLAREL) QC'                           : 'solarel_qc',
-                        'Conductivity Compressibility Compensation (CONDCMP) QC' : 'condcmp_qc',
-                        '1-D Interpolation (INTERP1) QC'                         : 'interp1_qc',
-                        'Combine QC Flags (CMBNFLG) QC'                          : 'cmbnflg_qc',
-                        }
-
-
-                qc_fields = None
-                if self.ooi_loader._extracted:
-                    # Yes, OOI Assets were parsed
-                    dps = self.ooi_loader.get_type_assets('data_product')
-                    if context.ooi_short_name in dps:
-                        dp = dps[context.ooi_short_name]
-                        qc_fields = [v for k,v in qc_map.iteritems() if dp[k] == 'applicable']
                 try:
                     if isinstance(context.param_type, (QuantityType, ParameterFunctionType)):
                         context.qc_contexts = tm.make_qc_functions(name,qc,self._register_id, qc_fields)

--- a/ion/services/sa/observatory/test/test_observatory_full_integration.py
+++ b/ion/services/sa/observatory/test/test_observatory_full_integration.py
@@ -225,7 +225,18 @@ class TestObservatoryManagementFullIntegration(IonIntegrationTestCase):
         sdef_list, _ = self.RR.find_resources_ext(restype=RT.StreamDefinition)
         passing &= self.assertTrue(len(sdef_list) >= 10)
 
-        # TODO: More tests?
+        # Verify that a PDict has the appropriate QC parameters defined
+        pdicts, _ = self.RR.find_resources_ext(restype=RT.ParameterDictionary, alt_id_ns='PRE', alt_id='DICT110')
+        passing &= self.assertTrue(len(pdicts)==1)
+        if not pdicts:
+            return passing
+        pdict = pdicts[0]
+
+        # According to the latest SAF, density should NOT have trend
+
+        parameters, _ = self.RR.find_objects(pdict, PRED.hasParameterContext)
+        names = [i.name for i in parameters if i.name.startswith('density')]
+        passing &= self.assertTrue('density_trndtst_qc' not in names)
 
         return passing
 
@@ -282,7 +293,6 @@ class TestObservatoryManagementFullIntegration(IonIntegrationTestCase):
             log.debug('deployment: %s', deploy.name)
             passing &= self.assertEquals(deploy.lcstate, LCS.DEPLOYED)
         return passing
-
 
     def rsn_node_checks(self):
         """
@@ -453,6 +463,9 @@ class TestObservatoryManagementFullIntegration(IonIntegrationTestCase):
 
     def check_rsn_instrument_data_product(self):
         passing = True
+        # for RS03AXBS-MJ03A-06-PRESTA301 (PREST-A) there are two listed data products
+        # SFLPRES-0 SFLPRES-1
+        # Check for the two data products and make sure they have the proper parameters
         return passing
 
     def check_glider(self):


### PR DESCRIPTION
This allows the SAF reference to override whether or not we've filled out the QC Functions column and it makes a best-guess (OOI Short Name) for the lookup table data product key.
