### PR TITLE
Fixes and adjustments in platform agent

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -362,7 +362,19 @@ class PlatformAgent(ResourceAgent):
             # nothing else to do here
             return
 
-        log.debug("verifying/processing _plat_config ...")
+        log.debug("verifying/processing platform config configuration ...")
+
+        stream_info = self.CFG.get('stream_config', None)
+        if stream_info is None:
+            msg = "'stream_config' key not in configuration"
+            log.error(msg)
+            raise PlatformException(msg)
+        for stream_name, stream_config in stream_info.iteritems():
+            if 'stream_def_dict' not in stream_config:
+                msg = "'stream_def_dict' key not in configuration for stream %r" % stream_name
+                log.error(msg)
+                raise PlatformException(msg)
+
 
         self._driver_config = self.CFG.get('driver_config', None)
         if None is self._driver_config:

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -1384,9 +1384,9 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
                 self.IMS.stop_instrument_agent_instance(i_obj.instrument_agent_instance_id)
             except:
                 log.exception(
-                    "instrument_id=%r: Exception in IMS.stop_instrument_agent_instance with "
+                    "Exception in IMS.stop_instrument_agent_instance with "
                     "instrument_agent_instance_id = %r",
-                    i_obj.instrument_id, i_obj.instrument_agent_instance_id)
+                    i_obj.instrument_agent_instance_id)
 
         else:
             try:

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -98,6 +98,7 @@ from interface.services.coi.iidentity_management_service import IdentityManageme
 from ion.services.sa.test.helpers import any_old, AgentProcessStateGate
 
 from ion.agents.instrument.driver_int_test_support import DriverIntegrationTestSupport
+from ion.agents.instrument.test.test_instrument_agent import DRV_URI_GOOD
 
 
 ###############################################################################
@@ -211,9 +212,8 @@ instruments_dict = {
     },
 }
 
-# The value should probably be defined in pyon.yml or some common place so
-# clients don't have to do updates upon new versions of the egg.
-SBE37_EGG = "http://sddevrepo.oceanobservatories.org/releases/seabird_sbe37smb_ooicore-0.1.1-py2.7.egg"
+SBE37_EGG = DRV_URI_GOOD
+
 
 class FakeProcess(LocalContextMixin):
     """


### PR DESCRIPTION
These commits should fix some of the recent breaks exposed on the buildbots.
Note, there's still a "fail to start port agent" kind of error that is most likely caused by a prior failing IMS.stop_instrument_agent, which seems related with recent changes in the handling of process_ids.  But please merge while we investigate.   Thx.
