### PR TITLE
Agent management service support to start agent instances

### DIFF
--- a/ion/services/coi/agent_management_service.py
+++ b/ion/services/coi/agent_management_service.py
@@ -2,7 +2,18 @@
 
 __author__ = 'Michael Meisinger'
 
+from pyon.public import BadRequest, log
+
+from interface.objects import AgentInstance, InstrumentAgentInstance, PlatformAgentInstance, ExternalDatasetAgentInstance, \
+    Resource, AgentDefinition, InstrumentAgent, PlatformAgent, ExternalDatasetAgent
+
 from interface.services.coi.iagent_management_service import BaseAgentManagementService
+from interface.services.sa.iinstrument_management_service import InstrumentManagementServiceProcessClient
+from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceProcessClient
+
+AT_INSTUMENT_AGENT = "InstrumentAgentInstance"
+AT_PLATFORM_AGENT = "PlatformAgentInstance"
+AT_EXTDATASET_AGENT = "ExternalDatasetAgentInstance"
 
 
 class AgentManagementService(BaseAgentManagementService):
@@ -11,6 +22,9 @@ class AgentManagementService(BaseAgentManagementService):
 
     @see https://confluence.oceanobservatories.org/display/syseng/CIAD+COI+OV+Agent+Management+Service
     """
+    def on_init(self):
+        self.ims_client = InstrumentManagementServiceProcessClient(process=self)
+        self.dams_client = DataAcquisitionManagementServiceProcessClient(process=self)
 
     def create_agent_definition(self, agent_definition=None):
         """Creates an Agent Definition resource from the parameter AgentDefinition object.
@@ -19,8 +33,16 @@ class AgentManagementService(BaseAgentManagementService):
         @retval agent_definition_id    str
         @throws BadRequest    if object passed has _id or _rev attribute
         """
-        ad_id, version = self.clients.resource_registry.create(agent_definition)
-        return ad_id
+        atype, ainst, svc_client = self._get_agent_type(agent_definition)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.create_instrument_agent(agent_definition)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.create_platform_agent(agent_definition)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.create_external_dataset_agent(agent_definition)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
 
     def update_agent_definition(self, agent_definition=None):
         """Updates an existing Agent Definition resource.
@@ -30,7 +52,17 @@ class AgentManagementService(BaseAgentManagementService):
         @throws NotFound    object with specified id does not exist
         @throws Conflict    object not based on latest persisted object version
         """
-        self.clients.resource_registry.update(agent_definition)
+        atype, ainst, svc_client = self._get_agent_type(agent_definition)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.update_instrument_agent(agent_definition)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.update_platform_agent(agent_definition)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.update_external_dataset_agent(agent_definition)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
+
 
     def read_agent_definition(self, agent_definition_id=''):
         """Returns an existing Agent Definition resource.
@@ -39,8 +71,16 @@ class AgentManagementService(BaseAgentManagementService):
         @retval agent_definition    AgentDefinition
         @throws NotFound    object with specified id does not exist
         """
-        adef = self.clients.resource_registry.read(agent_definition_id)
-        return adef
+        atype, ainst, svc_client = self._get_agent_type(agent_definition_id)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.read_instrument_agent(agent_definition_id)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.read_platform_agent(agent_definition_id)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.read_external_dataset_agent(agent_definition_id)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
 
     def delete_agent_definition(self, agent_definition_id=''):
         """Deletes an existing Agent Definition resource.
@@ -48,7 +88,16 @@ class AgentManagementService(BaseAgentManagementService):
         @param agent_definition_id    str
         @throws NotFound    object with specified id does not exist
         """
-        self.clients.resource_registry.delete(agent_definition_id)
+        atype, ainst, svc_client = self._get_agent_type(agent_definition_id)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.delete_instrument_agent(agent_definition_id)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.delete_platform_agent(agent_definition_id)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.delete_external_dataset_agent(agent_definition_id)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
 
 
     def create_agent_instance(self, agent_instance=None):
@@ -58,8 +107,16 @@ class AgentManagementService(BaseAgentManagementService):
         @retval agent_instance_id    str
         @throws BadRequest    if object passed has _id or _rev attribute
         """
-        ai_id, version = self.clients.resource_registry.create(agent_instance)
-        return ai_id
+        atype, ainst, svc_client = self._get_agent_type(agent_instance)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.create_instrument_agent_instance_(agent_instance)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.create_platform_agent_instance(agent_instance)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.create_external_dataset_agent_instance(agent_instance)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
 
     def update_agent_instance(self, agent_instance=None):
         """Updates an existing Agent Instance resource.
@@ -69,7 +126,16 @@ class AgentManagementService(BaseAgentManagementService):
         @throws NotFound    object with specified id does not exist
         @throws Conflict    object not based on latest persisted object version
         """
-        self.clients.resource_registry.update(agent_instance)
+        atype, ainst, svc_client = self._get_agent_type(agent_instance)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.update_instrument_agent_instance(agent_instance)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.update_platform_agent_instance(agent_instance)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.update_data_source_agent_instance(agent_instance)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
 
     def read_agent_instance(self, agent_instance_id=''):
         """Returns an existing Agent Instance resource.
@@ -78,8 +144,16 @@ class AgentManagementService(BaseAgentManagementService):
         @retval agent_instance    AgentInstance
         @throws NotFound    object with specified id does not exist
         """
-        ainst = self.clients.resource_registry.read(agent_instance_id)
-        return ainst
+        atype, ainst, svc_client = self._get_agent_type(agent_instance_id)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.read_instrument_agent_instance(agent_instance_id)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.read_platform_agent_instance(agent_instance_id)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.read_external_dataset_agent_instance(agent_instance_id)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
 
     def delete_agent_instance(self, agent_instance_id=''):
         """Deletes an existing Agent Instance resource.
@@ -87,5 +161,73 @@ class AgentManagementService(BaseAgentManagementService):
         @param agent_instance_id    str
         @throws NotFound    object with specified id does not exist
         """
-        self.clients.resource_registry.delete(agent_instance_id)
+        atype, ainst, svc_client = self._get_agent_type(agent_instance_id)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.delete_instrument_agent_instance(agent_instance_id)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.delete_platform_agent_instance(agent_instance_id)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.delete_external_dataset_agent_instance(agent_instance_id)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
+
+    def start_agent_instance(self, agent_instance_id=''):
+        """Start the given Agent Instance. Delegates to the type specific service.
+
+        @param agent_instance_id    str
+        @retval process_id    str
+        @throws NotFound    object with specified id does not exist
+        """
+        atype, ainst, svc_client = self._get_agent_type(agent_instance_id)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.start_instrument_agent_instance(agent_instance_id)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.start_platform_agent_instance(agent_instance_id)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.start_external_dataset_agent_instance(agent_instance_id)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
+
+    def stop_agent_instance(self, agent_instance_id=''):
+        """Stop the given Agent Instance. Delegates to the type specific service.
+
+        @param agent_instance_id    str
+        @throws NotFound    object with specified id does not exist
+        """
+        atype, ainst, svc_client = self._get_agent_type(agent_instance_id)
+        if atype == AT_INSTUMENT_AGENT:
+            res = self.ims_client.stop_instrument_agent_instance(agent_instance_id)
+        elif atype == AT_PLATFORM_AGENT:
+            res = self.ims_client.stop_platform_agent_instance(agent_instance_id)
+        elif atype == AT_EXTDATASET_AGENT:
+            res = self.dams_client.stop_external_dataset_agent_instance(agent_instance_id)
+        else:
+            raise BadRequest("Unknown agent type: %s" % atype)
+        return res
+
+    def _get_agent_type(self, agent=''):
+        if isinstance(agent, str):
+            res_obj = self.clients.resource_registry.read(agent)
+        elif isinstance(agent, AgentInstance) or isinstance(agent, AgentDefinition):
+            res_obj = agent
+        else:
+            raise BadRequest("Resource must be AgentInstance or AgentDefinition, is: %s" % agent.type_)
+
+        atype = None
+        svc_client = None
+        is_instance = res_obj.type_.endswith("Instance")
+        if isinstance(res_obj, InstrumentAgentInstance) or isinstance(res_obj, InstrumentAgent):
+            atype = AT_INSTUMENT_AGENT
+            svc_client = self.ims_client
+        elif isinstance(res_obj, PlatformAgentInstance) or isinstance(res_obj, PlatformAgent):
+            atype = AT_PLATFORM_AGENT
+            svc_client = self.ims_client
+        elif isinstance(res_obj, ExternalDatasetAgentInstance) or isinstance(res_obj, ExternalDatasetAgent):
+            atype = AT_EXTDATASET_AGENT
+            svc_client = self.dams_client
+        else:
+            raise BadRequest("Resource must is unknown AgentInstance: %s" % res_obj.type_)
+        return atype, res_obj, svc_client
 

--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1424,10 +1424,15 @@ class InstrumentManagementService(BaseInstrumentManagementService):
     def find_instrument_agent_instance_by_instrument_device(self, instrument_device_id=''):
         instrument_agent_instance_objs = \
             self.RR2.find_instrument_agent_instances_of_instrument_device_using_has_agent_instance(instrument_device_id)
-        if 0 < len(instrument_agent_instance_objs):
+        if instrument_agent_instance_objs:
             log.debug("L4-CI-SA-RQ-363: device %s is connected to instrument agent instance %s",
                       str(instrument_device_id),
                       str(instrument_agent_instance_objs[0]._id))
+        else:
+            instrument_agent_instance_objs = \
+                self.RR2.find_external_dataset_agent_instances_of_instrument_device_using_has_agent_instance(instrument_device_id)
+            log.debug("Found ExternalDatasetAgentInstance %s for InstrumentDevice %s" % (instrument_agent_instance_objs, instrument_device_id))
+
         return instrument_agent_instance_objs
 
     def find_instrument_device_by_platform_device(self, platform_device_id=''):


### PR DESCRIPTION
Extends IMS to return ExternalDatasetAgentInstances for InstrumentDevice in find_instrument_agent_instance_by_instrument_device if no InstrumentAgentInstances found
