### PR TITLE
Skips launching the qc post processor if test

### DIFF
--- a/ion/processes/bootstrap/plugins/bootstrap_qc_post_processor.py
+++ b/ion/processes/bootstrap/plugins/bootstrap_qc_post_processor.py
@@ -12,7 +12,9 @@ from ion.core.bootstrap_process import BootstrapPlugin
 from pyon.util.containers import DotDict
 from interface.objects import ProcessDefinition
 from uuid import uuid4
+from pyon.core.bootstrap import testing, get_sys_name
 import time
+import os
 
 class BootstrapQCPostProcessor(BootstrapPlugin):
     '''
@@ -21,6 +23,9 @@ class BootstrapQCPostProcessor(BootstrapPlugin):
     '''
 
     def on_initial_bootstrap(self, process, config, **kwargs):
+        if 'test' in get_sys_name():
+            # If this is a launch designed for tests, don't launch the QC Post Processor
+            return
         if self.process_exists(process, 'qc_post_processor'):
             # Short circuit the bootstrap to make sure not more than one is ever started
             return


### PR DESCRIPTION
This is a naive solution that skips the qc post processor
creation if the string 'test' is in the system name.
