### PR TITLE
Fix references to agent_process_id, fix buildbot

### DIFF
--- a/ion/services/cei/process_dispatcher_service.py
+++ b/ion/services/cei/process_dispatcher_service.py
@@ -67,6 +67,9 @@ class ProcessStateGate(EventSubscriber):
     """
     def __init__(self, read_process_fn=None, process_id='', desired_state=None, *args, **kwargs):
 
+        if not process_id:
+            raise BadRequest("ProcessStateGate trying to wait on invalid process (id = '%s')" % process_id)
+
         EventSubscriber.__init__(self, *args,
                                  callback=self.trigger_cb,
                                  event_type="ProcessLifecycleEvent",

--- a/ion/services/sa/acquisition/data_acquisition_management_service.py
+++ b/ion/services/sa/acquisition/data_acquisition_management_service.py
@@ -2,6 +2,7 @@
 
 """Data Acquisition Management service to keep track of Data Producers, Data Sources and external data agents
 and the relationships between them"""
+from pyon.agent.agent import ResourceAgentClient
 
 __author__ = 'Maurice Manning, Michael Meisinger'
 
@@ -751,14 +752,13 @@ class DataAcquisitionManagementService(BaseDataAcquisitionManagementService):
         """
         Deactivate the agent instance process
         """
-        external_dataset_agent_instance_obj = self.clients.resource_registry.read(external_dataset_agent_instance_id)
+        external_dataset_id = self.RR2.find_external_dataset_id_by_external_dataset_agent_instance(external_dataset_agent_instance_id)
+
+        agent_process_id = ResourceAgentClient._get_agent_process_id(external_dataset_id)
 
         # Cancels the execution of the given process id.
-        self.clients.process_dispatcher.cancel_process(external_dataset_agent_instance_obj.agent_process_id)
+        self.clients.process_dispatcher.cancel_process(agent_process_id)
 
-        external_dataset_agent_instance_obj.agent_process_id = ''
-
-        self.clients.resource_registry.update(external_dataset_agent_instance_obj)
 
 
     def retrieve_external_dataset_agent_instance(self, external_dataset_id=''):
@@ -776,9 +776,7 @@ class DataAcquisitionManagementService(BaseDataAcquisitionManagementService):
         if ai_ids is None:
             return None, None
         else:
-            dataset_agent_instance_obj = self.clients.resource_registry.read(ai_ids[0])
-
-            if not dataset_agent_instance_obj.agent_process_id:
+            if not ResourceAgentClient._get_agent_process_id(external_dataset_id):
                 active = False
             else:
                 active = True

--- a/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
+++ b/ion/services/sa/instrument/test/test_instrument_management_service_integration.py
@@ -32,7 +32,7 @@ from ooi.logging import log
 import unittest
 
 
-from ion.services.sa.test.helpers import any_old
+from ion.services.sa.test.helpers import any_old, AgentProcessStateGate
 
 
 @attr('INT', group='sa')
@@ -437,13 +437,12 @@ class TestInstrumentManagementServiceIntegration(IonIntegrationTestCase):
                         instrument_agent_instance_id=instAgentInstance_id)
 
         #wait for start
-        agent_process_id = ResourceAgentClient._get_agent_process_id(instDevice_id)
         instance_obj = self.IMS.read_instrument_agent_instance(instAgentInstance_id)
-        gate = ProcessStateGate(self.PDC.read_process,
-                                agent_process_id,
-                                ProcessStateEnum.RUNNING)
+        gate = AgentProcessStateGate(self.PDC.read_process,
+                                     instDevice_id,
+                                     ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(30), "The instrument agent instance (%s) did not spawn in 30 seconds" %
-                                        instance_obj.agent_process_id)
+                                        gate.process_id)
 
 
         # take snapshot of config

--- a/ion/services/sa/observatory/test/test_rsn_platform_instrument.py
+++ b/ion/services/sa/observatory/test/test_rsn_platform_instrument.py
@@ -28,7 +28,7 @@ from pyon.agent.agent import ResourceAgentState
 from pyon.event.event import EventSubscriber
 
 from ion.services.dm.utility.granule_utils import time_series_domain
-from ion.services.sa.test.helpers import any_old
+from ion.services.sa.test.helpers import any_old, AgentProcessStateGate
 from pyon.public import RT, PRED, IonObject
 
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
@@ -529,14 +529,14 @@ class TestPlatformInstrument(BaseIntTestPlatform):
 
         #wait for start
         agent_instance_obj = self.imsclient.read_platform_agent_instance(agent_instance_id)
-        gate = ProcessStateGate(self.processdispatchclient.read_process,
-                                agent_instance_obj.agent_process_id,
-                                ProcessStateEnum.RUNNING)
+        gate = AgentProcessStateGate(self.processdispatchclient.read_process,
+                                     self.platform_device._id,
+                                     ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(90), "The platform agent instance did not spawn in 90 seconds")
 
         # Start a resource agent client to talk with the agent.
         self._pa_client = ResourceAgentClient(self.platform_device,
-                                              name=agent_instance_obj.agent_process_id,
+                                              name=gate.process_id,
                                               process=FakeProcess())
         log.debug("got platform agent client %s", str(self._pa_client))
 

--- a/ion/services/sa/product/test/test_data_product_provenance.py
+++ b/ion/services/sa/product/test/test_data_product_provenance.py
@@ -635,7 +635,7 @@ class TestDataProductProvenance(IonIntegrationTestCase):
         print 'TestDataProductProvenance: Instrument agent instance obj: = ', inst_agent_instance_obj
 
         # Start a resource agent client to talk with the instrument agent.
-#        self._ia_client = ResourceAgentClient('iaclient', name=inst_agent_instance_obj.agent_process_id,  process=FakeProcess())
+#        self._ia_client = ResourceAgentClient('iaclient', name=ResourceAgentClient._get_agent_process_id(instDevice_id,  process=FakeProcess())
 #        print 'activate_instrument: got ia client %s', self._ia_client
 #        log.debug(" test_createTransformsThenActivateInstrument:: got ia client %s", str(self._ia_client))
 

--- a/ion/services/sa/test/helpers.py
+++ b/ion/services/sa/test/helpers.py
@@ -1,8 +1,10 @@
 import hashlib
 from unittest.case import SkipTest
 from interface.services.coi.iresource_registry_service import ResourceRegistryServiceClient
+from ion.services.cei.process_dispatcher_service import ProcessStateGate
 from ion.util.enhanced_resource_registry_client import EnhancedResourceRegistryClient
 from mock import Mock
+from pyon.agent.agent import ResourceAgentClient
 from pyon.core.exception import Unauthorized, Inconsistent, NotFound, BadRequest
 from pyon.public import IonObject
 from pyon.public import RT
@@ -72,6 +74,20 @@ def add_keyworded_attachment(resource_registry_client, resource_id, keywords, ex
     resource_registry_client.create_attachment(resource_id, ret)
 
     return ret
+
+
+class AgentProcessStateGate(ProcessStateGate):
+    """
+    This class is a thin wrapper around ProcessStateGate to handle agent processes
+    """
+    def __init__(self, read_process_fn=None, resource_id='', desired_state=None, *args, **kwargs):
+
+        agent_process_id = ResourceAgentClient._get_agent_process_id(resource_id)
+
+        super(AgentProcessStateGate, self).__init__(read_process_fn,
+                                                    agent_process_id,
+                                                    desired_state,
+                                                    *args, **kwargs)
 
 
 class UnitTestGenerator(object):

--- a/ion/services/sa/test/test_activate_instrument.py
+++ b/ion/services/sa/test/test_activate_instrument.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from ion.services.sa.test.helpers import AgentProcessStateGate
 
 from pyon.util.containers import DotDict
 from pyon.util.poller import poll
@@ -397,19 +398,18 @@ class TestActivateInstrumentIntegration(IonIntegrationTestCase):
 
 
         #wait for start
-        agent_process_id = ResourceAgentClient._get_agent_process_id(instDevice_id)
         inst_agent_instance_obj = self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
-        gate = ProcessStateGate(self.processdispatchclient.read_process,
-                                agent_process_id,
-                                ProcessStateEnum.RUNNING)
+        gate = AgentProcessStateGate(self.processdispatchclient.read_process,
+                                     instDevice_id,
+                                     ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(30), "The instrument agent instance (%s) did not spawn in 30 seconds" %
-                                        inst_agent_instance_obj.agent_process_id)
+                                        gate.process_id)
 
         #log.trace('Instrument agent instance obj: = %s' , str(inst_agent_instance_obj))
 
         # Start a resource agent client to talk with the instrument agent.
         self._ia_client = ResourceAgentClient(instDevice_id,
-                                              to_name=inst_agent_instance_obj.agent_process_id,
+                                              to_name=gate.process_id,
                                               process=FakeProcess())
 
         log.debug("test_activateInstrumentSample: got ia client %s" , str(self._ia_client))

--- a/ion/services/sa/test/test_ctd_transforms_L0_L1_L2.py
+++ b/ion/services/sa/test/test_ctd_transforms_L0_L1_L2.py
@@ -1,3 +1,4 @@
+from ion.services.sa.test.helpers import AgentProcessStateGate
 from pyon.public import log, IonObject
 from pyon.util.int_test import IonIntegrationTestCase
 
@@ -624,14 +625,13 @@ class TestCTDTransformsIntegration(IonIntegrationTestCase):
         inst_agent_instance_obj= self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
         
         # Wait for instrument agent to spawn
-        gate = ProcessStateGate(self.processdispatchclient.read_process,
-            inst_agent_instance_obj.agent_process_id, ProcessStateEnum.RUNNING)
+        gate = AgentProcessStateGate(self.processdispatchclient.read_process,
+                                     instDevice_id,
+                                     ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(15), "The instrument agent instance did not spawn in 15 seconds")
 
         # Start a resource agent client to talk with the instrument agent.
-        self._ia_client = ResourceAgentClient(instDevice_id,
-            to_name=inst_agent_instance_obj.agent_process_id,
-            process=FakeProcess())
+        self._ia_client = ResourceAgentClient(instDevice_id, to_name=gate.process_id, process=FakeProcess())
 
         #-------------------------------------------------------------------------------------
         # Streaming

--- a/ion/services/sa/test/test_deploy_activate_full.py
+++ b/ion/services/sa/test/test_deploy_activate_full.py
@@ -1,3 +1,4 @@
+from ion.services.sa.test.helpers import AgentProcessStateGate
 from pyon.public import log, IonObject
 from pyon.util.int_test import IonIntegrationTestCase
 
@@ -492,17 +493,19 @@ class TestIMSDeployAsPrimaryDevice(IonIntegrationTestCase):
 
         #wait for start
         instance_obj = self.imsclient.read_instrument_agent_instance(oldInstAgentInstance_id)
-        gate = ProcessStateGate(self.processdispatchclient.read_process,
-            instance_obj.agent_process_id,
-            ProcessStateEnum.RUNNING)
+        gate = AgentProcessStateGate(self.processdispatchclient.read_process,
+                                     oldInstDevice_id,
+                                     ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(30), "The instrument agent instance (%s) did not spawn in 30 seconds" %
-                                        instance_obj.agent_process_id)
+                                        gate.process_id)
 
         inst_agent1_instance_obj= self.imsclient.read_instrument_agent_instance(oldInstAgentInstance_id)
         print 'test_deployAsPrimaryDevice: Instrument agent instance obj: = ', inst_agent1_instance_obj
 
         # Start a resource agent client to talk with the instrument agent.
-        self._ia_client_sim1 = ResourceAgentClient('iaclient Sim1', name=inst_agent1_instance_obj.agent_process_id,  process=FakeProcess())
+        self._ia_client_sim1 = ResourceAgentClient('iaclient Sim1',
+                                                   name=gate.process_id,
+                                                   process=FakeProcess())
         print 'activate_instrument: got _ia_client_sim1 %s', self._ia_client_sim1
         log.debug(" test_deployAsPrimaryDevice:: got _ia_client_sim1 %s", str(self._ia_client_sim1))
 
@@ -516,17 +519,19 @@ class TestIMSDeployAsPrimaryDevice(IonIntegrationTestCase):
 
         #wait for start
         instance_obj = self.imsclient.read_instrument_agent_instance(newInstAgentInstance_id)
-        gate = ProcessStateGate(self.processdispatchclient.read_process,
-            instance_obj.agent_process_id,
-            ProcessStateEnum.RUNNING)
+        gate = AgentProcessStateGate(self.processdispatchclient.read_process,
+                                     oldInstDevice_id,
+                                     ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(30), "The instrument agent instance (%s) did not spawn in 30 seconds" %
-                                        instance_obj.agent_process_id)
+                                        gate.process_id)
 
         inst_agent2_instance_obj= self.imsclient.read_instrument_agent_instance(newInstAgentInstance_id)
         print 'test_deployAsPrimaryDevice: Instrument agent instance obj: = ', inst_agent2_instance_obj
 
         # Start a resource agent client to talk with the instrument agent.
-        self._ia_client_sim2 = ResourceAgentClient('iaclient Sim2', name=inst_agent2_instance_obj.agent_process_id,  process=FakeProcess())
+        self._ia_client_sim2 = ResourceAgentClient('iaclient Sim2',
+                                                   name=gate.process_id,
+                                                   process=FakeProcess())
         print 'activate_instrument: got _ia_client_sim2 %s', self._ia_client_sim2
         log.debug(" test_deployAsPrimaryDevice:: got _ia_client_sim2 %s", str(self._ia_client_sim2))
 

--- a/ion/services/sa/test/test_instrument_alerts.py
+++ b/ion/services/sa/test/test_instrument_alerts.py
@@ -7,6 +7,7 @@
 @brief Test alerts
 
 """
+from ion.services.sa.test.helpers import AgentProcessStateGate
 
 from pyon.public import log, IonObject
 from pyon.util.int_test import IonIntegrationTestCase
@@ -308,15 +309,15 @@ class TestInstrumentAlerts(IonIntegrationTestCase):
         inst_agent_instance_obj= self.imsclient.read_instrument_agent_instance(instAgentInstance_id)
 
         # Wait for instrument agent to spawn
-        agent_process_id = ResourceAgentClient._get_agent_process_id(instDevice_id)
-        gate = ProcessStateGate(self.processdispatchclient.read_process,
-                                agent_process_id, ProcessStateEnum.RUNNING)
+        gate = AgentProcessStateGate(self.processdispatchclient.read_process,
+                                     instDevice_id,
+                                     ProcessStateEnum.RUNNING)
         self.assertTrue(gate.await(15), "The instrument agent instance did not spawn in 15 seconds")
 
         # Start a resource agent client to talk with the instrument agent.
         self._ia_client = ResourceAgentClient(instDevice_id,
-            to_name=inst_agent_instance_obj.agent_process_id,
-            process=FakeProcess())
+                                              to_name=gate.process_id,
+                                              process=FakeProcess())
 
         #-------------------------------------------------------------------------------------
         # Set up the subscriber to catch the alert event


### PR DESCRIPTION
This patch removes references to agent_process_id, which is an incorrect (and unreliable source) for the running agent's process ID.

This patch adds AgentProcessStateGate, a thin wrapper around ProcessStateGate that accepts a resource ID.  This saves code lines and unnecessary resource registry find ops.
