### PR TITLE
adjustments/fixes arising from testing with actual RSN OMS endpoint

### DIFF
--- a/ion/agents/platform/rsn/simulator/oms_simulator.py
+++ b/ion/agents/platform/rsn/simulator/oms_simulator.py
@@ -391,7 +391,7 @@ class CIOMSSimulator(CIOMSClient):
         log.debug("unregister_event_listener called: url=%r", url)
 
         if not url in self._reg_event_listeners:
-            return {url: InvalidResponse.EVENT_LISTENER_URL}
+            return {url: 0}
 
         #
         # registered, so remove it

--- a/ion/agents/platform/rsn/test/oms_simple.py
+++ b/ion/agents/platform/rsn/test/oms_simple.py
@@ -229,10 +229,11 @@ if __name__ == "__main__":  # pragma: no cover
     if reterr is None:
         full_method_name = "port.get_platform_ports"
         retval, reterr = run(full_method_name, "dummy_platform_id")
+        orig_retval = retval
         retval, reterr = verify_entry_in_dict(retval, reterr, "dummy_platform_id")
-        if retval is not INVALID_PLATFORM_ID:
+        if retval != INVALID_PLATFORM_ID:
             reterr = "expecting dict {%r: %r}. got: %r" % (
-                "dummy_platform_id", INVALID_PLATFORM_ID, retval)
+                "dummy_platform_id", INVALID_PLATFORM_ID, orig_retval)
             tried[full_method_name] = reterr
             format_err(reterr)
 
@@ -245,12 +246,17 @@ if __name__ == "__main__":  # pragma: no cover
     retval, reterr = verify_entry_in_dict(retval, reterr, port_id)
     retval, reterr = verify_entry_in_dict(retval, reterr, instrument_id)
 
+    connect_instrument_error = reterr
+
     #----------------------------------------------------------------------
     full_method_name = "instr.get_connected_instruments"
     retval, reterr = run(full_method_name, platform_id, port_id)
     retval, reterr = verify_entry_in_dict(retval, reterr, platform_id)
     retval, reterr = verify_entry_in_dict(retval, reterr, port_id)
-    retval, reterr = verify_entry_in_dict(retval, reterr, instrument_id)
+    # note, in case of error in instr.connect_instrument, don't expect the
+    # instrument_id to be reported:
+    if connect_instrument_error is None:
+        retval, reterr = verify_entry_in_dict(retval, reterr, instrument_id)
 
     #----------------------------------------------------------------------
     full_method_name = "instr.disconnect_instrument"

--- a/ion/agents/platform/rsn/test/oms_test_mixin.py
+++ b/ion/agents/platform/rsn/test/oms_test_mixin.py
@@ -397,7 +397,7 @@ class OmsTestMixin(HelperTestMixin):
     def test_bi_unregister_event_listener_not_registered_url(self):
         url = "http://_never_registered_url"
         res = self._unregister_event_listener(url)
-        self.assertEquals(InvalidResponse.EVENT_LISTENER_URL, res)
+        self.assertEquals(0, res)
 
     def test_get_checksum(self):
         platform_id = self.PLATFORM_ID


### PR DESCRIPTION
Along with adjustments made by Matthew on the RSN side, the output of the current verification programs is captured here:

https://confluence.oceanobservatories.org/pages/viewpage.action?pageId=39781061
