### PR TITLE
OOIION-1172: Stop storing agent process IDs in resources

### DIFF
--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -231,7 +231,7 @@ class InstrumentManagementService(BaseInstrumentManagementService):
         #todo
         # Start a resource agent client to talk with the instrument agent.
 #        self._ia_client = ResourceAgentClient(instrument_device_id,
-#                                              to_name=inst_agent_instance_obj.agent_process_id,
+#                                              to_name=ResourceAgentClient._get_agent_process_id(instrument_device_id),
 #                                              process=FakeProcess())
         snapshot["running_config"] = {} #agent.get_config()
 
@@ -382,7 +382,7 @@ class InstrumentManagementService(BaseInstrumentManagementService):
         process_id = launcher.launch(config, config_builder._get_process_definition()._id)
         if not process_id:
             raise ServerError("Launched instrument agent instance but no process_id")
-        config_builder.record_launch_parameters(config, process_id)
+        config_builder.record_launch_parameters(config)
 
         self.record_instrument_producer_activation(config_builder._get_device()._id, instrument_agent_instance_id)
 
@@ -549,8 +549,6 @@ class InstrumentManagementService(BaseInstrumentManagementService):
             log.debug("Success cancelling agent process")
 
 
-        #reset the process ids.
-        agent_instance_obj.agent_process_id = None
         if "pagent_pid" in agent_instance_obj.driver_config:
             agent_instance_obj.driver_config['pagent_pid'] = None
         self.RR2.update(agent_instance_obj)
@@ -948,7 +946,7 @@ class InstrumentManagementService(BaseInstrumentManagementService):
 
 
         process_id = launcher.launch(config, configuration_builder._get_process_definition()._id)
-        configuration_builder.record_launch_parameters(config, process_id)
+        configuration_builder.record_launch_parameters(config)
 
         launcher.await_launch(self._agent_launch_timeout("start_platform_agent_instance"))
 

--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from ooi.logging import log
 from ooi.timer import Timer, Accumulator
 
-from pyon.agent.agent import ResourceAgentState
+from pyon.agent.agent import ResourceAgentState, ResourceAgentClient
 from pyon.core.bootstrap import IonObject
 from pyon.core.exception import Inconsistent, BadRequest, NotFound, ServerError, Unauthorized
 from pyon.core.governance import ORG_MANAGER_ROLE, GovernanceHeaderValues, has_org_role
@@ -532,13 +532,14 @@ class InstrumentManagementService(BaseInstrumentManagementService):
                                           object=agent_instance_id,
                                           id_only=True)
 
+        agent_process_id = ResourceAgentClient._get_agent_process_id(device_id)
 
         log.debug("Canceling the execution of agent's process ID")
-        if None is agent_instance_obj.agent_process_id:
+        if None is agent_process_id:
             raise BadRequest("Agent Instance '%s' does not have an agent_process_id.  Stopped already?"
             % agent_instance_id)
         try:
-            self.clients.process_dispatcher.cancel_process(process_id=agent_instance_obj.agent_process_id)
+            self.clients.process_dispatcher.cancel_process(process_id=agent_process_id)
         except NotFound:
             log.debug("No agent process found")
             pass
@@ -546,8 +547,6 @@ class InstrumentManagementService(BaseInstrumentManagementService):
             raise e
         else:
             log.debug("Success cancelling agent process")
-
-
 
 
         #reset the process ids.

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -7,6 +7,7 @@ from ion.agents.port.port_agent_process import PortAgentProcessType, PortAgentTy
 from ion.services.cei.process_dispatcher_service import ProcessStateGate
 from ion.services.sa.instrument.agent_configuration_builder import PlatformAgentConfigurationBuilder, InstrumentAgentConfigurationBuilder
 from ion.util.enhanced_resource_registry_client import EnhancedResourceRegistryClient
+from pyon.agent.agent import ResourceAgentClient
 
 from pyon.datastore.datastore import DataStore
 from pyon.public import IonObject
@@ -436,9 +437,10 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
                         instrument_agent_instance_id=instAgentInstance_id)
 
         #wait for start
+        agent_process_id = ResourceAgentClient._get_agent_process_id(instDevice_id)
         instance_obj = self.IMS.read_instrument_agent_instance(instAgentInstance_id)
         gate = ProcessStateGate(self.PDC.read_process,
-                                instance_obj.agent_process_id,
+                                agent_process_id,
                                 ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(30), "The instrument agent instance (%s) did not spawn in 30 seconds" %
                                         instance_obj.agent_process_id)

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -447,8 +447,7 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         # take snapshot of config
         snap_id = self.IMS.save_resource_state(instDevice_id, "xyzzy snapshot")
         snap_obj = self.RR.read_attachment(snap_id, include_content=True)
-        print "Saved config:"
-        print snap_obj.content
+
 
         #modify config
         instance_obj.driver_config["comms_config"] = "BAD_DATA"
@@ -457,6 +456,12 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
         #restore config
         self.IMS.restore_resource_state(instDevice_id, snap_id)
         instance_obj = self.RR.read(instAgentInstance_id)
+
+        if "BAD_DATA" == instance_obj.driver_config["comms_config"]:
+            print "Saved config:"
+            print snap_obj.content
+            self.fail("Saved config was not properly restored")
+
         self.assertNotEqual("BAD_DATA", instance_obj.driver_config["comms_config"])
 
         

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -397,9 +397,10 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
 
         #wait for start
+        agent_process_id = ResourceAgentClient._get_agent_process_id(instDevice_id)
         inst_agent_instance_obj = self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
         gate = ProcessStateGate(self.processdispatchclient.read_process,
-                                inst_agent_instance_obj.agent_process_id,
+                                agent_process_id,
                                 ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(30), "The instrument agent instance (%s) did not spawn in 30 seconds" %
                                         inst_agent_instance_obj.agent_process_id)

--- a/ion/services/sa/test/test_driver_egg.py
+++ b/ion/services/sa/test/test_driver_egg.py
@@ -314,30 +314,31 @@ class TestDriverEgg(IonIntegrationTestCase):
                         instrument_agent_instance_id=instAgentInstance_id)
 
         #wait for start
-        instance_obj = self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
-        print "Agent process id is '%s'" % str(instance_obj.agent_process_id)
-        self.assertTrue(instance_obj.agent_process_id)
+        inst_agent_instance_obj = self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
+        agent_process_id = ResourceAgentClient._get_agent_process_id(instDevice_id)
+
+        print "Agent process id is '%s'" % str(agent_process_id)
+        self.assertTrue(agent_process_id)
         gate = ProcessStateGate(self.processdispatchclient.read_process,
-                                instance_obj.agent_process_id,
+                                agent_process_id,
                                 ProcessStateEnum.RUNNING)
 
         if not expect_launch:
             self.assertFalse(gate.await(30), "The instance (%s) of bogus instrument agent spawned in 30 seconds ?!?" %
-                                             instance_obj.agent_process_id)
+                                             agent_process_id)
             return
 
         self.assertTrue(gate.await(30), "The instrument agent instance (%s) did not spawn in 30 seconds" %
-                                        instance_obj.agent_process_id)
+                                        agent_process_id)
 
 
         print "Instrument Agent Instance successfully triggered ProcessStateGate as RUNNING"
 
-        inst_agent_instance_obj = self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
         #print  'Instrument agent instance obj: = %s' % str(inst_agent_instance_obj)
 
         # Start a resource agent client to talk with the instrument agent.
         self._ia_client = ResourceAgentClient(instDevice_id,
-                                              to_name=inst_agent_instance_obj.agent_process_id,
+                                              to_name=agent_process_id,
                                               process=FakeProcess())
 
         print "ResourceAgentClient created: %s" % str(self._ia_client)

--- a/ion/services/sa/test/test_instrument_alerts.py
+++ b/ion/services/sa/test/test_instrument_alerts.py
@@ -308,8 +308,9 @@ class TestInstrumentAlerts(IonIntegrationTestCase):
         inst_agent_instance_obj= self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
 
         # Wait for instrument agent to spawn
+        agent_process_id = ResourceAgentClient._get_agent_process_id(instDevice_id)
         gate = ProcessStateGate(self.processdispatchclient.read_process,
-            inst_agent_instance_obj.agent_process_id, ProcessStateEnum.RUNNING)
+                                agent_process_id, ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(15), "The instrument agent instance did not spawn in 15 seconds")
 
         # Start a resource agent client to talk with the instrument agent.


### PR DESCRIPTION
This patch removes dependence on the agent instance resource for keeping track of the agent process ID.  Instead, this is retrieved directly from the ResourceAgent classmethod.  

All IMS code and tests have had references to this field removed.

SMOKE tests pass as do the following affected tests:
- ion.services.sa.instrument.test.test_instrument_management_service_integration:TestInstrumentManagementServiceIntegration.test_resource_state_save_restore 
- ion.services.sa.test.test_activate_instrument:TestActivateInstrumentIntegration.test_activateInstrumentSample 
- ion.services.sa.test.test_driver_egg:TestDriverEgg.test_driverLaunchBogusModuleWithURI 
- ion.services.sa.test.test_driver_egg:TestDriverEgg.test_driverLaunchModuleWithURI 
- ion.services.sa.test.test_driver_egg:TestDriverEgg.test_driverLaunchNoModuleBadEggURI 
- ion.services.sa.test.test_driver_egg:TestDriverEgg.test_driverLaunchNoModuleOnlyURI 
- ion.services.sa.test.test_instrument_alerts:TestInstrumentAlerts.test_alerts
