### PR TITLE
Email formatting improvements

### DIFF
--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -6,7 +6,6 @@ __author__ = 'Bill Bollenbacher, Swarbhanu Chatterjee, David Stuebe'
 
 import pprint
 import string
-from email.mime.text import MIMEText
 from datetime import datetime
 
 from pyon.core.exception import BadRequest, IonException, NotFound, Inconsistent
@@ -18,7 +17,7 @@ from pyon.event.event import EventPublisher, EventSubscriber
 from pyon.core.governance import ORG_MEMBER_ROLE, GovernanceHeaderValues, has_org_role
 
 from ion.services.dm.utility.uns_utility_methods import setting_up_smtp_client, convert_events_to_email_message
-from ion.services.dm.utility.uns_utility_methods import calculate_reverse_user_info, _convert_timestamp_to_human_readable
+from ion.services.dm.utility.uns_utility_methods import calculate_reverse_user_info
 
 from interface.services.dm.idiscovery_service import DiscoveryServiceClient
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -3,16 +3,19 @@
 @file ion/services/dm/utility/uns_utility_methods.py
 @description A module containing common utility methods used by UNS and the notification workers.
 """
-from pyon.public import get_sys_name, CFG
+from pyon.public import get_sys_name, OT, IonObject, CFG
 from pyon.util.ion_time import IonTime
 from pyon.util.log import log
 from pyon.core.exception import BadRequest, NotFound
-from interface.objects import NotificationRequest, Event
+from interface.objects import NotificationRequest, Event, DeviceStatusType
+from pyon.util.containers import get_ion_ts
 import smtplib
 import gevent
+import pprint
 import string
 from email.mime.text import MIMEText
 from gevent import Greenlet
+
 
 
 class fake_smtplib(object):
@@ -72,9 +75,9 @@ def setting_up_smtp_client():
     return smtp_client
 
 
-def _convert_timestamp_to_human_readable(t = ''):
+def convert_timestamp_to_human_readable(timestamp=''):
 
-    it = IonTime(int(t)/1000.)
+    it = IonTime(int(timestamp)/1000.)
     return str(it)
 
 
@@ -96,7 +99,7 @@ def convert_events_to_email_message(events=None, rr_client=None):
     resource_human_readable = "<uninitialized string>"
     for idx, event in enumerate(events, 1):
 
-        ts_created = _convert_timestamp_to_human_readable(event.ts_created)
+        ts_created = convert_timestamp_to_human_readable(event.ts_created)
 
         # build human readable resource string
         resource_human_readable = "'%s' with ID='%s' (not found)" % (event.origin_type, event.origin)
@@ -118,7 +121,7 @@ def convert_events_to_email_message(events=None, rr_client=None):
                                  "",
                                  "Date & Time: %s" %  ts_created,
                                  "",
-                                 "Description: %s" % event.description or "Not provided",
+                                 "Description: %s" % get_event_summary(event) or event.description or "Not provided",
 #                                 "",
 #                                 "Event object as a dictionary: %s," %  str(event),
                                  "\r\n",
@@ -360,3 +363,86 @@ def calculate_reverse_user_info(user_info=None):
 
     return reverse_user_info
 
+def get_event_computed_attributes(event):
+    """
+    @param event any Event to compute attributes for
+    @retval an EventComputedAttributes object for given event
+    """
+    evt_computed = IonObject(OT.EventComputedAttributes)
+    evt_computed.event_id = event._id
+    evt_computed.ts_computed = get_ion_ts()
+
+    try:
+        summary = get_event_summary(event)
+        evt_computed.event_summary = summary
+
+        spc_attrs = ["%s:%s" % (k, str(getattr(event, k))[:50]) for k in sorted(event.__dict__.keys()) if k not in ['_id', '_rev', 'type_', 'origin', 'origin_type', 'ts_created', 'base_types']]
+        evt_computed.special_attributes = ", ".join(spc_attrs)
+
+        evt_computed.event_attributes_formatted = pprint.pformat(event.__dict__)
+    except Exception as ex:
+        log.exception("Error computing EventComputedAttributes for event %s: %s", event, ex)
+
+    return evt_computed
+
+def get_event_summary(event):
+    event_types = [event.type_] + event.base_types
+    summary = ""
+    if "ResourceLifecycleEvent" in event_types:
+        summary = "%s lifecycle state change: %s_%s" % (event.origin_type, event.lcstate, event.availability)
+    elif "ResourceModifiedEvent" in event_types:
+        summary = "%s modified: %s" % (event.origin_type, event.sub_type)
+    elif "ResourceIssueReportedEvent" in event_types:
+        summary = "Issue created: %s" % event.description
+
+    elif "ResourceAgentStateEvent" in event_types:
+        summary = "%s agent state change: %s" % (event.origin_type, event.state)
+    elif "ResourceAgentResourceStateEvent" in event_types:
+        summary = "%s agent resource state change: %s" % (event.origin_type, event.state)
+    elif "ResourceAgentConfigEvent" in event_types:
+        summary = "%s agent config set: %s" % (event.origin_type, event.config)
+    elif "ResourceAgentResourceConfigEvent" in event_types:
+        summary = "%s agent resource config set: %s" % (event.origin_type, event.config)
+    elif "ResourceAgentCommandEvent" in event_types:
+        summary = "%s agent command '%s(%s)' succeeded: %s" % (event.origin_type, event.command, event.execute_command, "" if event.result is None else event.result)
+    elif "ResourceAgentErrorEvent" in event_types:
+        summary = "%s agent command '%s(%s)' failed: %s:%s (%s)" % (event.origin_type, event.command, event.execute_command, event.error_type, event.error_msg, event.error_code)
+    elif "ResourceAgentAsyncResultEvent" in event_types:
+        summary = "%s agent async command '%s(%s)' succeeded: %s" % (event.origin_type, event.command, event.desc, "" if event.result is None else event.result)
+    elif "ResourceAgentConnectionLostErrorEvent" in event_types:
+        summary = "%s agent: %s (%s)" % (event.origin_type, event.error_msg, event.error_code)
+    elif "ResourceAgentEvent" in event_types:
+        summary = "%s agent: %s" % (event.origin_type, event.type_)
+
+    elif "ResourceAgentResourceCommandEvent" in event_types:
+        summary = "%s agent resource command '%s(%s)' executed: %s" % (event.origin_type, event.command, event.execute_command, "OK" if event.result is None else event.result)
+    elif "DeviceStatusEvent" in event_types:
+        summary = "%s '%s' status change: %s" % (event.origin_type, event.sub_type, DeviceStatusType._str_map.get(event.status,"???"))
+    elif "DeviceOperatorEvent" in event_types or "ResourceOperatorEvent" in event_types:
+        summary = "Operator entered: %s" % event.description
+
+    elif "OrgMembershipGrantedEvent" in event_types:
+        summary = "Joined Org '%s' as member" % event.org_name
+    elif "OrgMembershipCancelledEvent" in event_types:
+        summary = "Cancelled Org '%s' membership" % event.org_name
+    elif "UserRoleGrantedEvent" in event_types:
+        summary = "Granted %s in Org '%s'" % (event.role_name, event.org_name)
+    elif "UserRoleRevokedEvent" in event_types:
+        summary = "Revoked %s in Org '%s'" % (event.role_name, event.org_name)
+    elif "ResourceSharedEvent" in event_types:
+        summary = "%s shared in Org: '%s'" % (event.sub_type, event.org_name)
+    elif "ResourceUnsharedEvent" in event_types:
+        summary = "%s unshared in Org: '%s'" % (event.sub_type, event.org_name)
+    elif "ResourceCommitmentCreatedEvent" in event_types:
+        summary = "%s commitment created in Org: '%s'" % (event.commitment_type, event.org_name)
+    elif "ResourceCommitmentReleasedEvent" in event_types:
+        summary = "%s commitment released in Org: '%s'" % (event.commitment_type, event.org_name)
+    elif "ParameterQCEvent" in event_types:
+        summary = "%s" % event.description
+
+
+    #        if event.description and summary:
+    #            summary = summary + ". " + event.description
+    #        elif event.description:
+    #            summary = event.description
+    return summary

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -84,6 +84,8 @@ def convert_events_to_email_message(events=None, rr_client=None):
 
     if 0 == len(events): raise BadRequest("Tried to convert events to email, but none were supplied")
 
+    ION_WEBSITE_URL = "http://example.url.com"
+
     msg_body = ""
 
     resource_human_readable = "<uninitialized string>"
@@ -99,34 +101,39 @@ def convert_events_to_email_message(events=None, rr_client=None):
         except NotFound:
             pass
 
+        if 1 == len(events):
+            eventtitle = "Type"
+        else:
+            eventtitle = "%s Type" % idx
+
         msg_body += string.join(("\r\n",
-                                 "Event %s: %s" %  (idx, event.type_),
+                                 "Event %s: %s" %  (eventtitle, event.type_),
                                  "",
                                  "Resource: %s" %  resource_human_readable,
                                  "",
-#                                 # originator is the same as the resource
-#                                 "Originator: %s" %  event.origin,
-#                                 "",
+                                 "Date & Time: %s" %  ts_created,
+                                 "",
                                  "Description: %s" % event.description or "Not provided",
-                                 "",
-                                 "ts_created: %s" %  ts_created,
-                                 "",
-                                 "Event object as a dictionary: %s," %  str(event),
+#                                 "",
+#                                 "Event object as a dictionary: %s," %  str(event),
                                  "\r\n",
-                                 "------------------------"
-                                 "\r\n"))
+                                 "------------------------",
+                                 "\r\n",
+                                 ),         # necessary!
+                                 "\r\n")
 
-    msg_body += "You received this notification from ION because you asked to be " +\
-                "notified about this event from this source. " +\
-                "To modify or remove notifications about this event, " +\
-                "please access My Notifications Settings in the ION Web UI. " +\
-                "Do not reply to this email.  This email address is not monitored " +\
-                "and the emails will not be read. \r\n "
+
+    msg_body += ("\r\n\r\nAutomated alert from the OOI ION system (%s). " % get_sys_name()) +\
+                "This notification was received based on " +\
+                "your current subscription settings for this event type from this resource. To unsubscribe " +\
+                "from notifications of this event type, please access the actions menu for the resource " +\
+                ("listed above in the ION interface, %s.  \r\n\r\n" % ION_WEBSITE_URL) +\
+                "Do not reply to this email.  This email address is not monitored and the emails will not be read.\r\n"
 
 
     log.debug("The email has the following message body: %s", msg_body)
 
-    msg_subject = "(SysName: " + get_sys_name() + ") "
+    msg_subject = ""
     if 1 == len(events):
         msg_subject += "ION event " + events[0].type_ + " from " + resource_human_readable
     else:

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -84,7 +84,12 @@ def convert_events_to_email_message(events=None, rr_client=None):
 
     if 0 == len(events): raise BadRequest("Tried to convert events to email, but none were supplied")
 
-    ION_WEBSITE_URL = "http://example.url.com"
+    web_ui_url = CFG.get_safe('system.web_ui_url', None)
+    log.debug("found CFG.system.web_ui_url = %s" % web_ui_url)
+    if web_ui_url is None:
+        web_ui_txt = ""
+    else:
+        web_uri_txt = ": %s" % web_ui_url
 
     msg_body = ""
 
@@ -127,7 +132,7 @@ def convert_events_to_email_message(events=None, rr_client=None):
                 "This notification was received based on " +\
                 "your current subscription settings for this event type from this resource. To unsubscribe " +\
                 "from notifications of this event type, please access the actions menu for the resource " +\
-                ("listed above in the ION interface, %s.  \r\n\r\n" % ION_WEBSITE_URL) +\
+                ("listed above in the ION interface%s.  \r\n\r\n" % web_uri_txt) +\
                 "Do not reply to this email.  This email address is not monitored and the emails will not be read.\r\n"
 
 

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -89,7 +89,7 @@ def convert_events_to_email_message(events=None, rr_client=None):
     if web_ui_url is None:
         web_ui_txt = ""
     else:
-        web_uri_txt = ": %s" % web_ui_url
+        web_ui_txt = ": %s" % web_ui_url
 
     msg_body = ""
 
@@ -132,7 +132,7 @@ def convert_events_to_email_message(events=None, rr_client=None):
                 "This notification was received based on " +\
                 "your current subscription settings for this event type from this resource. To unsubscribe " +\
                 "from notifications of this event type, please access the actions menu for the resource " +\
-                ("listed above in the ION interface%s.  \r\n\r\n" % web_uri_txt) +\
+                ("listed above in the ION interface%s.  \r\n\r\n" % web_ui_txt) +\
                 "Do not reply to this email.  This email address is not monitored and the emails will not be read.\r\n"
 
 

--- a/scripts/get-latest-code.sh
+++ b/scripts/get-latest-code.sh
@@ -56,7 +56,7 @@ ant clean
 sh scripts/cc-cleanup.sh
 
 echo -e "\n\n=== BOOTSTRAPPING ===\n"
-python bootstrap.py -v 1.7
+python bootstrap.py -v 2.2.0
 
 echo -e "\n\n=== BUILDING OUT ===\n"
 bin/buildout -c gcoverage*


### PR DESCRIPTION
## Ready to merge

Fixes in this commit:
- Removed sysname from subject line (added to end of message body in case it's needed)
- Conditional formatting of "Event Type:" or "Event 1 Type" depending if there are multiple events in an email
- "ts_created" is now "Date & Time"
- Removed "full dictionary" listing
- Changed unsubscribe information as per Lynn's suggestion
- URL for "unsubscribe" is now set in `CFG.system.web_ui_url` and is sensibly formatted if that entry is not supplied
- Human-readable description (using existing event formatting function)
