### PR TITLE
All egg URIs now point to a master list

### DIFF
--- a/ion/agents/instrument/test/test_instrument_agent.py
+++ b/ion/agents/instrument/test/test_instrument_agent.py
@@ -136,6 +136,12 @@ DRV_SHA = DRV_SHA_0_1_5
 DRV_MOD = 'mi.instrument.seabird.sbe37smb.ooicore.driver'
 DRV_CLS = 'SBE37Driver'
 
+# these defintions will be referenced by other tests
+#  404: bad URI; BAD: driver will launch but commands will fail; GOOD: launch and commanding will succeed
+DRV_URI_GOOD = DRV_URI
+DRV_URI_BAD  = "http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.1a-py2.7.egg"
+DRV_URI_404  = "http://sddevrepo.oceanobservatories.org/releases/completely_made_up_404.egg"
+
 # Driver config.
 # DVR_CONFIG['comms_config']['port'] is set by the setup.
 DVR_CONFIG = {

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -1,19 +1,17 @@
 from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcherServiceClient
 from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
-from interface.services.icontainer_agent import ContainerAgentClient
 
 #from pyon.ion.endpoint import ProcessRPCClient
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 from ion.agents.port.port_agent_process import PortAgentProcessType, PortAgentType
 from ion.services.cei.process_dispatcher_service import ProcessStateGate
 from ion.services.sa.instrument.agent_configuration_builder import PlatformAgentConfigurationBuilder, InstrumentAgentConfigurationBuilder
 from ion.util.enhanced_resource_registry_client import EnhancedResourceRegistryClient
-from pyon.core.exception import BadRequest
 
 from pyon.datastore.datastore import DataStore
-from pyon.public import Container, IonObject
+from pyon.public import IonObject
 from pyon.util.containers import DotDict
 from pyon.util.int_test import IonIntegrationTestCase
-from ion.util.parameter_yaml_IO import get_param_dict
 from ion.services.dm.utility.granule_utils import time_series_domain
 
 
@@ -24,13 +22,13 @@ from interface.services.dm.ipubsub_management_service import PubsubManagementSer
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.sa.iobservatory_management_service import ObservatoryManagementServiceClient
-from interface.objects import ComputedValueAvailability, ProcessDefinition, ProcessStateEnum, StreamConfiguration
+from interface.objects import ComputedValueAvailability, ProcessStateEnum, StreamConfiguration
 from interface.objects import ComputedIntValue, ComputedFloatValue, ComputedStringValue
 
 from pyon.public import RT, PRED, CFG, OT, LCE
 from nose.plugins.attrib import attr
 from ooi.logging import log
-import unittest, simplejson
+import unittest
 
 
 from ion.services.sa.test.helpers import any_old
@@ -47,6 +45,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         #print 'starting container'
         #container.start()
         #print 'started container'
+        unittest # suppress an pycharm inspector error if all unittest.skip references are commented out
 
         self.container.start_rel_from_url('res/deploy/r2deploy.yml')
         self.RR   = ResourceRegistryServiceClient(node=self.container.node)
@@ -328,7 +327,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         instAgent_obj = IonObject(RT.InstrumentAgent,
                                   name='agent007',
                                   description="SBE37IMAgent",
-                                  driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg",
+                                  driver_uri=DRV_URI_GOOD,
                                   stream_configurations = [raw_config, parsed_config] )
         instAgent_id = self.IMS.create_instrument_agent(instAgent_obj)
         log.debug( 'new InstrumentAgent id = %s', instAgent_id)

--- a/ion/services/sa/observatory/test/test_platform_instrument.py
+++ b/ion/services/sa/observatory/test/test_platform_instrument.py
@@ -43,16 +43,16 @@ from pyon.public import CFG
 
 import sys
 from ion.agents.instrument.driver_process import ZMQEggDriverProcess
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 
 # A seabird driver.
-DRV_URI = 'http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.1.0-py2.7.egg'
 DRV_MOD = 'mi.instrument.seabird.sbe37smb.ooicore.driver'
 DRV_CLS = 'SBE37Driver'
 
 WORK_DIR = '/tmp/'
 
 DVR_CONFIG = {
-    'dvr_egg' : DRV_URI,
+    'dvr_egg' : DRV_URI_GOOD,
     'dvr_mod' : DRV_MOD,
     'dvr_cls' : DRV_CLS,
     'workdir' : WORK_DIR,
@@ -61,7 +61,7 @@ DVR_CONFIG = {
 
 # Dynamically load the egg into the test path
 launcher = ZMQEggDriverProcess(DVR_CONFIG)
-egg = launcher._get_egg(DRV_URI)
+egg = launcher._get_egg(DRV_URI_GOOD)
 if not egg in sys.path:
     sys.path.insert(0, egg)
 

--- a/ion/services/sa/process/test/test_data_process_with_lookup_tables.py
+++ b/ion/services/sa/process/test/test_data_process_with_lookup_tables.py
@@ -23,7 +23,7 @@ from pyon.public import RT, PRED
 from pyon.util.context import LocalContextMixin
 from pyon.util.int_test import IonIntegrationTestCase
 from ion.services.dm.utility.granule_utils import time_series_domain
-
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 
 import base64
 
@@ -73,7 +73,7 @@ class TestDataProcessWithLookupTable(IonIntegrationTestCase):
         #-------------------------------
         # Create InstrumentAgent
         #-------------------------------
-        instAgent_obj = IonObject(RT.InstrumentAgent, name='agent007', description="SBE37IMAgent", driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
+        instAgent_obj = IonObject(RT.InstrumentAgent, name='agent007', description="SBE37IMAgent", driver_uri=DRV_URI_GOOD)
         try:
             instAgent_id = self.imsclient.create_instrument_agent(instAgent_obj)
         except BadRequest as ex:

--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-'''
+"""
 @file ion/services/sa/process/test/test_int_data_process_management_service.py
 @author Maurice Manning
 @test ion.services.sa.process.DataProcessManagementService integration test
-'''
+"""
 
 import time
 import numpy as np
@@ -51,7 +51,7 @@ from interface.services.dm.idataset_management_service import DatasetManagementS
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 from interface.services.dm.iuser_notification_service import UserNotificationServiceClient
 from interface.services.dm.idata_retriever_service import DataRetrieverServiceClient
-
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 
 class FakeProcess(LocalContextMixin):
     """
@@ -251,7 +251,7 @@ class TestIntDataProcessManagementServiceMultiOut(IonIntegrationTestCase):
         #-------------------------------
         # Create InstrumentAgent
         #-------------------------------
-        instAgent_obj = IonObject(RT.InstrumentAgent, name='agent007', description="SBE37IMAgent", driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
+        instAgent_obj = IonObject(RT.InstrumentAgent, name='agent007', description="SBE37IMAgent", driver_uri=DRV_URI_GOOD)
         instAgent_id = self.imsclient.create_instrument_agent(instAgent_obj)
 
         self.imsclient.assign_instrument_model_to_instrument_agent(instModel_id, instAgent_id)
@@ -733,7 +733,8 @@ class TestDataProcessManagementPrime(IonIntegrationTestCase):
         rdt = RecordDictionaryTool.load_from_granule(granule)
         return verifier(rdt)
 
-    def make_data_product(self, pdict_name, dp_name, available_fields=[]):
+    def make_data_product(self, pdict_name, dp_name, available_fields=None):
+        if available_fields is None: available_fields = []
         pdict_id = self.dataset_management.read_parameter_dictionary_by_name(pdict_name, id_only=True)
         stream_def_id = self.pubsub_management.create_stream_definition('%s stream_def' % dp_name, parameter_dictionary_id=pdict_id, available_fields=available_fields or None)
         self.addCleanup(self.pubsub_management.delete_stream_definition, stream_def_id)
@@ -930,7 +931,8 @@ class TestDataProcessManagementPrime(IonIntegrationTestCase):
                 self.fail("Active subscription found. Deactivate did not succeed")
 
 
-    def attach_qc_document(self, data_product_id, document_keys=[]):
+    def attach_qc_document(self, data_product_id, document_keys=None):
+        if document_keys is None: document_keys = []
         producers, _ = self.resource_registry.find_objects(data_product_id, PRED.hasDataProducer, id_only=False)
         if producers:
             producer = producers[0]

--- a/ion/services/sa/product/test/test_data_product_provenance.py
+++ b/ion/services/sa/product/test/test_data_product_provenance.py
@@ -25,6 +25,7 @@ from nose.plugins.attrib import attr
 
 from interface.objects import StreamConfiguration
 from ion.agents.port.port_agent_process import PortAgentProcessType, PortAgentType
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 from ion.services.dm.utility.granule_utils import time_series_domain
 import base64
 import unittest
@@ -177,7 +178,7 @@ class TestDataProductProvenance(IonIntegrationTestCase):
         instAgent_obj = IonObject(RT.InstrumentAgent,
                                 name='agent007',
                                 description="SBE37IMAgent",
-                                driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg",
+                                driver_uri=DRV_URI_GOOD,
                                 stream_configurations = [parsed_config] )
         try:
             instAgent_id = self.imsclient.create_instrument_agent(instAgent_obj)

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -18,6 +18,7 @@ from interface.services.dm.iuser_notification_service import UserNotificationSer
 
 # This import will dynamically load the driver egg.  It is needed for the MI includes below
 import ion.agents.instrument.test.test_instrument_agent
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37ProtocolEvent
 
 from ion.services.dm.utility.granule_utils import time_series_domain
@@ -266,7 +267,7 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
         instAgent_obj = IonObject(RT.InstrumentAgent,
                                   name='agent007',
                                   description="SBE37IMAgent",
-                                  driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1a-py2.7.egg",
+                                  driver_uri=DRV_URI_GOOD,
                                   stream_configurations = [raw_config, parsed_config])
         instAgent_id = self.imsclient.create_instrument_agent(instAgent_obj)
         log.debug('new InstrumentAgent id = %s', instAgent_id)

--- a/ion/services/sa/test/test_assembly.py
+++ b/ion/services/sa/test/test_assembly.py
@@ -29,7 +29,7 @@ from ion.services.sa.instrument.flag import KeywordFlag
 from ion.services.dm.utility.granule_utils import time_series_domain
 
 from ion.agents.port.port_agent_process import PortAgentType
-
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
 
 import string
@@ -198,7 +198,7 @@ class TestAssembly(GenericIntHelperTestCase):
         instAgent_obj = IonObject(RT.InstrumentAgent,
                                   name='agent007',
                                   description="SBE37IMAgent",
-                                  driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
+                                  driver_uri=DRV_URI_GOOD)
         instrument_agent_id = self.perform_fcruf_script(RT.InstrumentAgent,
                                                         "instrument_agent", 
                                                         self.client.IMS,

--- a/ion/services/sa/test/test_ctd_transforms_L0_L1_L2.py
+++ b/ion/services/sa/test/test_ctd_transforms_L0_L1_L2.py
@@ -13,6 +13,7 @@ from interface.services.cei.iprocess_dispatcher_service import ProcessDispatcher
 
 # This import will dynamically load the driver egg.  It is needed for the MI includes below
 import ion.agents.instrument.test.test_instrument_agent
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37ProtocolEvent
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37Parameter
 
@@ -151,7 +152,7 @@ class TestCTDTransformsIntegration(IonIntegrationTestCase):
         instAgent_obj = IonObject(RT.InstrumentAgent,
                                     name='agent007',
                                     description="SBE37IMAgent",
-                                    driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.4-py2.7.egg",
+                                    driver_uri=DRV_URI_GOOD,
                                     stream_configurations = [raw_config, parsed_config] )
         instAgent_id = self.imsclient.create_instrument_agent(instAgent_obj)
 

--- a/ion/services/sa/test/test_deploy_activate_full.py
+++ b/ion/services/sa/test/test_deploy_activate_full.py
@@ -24,7 +24,7 @@ from interface.objects import AgentCommand, StreamConfiguration, ProcessStateEnu
 
 from ion.services.cei.process_dispatcher_service import ProcessStateGate
 from ion.agents.port.port_agent_process import PortAgentProcessType, PortAgentType
-
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 # This import will dynamically load the driver egg.  It is needed for the MI includes below
 import ion.agents.instrument.test.test_instrument_agent
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37ProtocolEvent
@@ -145,7 +145,7 @@ class TestIMSDeployAsPrimaryDevice(IonIntegrationTestCase):
         instAgent_obj = IonObject(RT.InstrumentAgent,
             name='agent007',
             description="SBE37IMAgent",
-            driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1-py2.7.egg")
+            driver_uri=DRV_URI_GOOD)
             
         try:
             instAgent_id = self.imsclient.create_instrument_agent(instAgent_obj)

--- a/ion/services/sa/test/test_driver_egg.py
+++ b/ion/services/sa/test/test_driver_egg.py
@@ -37,6 +37,7 @@ from interface.objects import AgentCommand, ProcessDefinition, ProcessStateEnum,
 # This import will dynamically load the driver egg.  It is needed for the MI includes below
 import ion.agents.instrument.test.test_instrument_agent
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37ProtocolEvent
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD, DRV_URI_BAD, DRV_URI_404
 
 import unittest
 
@@ -82,10 +83,6 @@ class TestDriverEgg(IonIntegrationTestCase):
         self._samples_received = []
 
         self.event_publisher = EventPublisher()
-
-        self.egg_url_good = "http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.1a-py2.7.egg"
-        self.egg_url_bad  = "http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.1a-py2.7.egg"
-        self.egg_url_404  = "http://sddevrepo.oceanobservatories.org/releases/completely_made_up_404.egg"
 
 
 
@@ -135,7 +132,7 @@ class TestDriverEgg(IonIntegrationTestCase):
                                   description="SBE37IMAgent",
                                   driver_module="mi.instrument.seabird.sbe37smb.ooicore.driver",
                                   driver_class="SBE37Driver",
-                                  driver_uri=self.egg_url_good,
+                                  driver_uri=DRV_URI_GOOD,
                                   stream_configurations = [raw_config, parsed_config])
 
         self.base_activateInstrumentSample(instAgent_obj)
@@ -148,7 +145,7 @@ class TestDriverEgg(IonIntegrationTestCase):
                                   description="SBE37IMAgent",
                                   #driver_module="mi.instrument.seabird.sbe37smb.ooicore.driver",
                                   #driver_class="SBE37Driver",
-                                  driver_uri=self.egg_url_good,
+                                  driver_uri=DRV_URI_GOOD,
                                   stream_configurations = [raw_config, parsed_config])
 
         self.base_activateInstrumentSample(instAgent_obj)
@@ -161,7 +158,7 @@ class TestDriverEgg(IonIntegrationTestCase):
                                   description="SBE37IMAgent",
                                   driver_module="bogus",
                                   driver_class="Bogus",
-                                  driver_uri=self.egg_url_good,
+                                  driver_uri=DRV_URI_GOOD,
                                   stream_configurations = [raw_config, parsed_config])
 
         self.base_activateInstrumentSample(instAgent_obj)
@@ -175,20 +172,19 @@ class TestDriverEgg(IonIntegrationTestCase):
                                   description="SBE37IMAgent",
                                   #driver_module="mi.instrument.seabird.sbe37smb.ooicore.driver",
                                   #driver_class="SBE37Driver",
-                                  driver_uri=self.egg_url_404,
+                                  driver_uri=DRV_URI_404,
                                   stream_configurations = [raw_config, parsed_config])
 
         self.base_activateInstrumentSample(instAgent_obj, False)
 
     def test_driverLaunchNoModuleBadEggURI(self):
         raw_config, parsed_config = self.get_streamConfigs()
-
         instAgent_obj = IonObject(RT.InstrumentAgent,
                                   name='agent007',
                                   description="SBE37IMAgent",
                                   #driver_module="mi.instrument.seabird.sbe37smb.ooicore.driver",
                                   #driver_class="SBE37Driver",
-                                  driver_uri=self.egg_url_bad,
+                                  driver_uri=DRV_URI_BAD,
                                   stream_configurations = [raw_config, parsed_config])
 
         self.base_activateInstrumentSample(instAgent_obj, True, False)

--- a/ion/services/sa/test/test_instrument_alerts.py
+++ b/ion/services/sa/test/test_instrument_alerts.py
@@ -34,6 +34,7 @@ from ion.services.dm.utility.granule_utils import time_series_domain
 
 # This import will dynamically load the driver egg.  It is needed for the MI includes below
 import ion.agents.instrument.test.test_instrument_agent
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37ProtocolEvent
 from mi.instrument.seabird.sbe37smb.ooicore.driver import SBE37Parameter
 
@@ -130,7 +131,7 @@ class TestInstrumentAlerts(IonIntegrationTestCase):
         instAgent_obj = IonObject(RT.InstrumentAgent,
             name='agent007',
             description="SBE37IMAgent",
-            driver_uri="http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.0.4-py2.7.egg",
+            driver_uri=DRV_URI_GOOD,
             stream_configurations = [raw_config, parsed_config] )
 
         instAgent_id = self.imsclient.create_instrument_agent(instAgent_obj)


### PR DESCRIPTION
The master list of testable egg URIs is now kept in this file:
https://github.com/ooici/coi-services/blob/master/ion/agents/instrument/test/test_instrument_agent.py

All tests have been updated to replace hard-coded URIs with pointers to this file.

All test in all these files are passing.
