### PR TITLE
dispatch _configure_aparams in PlatformAgent so the alert definitions are captured and processed

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -324,6 +324,7 @@ class PlatformAgent(ResourceAgent):
         """
         - Validates the given configuration and does related preparations.
         - creates AgentAlertManager and StatusManager
+        - configures aparams if not already config'ed (see _configure_aparams)
         - Children agents (platforms and instruments) are launched here (in a
           separate greenlet).
         """
@@ -337,6 +338,11 @@ class PlatformAgent(ResourceAgent):
 
         # create StatusManager now that we have all needed elements:
         self._status_manager = StatusManager(self)
+
+        if self._configure_aparams_arg:
+            # see explanation in _configure_aparams
+            self._do_configure_aparams(self._configure_aparams_arg)
+            self._configure_aparams_arg = None
 
         self._async_children_launched = AsyncResult()
 
@@ -3185,6 +3191,51 @@ class PlatformAgent(ResourceAgent):
         result = self._shutdown(recursion)
 
         return next_state, result
+
+    ##############################################################
+    # Agent parameter functions.
+    ##############################################################
+
+    def _configure_aparams(self, aparams=None):
+        """
+        Configure aparams from agent config values.
+
+        **NOTE**:
+        the base class calls this as part of on_init, but the PlatforAgent
+        currently does much of its preparations in on_start, including the
+        set-up of the alert manager and the status manager. So, as a mechanism
+        to handle this, here we basically save the argument `aparams` for
+        actual processing during on_start.
+        """
+
+        log.debug("%r: _configure_aparams: aparams=%s" % (self._platform_id, aparams))
+
+        self._configure_aparams_arg = None
+
+        if self._aam:
+            # if we already have an alert manager, do the thing right away (but
+            # this is not the case at time of writing).
+            self._do_configure_aparams(aparams)
+        else:
+            # save the argument for subsequent processing in on_start:
+            self._configure_aparams_arg = aparams
+
+    def _do_configure_aparams(self, aparams):
+
+        aparams = aparams or []
+
+        # TODO: pubrate
+        # # If specified and configed, build the pubrate aparam.
+        # aparam_pubrate_config = self.CFG.get('aparam_pubrate_config', None)
+        # if aparam_pubrate_config and 'pubrate' in aparams:
+        #     self.aparam_set_pubrate(aparam_pubrate_config)
+
+        # If specified and configed, build the alerts aparam.
+        aparam_alerts_config = self.CFG.get('aparam_alerts_config', None)
+        log.debug("%r: _configure_aparams: aparam_alerts_config=%s" % (
+                  self._platform_id, aparam_alerts_config))
+        if aparam_alerts_config and 'alerts' in aparams:
+            self.aparam_set_alerts(aparam_alerts_config)
 
     ##############################################################
     # Base class overrides for state and cmd error alerts.

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -3237,6 +3237,12 @@ class PlatformAgent(ResourceAgent):
         if aparam_alerts_config and 'alerts' in aparams:
             self.aparam_set_alerts(aparam_alerts_config)
 
+    def _restore_resource(self, state, prev_state):
+        """
+        Restore agent/resource configuration and state.
+        """
+        log.warn("%r: PlatformAgent._restore_resource not implemented yet" % self._platform_id)
+
     ##############################################################
     # Base class overrides for state and cmd error alerts.
     ##############################################################

--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -51,6 +51,7 @@ from ion.agents.platform.rsn.rsn_platform_driver import RSNPlatformDriverEvent
 
 from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform
 from ion.services.dm.utility.granule_utils import RecordDictionaryTool
+from pyon.public import IonObject
 
 from gevent import sleep
 from gevent.event import AsyncResult

--- a/ion/services/sa/observatory/test/test_rsn_platform_instrument.py
+++ b/ion/services/sa/observatory/test/test_rsn_platform_instrument.py
@@ -53,6 +53,7 @@ from ion.services.cei.process_dispatcher_service import ProcessStateGate
 
 from ion.agents.platform.rsn.test.oms_test_mixin import OmsTestMixin
 
+import unittest
 import pprint
 
 import gevent
@@ -180,7 +181,7 @@ class TestPlatformInstrument(BaseIntTestPlatform):
 #            pnode.add_attribute(attr)
         return attr_infos
 
-    # @unittest.skip('Still in construction...')
+    @unittest.skip('Still in construction...')
     def test_platform_with_instrument_streaming(self):
         #
         # The following is with just a single platform and the single

--- a/ion/services/sa/observatory/test/test_rsn_platform_instrument.py
+++ b/ion/services/sa/observatory/test/test_rsn_platform_instrument.py
@@ -53,7 +53,7 @@ from ion.services.cei.process_dispatcher_service import ProcessStateGate
 
 from ion.agents.platform.rsn.test.oms_test_mixin import OmsTestMixin
 
-import unittest
+import pprint
 
 import gevent
 from gevent.event import AsyncResult
@@ -123,6 +123,22 @@ class TestPlatformInstrument(BaseIntTestPlatform):
     def setUp(self):
         self._start_container()
 
+        self._pp = pprint.PrettyPrinter()
+
+        log.debug("oms_uri = %s", OMS_URI)
+        self.oms = CIOMSClientFactory.create_instance(OMS_URI)
+
+        self._get_platform_attributes()
+
+        url = OmsTestMixin.start_http_server()
+        log.info("TestPlatformInstrument:setup http url %s", url)
+
+        result = self.oms.event.register_event_listener(url)
+        log.info("TestPlatformInstrument:setup register_event_listener result %s", result)
+
+#        response = self.oms.port.get_platform_ports('LPJBox_CI_Ben_Hall')
+#        log.info("TestPlatformInstrument:setup get_platform_ports %s", response)
+
         self.container.start_rel_from_url('res/deploy/r2deploy.yml')
 
         # Now create client to DataProductManagementService
@@ -147,18 +163,6 @@ class TestPlatformInstrument(BaseIntTestPlatform):
         self.platform_agent_instance_id = ''
         self._pa_client = ''
 
-        log.debug("oms_uri = %s", OMS_URI)
-        self.oms = CIOMSClientFactory.create_instance(OMS_URI)
-        url = OmsTestMixin.start_http_server()
-        log.info("TestPlatformInstrument:setup http url %s", url)
-
-        result = self.oms.event.register_event_listener(url)
-        log.info("TestPlatformInstrument:setup register_event_listener result %s", result)
-
-
-#        response = self.oms.port.get_platform_ports('LPJBox_CI_Ben_Hall')
-#        log.info("TestPlatformInstrument:setup get_platform_ports %s", response)
-
         def done():
             CIOMSClientFactory.destroy_instance(self.oms)
             event_notifications = OmsTestMixin.stop_http_server()
@@ -166,8 +170,17 @@ class TestPlatformInstrument(BaseIntTestPlatform):
 
         self.addCleanup(done)
 
+    def _get_platform_attributes(self):
+        attr_infos = self.oms.attr.get_platform_attributes('LPJBox_CI_Ben_Hall')
+        log.debug('_get_platform_attributes: %s', self._pp.pformat(attr_infos))
 
-    @unittest.skip('Still in construction...')
+#        ret_infos = attr_infos['LPJBox_CI_Ben_Hall']
+#        for attrName, attr_defn in ret_infos.iteritems():
+#            attr = AttrNode(attrName, attr_defn)
+#            pnode.add_attribute(attr)
+        return attr_infos
+
+    # @unittest.skip('Still in construction...')
     def test_platform_with_instrument_streaming(self):
         #
         # The following is with just a single platform and the single
@@ -474,20 +487,6 @@ class TestPlatformInstrument(BaseIntTestPlatform):
 
 
 
-
-
-    def _get_platform_attributes(self):
-        # Use the network definition provided by RSN OMS directly.
-        rsn_oms = CIOMSClientFactory.create_instance('http://alice:1234@10.180.80.10:9021/')
-        attr_infos = rsn_oms.attr.get_platform_attributes('LPJBox_CI_Ben_Hall')
-
-        log.debug('_get_platform_attributes: %s', attr_infos)
-
-#        ret_infos = attr_infos['LPJBox_CI_Ben_Hall']
-#        for attrName, attr_defn in ret_infos.iteritems():
-#            attr = AttrNode(attrName, attr_defn)
-#            pnode.add_attribute(attr)
-        return attr_infos
 
 
     def _start_platform(self):


### PR DESCRIPTION
Fixes https://jira.oceanobservatories.org/tasks/browse/OOIION-1268

UI testing using

```
bin/pycc -x ion.processes.bootstrap.ion_loader.IONLoader op=load  scenario=BETA,R2_DEMO loadui=True attachments=res/preload/r2_ioc/attachments ui_path="https://userexperience.oceanobservatories.org/database-exports/Candidates"  path=master
```

In the UI adding the following alert def to the "Beta Demonstration Platform Device" platform:

```
{"stream_name":     "parsed",
 "alert_type":      1,   
 "name":            "input_voltage_warning_interval",
 "lower_bound":     111,
 "aggregate_type":  2,
 "alert_class":     "IntervalAlert",
 "value_id":        "input_voltage",
 "lower_rel_op":    "<",
 "description":     "input_voltage is below the normal range of 111 and above."}  
```

Then after putting the platform in monitoring state I can see the alerts being processed in the logs and also the corresponding "data" status icon changing color upon refresh of the page.

Integration tests:

The existing integration test test-alerts in:
   https://github.com/ooici/coi-services/blob/master/ion/agents/platform/test/test_platform_agent_with_rsn.py
was adjusted to also test alert defs passed via configuration to the platform agent.

NOTE: The base class calls _configure_aparams as part of on_init, but the PlatformAgent currently does much of its preparations in on_start, including the set-up of the alert manager and the status manager. So, as a mechanism to handle this, we basically save the argument `aparams` for actual processing during on_start.
