### PR TITLE
adjustments related with handling of external OMS events in platform agent code

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -923,10 +923,6 @@ class PlatformAgent(ResourceAgent):
             self._asp.handle_attribute_value_event(driver_event)
             return
 
-        if isinstance(driver_event, ExternalEventDriverEvent):
-            self._handle_external_event_driver_event(driver_event)
-            return
-
         if isinstance(driver_event, StateChangeDriverEvent):
             self._async_driver_event_state_change(driver_event.state)
             return
@@ -969,31 +965,6 @@ class PlatformAgent(ResourceAgent):
                           self._platform_id, stream_name, param_name, value)
                 self._aam.process_alerts(stream_name=stream_name,
                                          value=value, value_id=param_name)
-
-    def _handle_external_event_driver_event(self, driver_event):
-
-        event_instance = driver_event.event_instance
-
-        description  = "external event payload: %s" % str(event_instance)
-
-        event_data = {
-            'description':  description,
-            'sub_type':     'platform_event',
-        }
-
-        log.info("%r: publishing external platform event: event_data=%s",
-                 self._platform_id, event_data)
-
-        try:
-            self._event_publisher.publish_event(
-                event_type='DeviceEvent',
-                origin_type=self.ORIGIN_TYPE,
-                origin=self.resource_id,
-                **event_data)
-
-        except:
-            log.exception("%r: Error while publishing external platform event: %s",
-                          self._platform_id, event_data)
 
     def _async_driver_event_agent_event(self, event):
         """

--- a/ion/agents/platform/rsn/oms_client.py
+++ b/ion/agents/platform/rsn/oms_client.py
@@ -5,7 +5,7 @@
 @file    ion/agents/platform/rsn/oms_client.py
 @author  Carlos Rueda
 @brief   CIOMSClient captures the CI-OMS interface.
-         See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+         See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
          See module ion.agents.platform.responses.
 
 """
@@ -25,7 +25,7 @@ class CIOMSClient(object):
     This class captures the interface with OMS mainly for purposes of serving
     as a base class for the simulator.
 
-    See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+    See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
 
     Note: the real OMS interface uses "handlers" for grouping operations
     (for example, "ping" is a method of the "hello" handler). Here we define
@@ -59,147 +59,108 @@ class CIOMSClient(object):
 
     def ping(self):
         """
-        Basic verification of connection with OMS.
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_platform_map(self):
         """
-        Returns platform map. This is the network object model in the OMS.
-
-        @retval [(platform_id, parent_platform_id), ...]
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_platform_types(self):
         """
-        Returns the types of platforms in the network
-
-        @retval { platform_type: description, ... } Dict of platform types in
-         the network.
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_platform_metadata(self, platform_id):
         """
-        Returns the metadata for a requested platform.
-
-        @param platform_id Platform ID
-        @retval { platform_id: {mdAttrName: mdAttrValue, ...\, ... }
-                dict with a single entry for the requested platform ID with a
-                dictionary for corresponding metadata
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_platform_attributes(self, platform_id):
         """
-        Returns the attributes associated to a given platform.
-
-        @param platform_id Platform ID
-        @retval {platform_id: {attrName : info, ...}, ...}
-                dict with a single entry for the requested platform ID with an
-                info dictionary for each attribute in that platform.
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_platform_attribute_values(self, platform_id, attrs):
         """
-        See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def set_platform_attribute_values(self, platform_id, attrs):
         """
-        See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_platform_ports(self, platform_id):
         """
-        See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def connect_instrument(self, platform_id, port_id, instrument_id, attributes):
         """
-        Adds an instrument to a platform port.
-
-        @param platform_id	 	 Platform ID
-        @param port_id	 	     Port ID
-        @param instrument_id	 Instrument ID
-        @param attributes	 	 {'maxCurrentDraw': value, 'initCurrent': value,
-                                 'dataThroughput': value, 'instrumentType': value}
-
-        @retval
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def disconnect_instrument(self, platform_id, port_id, instrument_id):
         """
-        Removes an instrument from a platform port.
-
-        @param platform_id	 	 Platform ID
-        @param port_id	 	     Port ID
-        @param instrument_id	 Instrument ID
-
-        @retval
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_connected_instruments(self, platform_id, port_id):
         """
-        Retrieves the IDs of the instruments connected to a platform port.
-
-        @param platform_id	 	 Platform ID
-        @param port_id	 	     Port ID
-
-        @retval
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def turn_on_platform_port(self, platform_id, port_id):
         """
-        Turns on a port in a platform. This operation should be called after the
-        instruments to be associated with the port have been added (see connect_instrument).
-
-        @param platform_id	 	 Platform ID
-        @param port_id	 	     PortID ID
-
-        @retval TBD
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def turn_off_platform_port(self, platform_id, port_id):
         """
-        Turns off a port in a platform.
-
-        @param platform_id	 	 Platform ID
-        @param port_id	 	     PortID ID
-
-        @retval TBD
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def register_event_listener(self, url):
         """
-        See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def unregister_event_listener(self, url):
         """
-        See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_registered_event_listeners(self):
         """
-        See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
+        """
+        raise NotImplementedError()  #pragma: no cover
+
+    def generate_test_event(self, event):
+        """
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover
 
     def get_checksum(self, platform_id):
         """
-        See https://confluence.oceanobservatories.org/display/CIDev/CI-OMS+interface
+        See https://confluence.oceanobservatories.org/display/syseng/CIAD+MI+SV+CI-OMS+interface
         """
         raise NotImplementedError()  #pragma: no cover

--- a/ion/agents/platform/rsn/simulator/oms_simulator.py
+++ b/ion/agents/platform/rsn/simulator/oms_simulator.py
@@ -99,7 +99,7 @@ class CIOMSSimulator(CIOMSClient):
 
     def _enter(self):
         """
-        Called when entering any of the CI-OMS interface methods methods.
+        Called when entering any of the CI-OMS interface methods.
         """
         self._dispatch_synthetic_exception()
 
@@ -409,6 +409,25 @@ class CIOMSSimulator(CIOMSClient):
         self._enter()
 
         return self._reg_event_listeners
+
+    def generate_test_event(self, event):
+        self._enter()
+
+        if self._event_generator:  # there are listeners registered.
+            # copy event and include the additional fields:
+            event_instance = event.copy()
+            event_instance['test_event'] = True
+            timestamp = ntplib.system_to_ntp_time(time.time())
+            if 'timestamp' not in event_instance:
+                event_instance['timestamp'] = timestamp
+            if 'first_time_timestamp' not in event_instance:
+                event_instance['first_time_timestamp'] = timestamp
+            # simply notify listeners right away
+            self._event_notifier.notify(event_instance)
+            return True
+
+        else:  # there are *no* listeners registered.
+            return False
 
     def get_checksum(self, platform_id):
         """

--- a/ion/agents/platform/rsn/simulator/test/test_oms_simulator.py
+++ b/ion/agents/platform/rsn/simulator/test/test_oms_simulator.py
@@ -22,8 +22,19 @@ from ion.agents.platform.rsn.oms_client_factory import CIOMSClientFactory
 from ion.agents.platform.rsn.test.oms_test_mixin import OmsTestMixin
 
 from nose.plugins.attrib import attr
+import unittest
+import os
 
 
+#
+# Skip if OMS environment variable is defined: this unit test is specifically
+# for the simulator run in embedded form. Other tests, eg., test_oms_client,
+# are more flexible (and "integration" in nature), allowing to test against
+# not only the simulator (launched in whatever form) but also the real RSN OMS
+# endpoint.
+#
+
+@unittest.skipIf(os.getenv("OMS") is not None, "OMS environment variable is defined.")
 @attr('UNIT', group='sa')
 class Test(IonUnitTestCase, OmsTestMixin):
     """
@@ -34,11 +45,8 @@ class Test(IonUnitTestCase, OmsTestMixin):
     @classmethod
     def setUpClass(cls):
         OmsTestMixin.setUpClass()
-        OmsTestMixin.start_http_server()
         cls.oms = CIOMSClientFactory.create_instance()
 
     @classmethod
     def tearDownClass(cls):
         CIOMSClientFactory.destroy_instance(cls.oms)
-        event_notifications = OmsTestMixin.stop_http_server()
-        log.info("event_notifications = %s" % str(event_notifications))

--- a/ion/agents/platform/rsn/test/oms_test_mixin.py
+++ b/ion/agents/platform/rsn/test/oms_test_mixin.py
@@ -28,7 +28,7 @@ import yaml
 
 # some bogus IDs
 BOGUS_PLATFORM_ID = 'bogus_plat_id'
-BOGUS_ATTR_NAMES = ['bogus_attr1', 'bogus_attr2']
+BOGUS_ATTR_NAMES = ['bogus_attr1|1', 'bogus_attr2|2']
 BOGUS_PORT_ID = 'bogus_port_id'
 BOGUS_INSTRUMENT_ID = 'bogus_instrument_id'
 BOGUS_EVENT_TYPE = "bogus_event_type"
@@ -48,7 +48,7 @@ class OmsTestMixin(HelperTestMixin):
 
     def test_ab_get_platform_map(self):
         platform_map = self.oms.config.get_platform_map()
-        log.info("config.get_platform_map = %s" % platform_map)
+        log.info("config.get_platform_map() => %s" % platform_map)
         self.assertIsInstance(platform_map, list)
         roots = []
         for pair in platform_map:
@@ -62,7 +62,7 @@ class OmsTestMixin(HelperTestMixin):
 
     def test_ac_get_platform_types(self):
         retval = self.oms.config.get_platform_types()
-        log.info("config.get_platform_types = %s" % retval)
+        log.info("config.get_platform_types() => %s" % retval)
         self.assertIsInstance(retval, dict)
         for k, v in retval.iteritems():
             self.assertIsInstance(k, str)
@@ -71,29 +71,30 @@ class OmsTestMixin(HelperTestMixin):
     def test_ad_get_platform_metadata(self):
         platform_id = self.PLATFORM_ID
         retval = self.oms.config.get_platform_metadata(platform_id)
-        log.info("config.get_platform_metadata(%r) = %s" % (platform_id,  retval))
+        log.info("config.get_platform_metadata(%r) => %s" % (platform_id, retval))
         md = self._verify_valid_platform_id(platform_id, retval)
         self.assertIsInstance(md, dict)
-        if not 'platform_types' in md:
-            log.warn("RSN OMS spec: platform_types not included in metadata: %s", md)
+        # TODO: decide on the actual expected metadata.
+        # if not 'platform_types' in md:
+        #     log.warn("RSN OMS spec: platform_types not included in metadata: %s", md)
 
     def test_ad_get_platform_metadata_invalid(self):
         platform_id = BOGUS_PLATFORM_ID
         retval = self.oms.config.get_platform_metadata(platform_id)
-        log.info("config.get_platform_metadata(%r) = %s" % (platform_id,retval))
+        log.info("config.get_platform_metadata(%r) => %s" % (platform_id, retval))
         self._verify_invalid_platform_id(platform_id, retval)
 
     def test_af_get_platform_attributes(self):
         platform_id = self.PLATFORM_ID
         retval = self.oms.attr.get_platform_attributes(platform_id)
-        log.info("attr.get_platform_attributes(%r) = %s" % (platform_id, retval))
+        log.info("attr.get_platform_attributes(%r) => %s" % (platform_id, retval))
         infos = self._verify_valid_platform_id(platform_id, retval)
         self.assertIsInstance(infos, dict)
 
     def test_ag_get_platform_attributes_invalid(self):
         platform_id = BOGUS_PLATFORM_ID
         retval = self.oms.attr.get_platform_attributes(platform_id)
-        log.info("attr.get_platform_attributes(%r) = %s" % (platform_id, retval))
+        log.info("attr.get_platform_attributes(%r) => %s" % (platform_id, retval))
         self._verify_invalid_platform_id(platform_id, retval)
 
     def test_ah_get_platform_attribute_values(self):
@@ -102,8 +103,9 @@ class OmsTestMixin(HelperTestMixin):
         cur_time = ntplib.system_to_ntp_time(time.time())
         from_time = cur_time - 50  # a 50-sec time window
         req_attrs = [(attr_id, from_time) for attr_id in attrNames]
+        log.debug("attr.get_platform_attribute_values(%r, %r)" % (platform_id, req_attrs))
         retval = self.oms.attr.get_platform_attribute_values(platform_id, req_attrs)
-        log.info("attr.get_platform_attribute_values = %s" % retval)
+        log.info("attr.get_platform_attribute_values(%r, %r) => %s" % (platform_id, req_attrs, retval))
         vals = self._verify_valid_platform_id(platform_id, retval)
         self.assertIsInstance(vals, dict)
         for attrName in attrNames:
@@ -115,8 +117,9 @@ class OmsTestMixin(HelperTestMixin):
         cur_time = ntplib.system_to_ntp_time(time.time())
         from_time = cur_time - 50  # a 50-sec time window
         req_attrs = [(attr_id, from_time) for attr_id in attrNames]
+        log.debug("attr.get_platform_attribute_values(%r, %r)" % (platform_id, req_attrs))
         retval = self.oms.attr.get_platform_attribute_values(platform_id, req_attrs)
-        log.info("attr.get_platform_attribute_values = %s" % retval)
+        log.info("attr.get_platform_attribute_values(%r, %r) => %s" % (platform_id, req_attrs, retval))
         self._verify_invalid_platform_id(platform_id, retval)
 
     def test_ah_get_platform_attribute_values_invalid_attributes(self):
@@ -125,8 +128,9 @@ class OmsTestMixin(HelperTestMixin):
         cur_time = ntplib.system_to_ntp_time(time.time())
         from_time = cur_time - 50  # a 50-sec time window
         req_attrs = [(attr_id, from_time) for attr_id in attrNames]
+        log.debug("attr.get_platform_attribute_values(%r, %r)" % (platform_id, req_attrs))
         retval = self.oms.attr.get_platform_attribute_values(platform_id, req_attrs)
-        log.info("attr.get_platform_attribute_values = %s" % retval)
+        log.info("attr.get_platform_attribute_values(%r, %r) => %s" % (platform_id, req_attrs, retval))
         vals = self._verify_valid_platform_id(platform_id, retval)
         self.assertIsInstance(vals, dict)
         for attrName in attrNames:
@@ -144,9 +148,9 @@ class OmsTestMixin(HelperTestMixin):
             return "test_value_for_%s" % attrName
 
         attrs = [(attrName, valueFor(attrName)) for attrName in attrNames]
+        log.debug("attr.set_platform_attribute_values(%r, %r)" % (platform_id, attrs))
         retval = self.oms.attr.set_platform_attribute_values(platform_id, attrs)
-        log.info("attr.set_platform_attribute_values(%r, %r) => %s" % (
-            platform_id, attrs, retval))
+        log.info("attr.set_platform_attribute_values(%r, %r) => %s" % (platform_id, attrs, retval))
         vals = self._verify_valid_platform_id(platform_id, retval)
         self.assertIsInstance(vals, dict)
         for attrName in attrNames:
@@ -157,7 +161,7 @@ class OmsTestMixin(HelperTestMixin):
 
     def _get_platform_ports(self, platform_id):
         retval = self.oms.port.get_platform_ports(platform_id)
-        log.info("port.get_platform_ports(%r) = %s" % (platform_id, retval))
+        log.info("port.get_platform_ports(%r) => %s" % (platform_id, retval))
         ports = self._verify_valid_platform_id(platform_id, retval)
         return ports
 
@@ -172,18 +176,31 @@ class OmsTestMixin(HelperTestMixin):
     def test_ak_get_platform_ports_invalid_platform_id(self):
         platform_id = BOGUS_PLATFORM_ID
         retval = self.oms.port.get_platform_ports(platform_id)
-        log.info("port.get_platform_ports = %s" % retval)
+        log.info("port.get_platform_ports(%r) => %s" % (platform_id, retval))
         self._verify_invalid_platform_id(platform_id, retval)
 
-    def test_am_connect_instrument(self):
+    def _get_connected_instruments(self, platform_id, port_id):
+        log.debug("instr.get_connected_instruments(%r, %r)" % (platform_id, port_id))
+        retval = self.oms.instr.get_connected_instruments(platform_id, port_id)
+        log.info("instr.get_connected_instruments(%r, %r) => %s" % (platform_id, port_id, retval))
+        ports = self._verify_valid_platform_id(platform_id, retval)
+        port_dic = self._verify_valid_port_id(port_id, ports)
+        self.assertIsInstance(port_dic, dict)
+        return port_dic
+
+    def test_al_get_connected_instruments(self):
         platform_id = self.PLATFORM_ID
         port_id = self.PORT_ID
-        instrument_id = self.INSTRUMENT_ID
-        # TODO proper values
-        attributes = {'maxCurrentDraw': 1, 'initCurrent': 2,
-                      'dataThroughput': 3, 'instrumentType': 'FOO'}
+        self._get_connected_instruments(platform_id, port_id)
+
+    def _connect_instrument(self, platform_id, port_id, instrument_id, attributes):
+        log.debug("instr.connect_instrument(%r, %r, %r, %r)" % (platform_id, port_id, instrument_id, attributes))
         retval = self.oms.instr.connect_instrument(platform_id, port_id, instrument_id, attributes)
-        log.info("instr.connect_instrument = %s" % retval)
+        log.info("instr.connect_instrument(%r, %r, %r, %r) => %s" % (platform_id, port_id, instrument_id, attributes, retval))
+        return retval
+
+    def _connect_instrument_valid(self, platform_id, port_id, instrument_id, attributes):
+        retval = self._connect_instrument(platform_id, port_id, instrument_id, attributes)
         ports = self._verify_valid_platform_id(platform_id, retval)
         port_dic = self._verify_valid_port_id(port_id, ports)
         self.assertIsInstance(port_dic, dict)
@@ -193,16 +210,48 @@ class OmsTestMixin(HelperTestMixin):
                 self.assertTrue(attr_name in instr_val)
                 attr_val = instr_val[attr_name]
                 self.assertEquals(attributes[attr_name], attr_val,
-                    "value given %s different from value received %s" % (
-                        attributes[attr_name], attr_val))
+                                  "value given %s different from value received %s" % (
+                                  attributes[attr_name], attr_val))
+
+    def _disconnect_instrument(self, platform_id, port_id, instrument_id):
+        log.debug("instr.disconnect_instrument(%r, %r, %r)" % (platform_id, port_id, instrument_id))
+        retval = self.oms.instr.disconnect_instrument(platform_id, port_id, instrument_id)
+        log.info("instr.disconnect_instrument(%r, %r, %r) => %s" % (platform_id, port_id, instrument_id, retval))
+        return retval
+
+    def _disconnect_instrument_valid(self, platform_id, port_id, instrument_id):
+        retval = self._disconnect_instrument(platform_id, port_id, instrument_id)
+        ports = self._verify_valid_platform_id(platform_id, retval)
+        port_dic = self._verify_valid_port_id(port_id, ports)
+        self.assertIsInstance(port_dic, dict)
+        self.assertIn(instrument_id, port_dic)
+        self._verify_instrument_disconnected(instrument_id, port_dic[instrument_id])
+
+    def test_am_connect_and_disconnect_instrument(self):
+        platform_id = self.PLATFORM_ID
+        port_id = self.PORT_ID
+        instrument_id = self.INSTRUMENT_ID
+
+        # connect (if not already connected)
+        port_dic = self._get_connected_instruments(platform_id, port_id)
+        if not instrument_id in port_dic:
+            # TODO proper values
+            attributes = {'maxCurrentDraw': 1, 'initCurrent': 2,
+                          'dataThroughput': 3, 'instrumentType': 'FOO'}
+
+            self._connect_instrument_valid(platform_id, port_id, instrument_id, attributes)
+
+        # disconnect:
+        port_dic = self._get_connected_instruments(platform_id, port_id)
+        if instrument_id in port_dic:
+            self._disconnect_instrument_valid(platform_id, port_id, instrument_id)
 
     def test_am_connect_instrument_invalid_platform_id(self):
         platform_id = BOGUS_PLATFORM_ID
         port_id = self.PORT_ID
         instrument_id = self.INSTRUMENT_ID
         attributes = {}
-        retval = self.oms.instr.connect_instrument(platform_id, port_id, instrument_id, attributes)
-        log.info("instr.connect_instrument = %s" % retval)
+        retval = self._connect_instrument(platform_id, port_id, instrument_id, attributes)
         self._verify_invalid_platform_id(platform_id, retval)
 
     def test_am_connect_instrument_invalid_port_id(self):
@@ -210,8 +259,7 @@ class OmsTestMixin(HelperTestMixin):
         port_id = BOGUS_PORT_ID
         instrument_id = self.INSTRUMENT_ID
         attributes = {}
-        retval = self.oms.instr.connect_instrument(platform_id, port_id, instrument_id, attributes)
-        log.info("instr.connect_instrument = %s" % retval)
+        retval = self._connect_instrument(platform_id, port_id, instrument_id, attributes)
         ports = self._verify_valid_platform_id(platform_id, retval)
         self._verify_invalid_port_id(port_id, ports)
 
@@ -220,9 +268,7 @@ class OmsTestMixin(HelperTestMixin):
         port_id = self.PORT_ID
         instrument_id = BOGUS_INSTRUMENT_ID
         attributes = {}
-        retval = self.oms.instr.connect_instrument(platform_id, port_id, instrument_id, attributes)
-        log.info("instr.connect_instrument(%r, %r, %r, %r) => %s" % (
-            platform_id, port_id, instrument_id, attributes, retval))
+        retval = self._connect_instrument(platform_id, port_id, instrument_id, attributes)
         ports = self._verify_valid_platform_id(platform_id, retval)
         port_dic = self._verify_valid_port_id(port_id, ports)
         self.assertIsInstance(port_dic, dict)
@@ -233,21 +279,21 @@ class OmsTestMixin(HelperTestMixin):
         ports = self._get_platform_ports(platform_id)
         for port_id in ports.iterkeys():
             retval = self.oms.port.turn_on_platform_port(platform_id, port_id)
-            log.info("port.turn_on_platform_port(%s,%s) = %s" % (platform_id, port_id, retval))
+            log.info("port.turn_on_platform_port(%s,%s) => %s" % (platform_id, port_id, retval))
             portRes = self._verify_valid_platform_id(platform_id, retval)
             res = self._verify_valid_port_id(port_id, portRes)
             self.assertEquals(res, NormalResponse.PORT_TURNED_ON)
 
     def test_an_turn_on_platform_port_invalid_platform_id(self):
-        # use valid for get_platform_ports
+        # use valid id for get_platform_ports
         platform_id = self.PLATFORM_ID
         ports = self._get_platform_ports(platform_id)
 
-        # use invalid for turn_on_platform_port
+        # use invalid id for turn_on_platform_port
         requested_platform_id = BOGUS_PLATFORM_ID
         for port_id in ports.iterkeys():
             retval = self.oms.port.turn_on_platform_port(requested_platform_id, port_id)
-            log.info("port.turn_on_platform_port(%s,%s) = %s" % (requested_platform_id, port_id, retval))
+            log.info("port.turn_on_platform_port(%r, %r) => %s" % (requested_platform_id, port_id, retval))
             self._verify_invalid_platform_id(requested_platform_id, retval)
 
     def test_ao_turn_off_platform_port(self):
@@ -255,7 +301,7 @@ class OmsTestMixin(HelperTestMixin):
         ports = self._get_platform_ports(platform_id)
         for port_id in ports.iterkeys():
             retval = self.oms.port.turn_off_platform_port(platform_id, port_id)
-            log.info("port.turn_off_platform_port(%s,%s) = %s" % (platform_id, port_id, retval))
+            log.info("port.turn_off_platform_port(%r, %r) => %s" % (platform_id, port_id, retval))
             portRes = self._verify_valid_platform_id(platform_id, retval)
             res = self._verify_valid_port_id(port_id, portRes)
             self.assertEquals(res, NormalResponse.PORT_TURNED_OFF)
@@ -269,7 +315,7 @@ class OmsTestMixin(HelperTestMixin):
         requested_platform_id = BOGUS_PLATFORM_ID
         for port_id in ports.iterkeys():
             retval = self.oms.port.turn_off_platform_port(requested_platform_id, port_id)
-            log.info("port.turn_off_platform_port(%s,%s) = %s" % (requested_platform_id, port_id, retval))
+            log.info("port.turn_off_platform_port(%r, %r) => %s" % (requested_platform_id, port_id, retval))
             self._verify_invalid_platform_id(requested_platform_id, retval)
 
     ###################################################################
@@ -280,18 +326,30 @@ class OmsTestMixin(HelperTestMixin):
     _notifications = []
     _http_server = None
 
+    # Based on the HTTP server launched via start_http_server (if called), or just an ad hoc url.
+    _use_fqdn_for_event_listener = False
+
+    # some dummy value ok for tests only dealing with (un)registration:
+    _url_for_listener = "http://listener.example.org"
+
     @classmethod
-    def start_http_server(cls, host='localhost', port=0):
+    def start_http_server(cls, port=5000):
         """
-        A subclass call this to start a server that handles the reception
-        of events keeping record of them in the member _notifications, which
-        can be consulted directly and it is also returned by stop_http_server.
+        Starts a server on the localhost to handle the reception of events reported by OMS.
+        The received events are kept in the member _notifications, which can be
+        consulted directly and it is also returned by stop_http_server.
+
+        @param port   Port to bind the server to. By default, 5000.
+
+        @return  URL that can be used as a listener for registration with OMS.
+                 This URL is composed based on the port and socket.getfqdn()
+                 if _use_fqdn_for_event_listener is True.
         """
         def application(environ, start_response):
             input = environ['wsgi.input']
             body = "\n".join(input.readlines())
             event_instance = yaml.load(body)
-            log.info('notification received event_instance=%s' % str(event_instance))
+            log.debug('http server received event_instance=%s' % str(event_instance))
 
             cls._notifications.append(event_instance)
 
@@ -300,29 +358,20 @@ class OmsTestMixin(HelperTestMixin):
             start_response(status, headers)
             return status
 
-        if not host:
-            host = socket.getfqdn()
-
         cls._notifications = []
-        cls._http_server = WSGIServer((host, port), application)
-        log.info("HTTP SERVER: starting http server for receiving event notifications...")
+        cls._http_server = WSGIServer(('localhost', port), application)
+        log.debug("starting http server for receiving event notifications...")
         cls._http_server.start()
         address = cls._http_server.address
-        log.info("HTTP SERVER: ... http server started: address: host=%r port=%r" % address)
+        log.info("http server for event listener started on %s:%s" % address)
 
-    @classmethod
-    def __get_url(cls):
-        """
-        Used here to compose the URL for various tests. This URL is based on the
-        HTTP server launched via start_http_server (if called), or just an ad hoc url.
-        """
-        if cls._http_server:
-            # use actual URL corresponding to the launched server
-            url = "http://%s:%s" % cls._http_server.address
+        if cls._use_fqdn_for_event_listener:
+            cls._url_for_listener = "http://%s:%s" % (socket.getfqdn(), address[1])
         else:
-            # use ad hoc url
-            url = "http://localhost:9753"
-        return url
+            cls._url_for_listener = "http://%s:%s" % address
+        log.info("url_for_listener = %s" % cls._url_for_listener)
+
+        return cls._url_for_listener
 
     @classmethod
     def stop_http_server(cls):
@@ -332,7 +381,7 @@ class OmsTestMixin(HelperTestMixin):
         """
         if cls._http_server:
             address = cls._http_server.address
-            log.info("HTTP SERVER: stopping http server: address: host=%r port=%r" % address)
+            log.info("stopping http server: address: host=%r port=%r" % address)
             cls._http_server.stop()
             cls._http_server = None
 
@@ -342,64 +391,88 @@ class OmsTestMixin(HelperTestMixin):
 
     def _get_registered_event_listeners(self):
         listeners = self.oms.event.get_registered_event_listeners()
-        log.info("event.get_registered_event_listeners returned %s" % str(listeners))
+        log.info("event.get_registered_event_listeners() => %s" % str(listeners))
         self.assertIsInstance(listeners, dict)
         return listeners
 
     def _register_event_listener(self, url):
+        log.info("event.register_event_listener(%r)" % url)
         result = self.oms.event.register_event_listener(url)
-        log.info("event.register_event_listener returned %s" % str(result))
+        log.info("event.register_event_listener(%r) => %s" % (url, str(result)))
         self.assertIsInstance(result, dict)
         self.assertEquals(len(result), 1)
         self.assertTrue(url in result)
-        return result[url]
 
-    def _register_one_event_listener(self):
-        url = self.__get_url()
-        res = self._register_event_listener(url)
-
-        # check that it's registered
         listeners = self._get_registered_event_listeners()
         self.assertTrue(url in listeners)
 
-        log.info("_register_one_event_listener: res=%s" % str(res))
-        return url, res
+        def unregister():
+            self._unregister_event_listener(url)
+        self.addCleanup(unregister)
 
-    def test_be_register_event_listener(self):
-        self._register_one_event_listener()
-
-    def test_bg_get_registered_event_listeners(self):
-        self._get_registered_event_listeners()
+        return result[url]
 
     def _unregister_event_listener(self, url):
         result = self.oms.event.unregister_event_listener(url)
-        log.info("event.unregister_event_listener returned %s" % str(result))
+        log.info("event.unregister_event_listener(%r) => %s" % (url, str(result)))
         self.assertIsInstance(result, dict)
         self.assertEquals(len(result), 1)
         self.assertTrue(url in result)
-        return result[url]
-
-    def test_bh_unregister_event_listener(self):
-        listeners = self._get_registered_event_listeners()
-        if len(listeners) == 0:
-            log.info("WARNING: No event listeners to unregister")
-            return
-
-        url = listeners.keys()[0]
-        reg_time = listeners[url]
-        self.assertIsInstance(reg_time, (float, int))
-        self._unregister_event_listener(url)
 
         # check that it's unregistered
         listeners = self._get_registered_event_listeners()
         self.assertTrue(url not in listeners)
+
+        return result[url]
+
+    def test_be_register_and_unregister_event_listener(self):
+        url = self._url_for_listener
+        self._register_event_listener(url)
+        self._unregister_event_listener(url)
 
     def test_bi_unregister_event_listener_not_registered_url(self):
         url = "http://_never_registered_url"
         res = self._unregister_event_listener(url)
         self.assertEquals(0, res)
 
+    def test_generate_test_event_and_reception(self):
+        # 1. start http server for listener:
+        url = self.start_http_server()
+        self.addCleanup(self.stop_http_server)
+
+        # 2. register listener:
+        self._register_event_listener(url)
+
+        # 3. request generation of test event:
+        event = {
+            'message'      : "fake event triggered from CI",
+            'platform_id'  : "some_platform_id",
+            'severity'     : "3",
+            'group '       : "power",
+        }
+        log.debug("event.generate_test_event(%r)" % event)
+        result = self.oms.event.generate_test_event(event)
+        log.info("event.generate_test_event(%r) => %r" % (event, result))
+        self.assertEquals(result, True)
+
+        # 4. wait until test event is notified
+        max_wait = 30
+        log.info("waiting for a max of %d secs for test event to be notified..." % max_wait)
+        wait_until = time.time() + max_wait
+        got_it = None
+        while not got_it and time.time() <= wait_until:
+            time.sleep(1)
+            for evt in self._notifications:
+                if event['message'] == evt['message']:
+                    got_it = evt
+                    break
+
+        self.assertIsNotNone(got_it, "didn't get expected test event notification within %d " \
+                             "secs. (Got %d event notifications.)" % (
+                             max_wait, len(self._notifications)))
+        log.info("got test event: %s" % got_it)
+
     def test_get_checksum(self):
         platform_id = self.PLATFORM_ID
         retval = self.oms.config.get_checksum(platform_id)
-        log.info("config.get_checksum = %s" % retval)
+        log.info("config.get_checksum(%r) => %s" % (platform_id, retval))

--- a/ion/agents/platform/rsn/test/test_oms_client.py
+++ b/ion/agents/platform/rsn/test/test_oms_client.py
@@ -4,7 +4,8 @@
 @package ion.agents.platform.rsn.test.test_oms_client
 @file    ion/agents/platform/rsn/test/test_oms_client.py
 @author  Carlos Rueda
-@brief   Test cases for CIOMSClient.
+@brief   Test cases for CIOMSClient. The OMS enviroment variable can be used
+         to indicate which CIOMSClient will be tested.
 """
 
 __author__ = 'Carlos Rueda'
@@ -26,21 +27,26 @@ import os
 
 @attr('INT', group='sa')
 class Test(IonIntegrationTestCase, OmsTestMixin):
+    """
+    The OMS enviroment variable can be used to indicate which CIOMSClient will
+    be tested. By default, it tests against the simulator, which is launched
+    as an external process.
+    """
 
     @classmethod
     def setUpClass(cls):
         OmsTestMixin.setUpClass()
+        if os.getenv('OMS') == "rsn":
+            # use FQDM for local host if testing against actual RSN OMS:
+            cls._use_fqdn_for_event_listener = True
 
     def setUp(self):
         oms_uri = os.getenv('OMS', "launchsimulator")
         oms_uri = self._dispatch_simulator(oms_uri)
         log.debug("oms_uri = %s", oms_uri)
         self.oms = CIOMSClientFactory.create_instance(oms_uri)
-        OmsTestMixin.start_http_server()
 
         def done():
             CIOMSClientFactory.destroy_instance(self.oms)
-            event_notifications = OmsTestMixin.stop_http_server()
-            log.info("event_notifications = %s" % str(event_notifications))
 
         self.addCleanup(done)

--- a/ion/agents/platform/status_manager.py
+++ b/ion/agents/platform/status_manager.py
@@ -904,7 +904,7 @@ Published event: AGGREGATE_POWER -> STATUS_OK
     def _start_diagnostics_subscriber(self):  # pragma: no cover
         """
         For debugging/diagnostics purposes.
-        Registers a subscriber to DeviceEvent events with origin="command_line"
+        Registers a subscriber to DeviceStatusEvent events with origin="command_line"
         and sub_type="diagnoser" to log the current statuses via log.info.
         This method does nothing if the logging level is not enabled for INFO
         for this module.
@@ -920,7 +920,7 @@ Published event: AGGREGATE_POWER -> STATUS_OK
         if not log.isEnabledFor(logging.INFO):
             return
 
-        event_type  = "DeviceEvent"
+        event_type  = "DeviceStatusEvent"
         origin      = "command_line"
         sub_type    = "diagnoser"
 
@@ -986,7 +986,7 @@ def publish_event_for_diagnostics():  # pragma: no cover
 
     from pyon.event.event import EventPublisher
     ep = EventPublisher()
-    evt = dict(event_type='DeviceEvent', sub_type='diagnoser', origin='command_line')
+    evt = dict(event_type='DeviceStatusEvent', sub_type='diagnoser', origin='command_line')
     print("publishing: %s" % str(evt))
     ep.publish_event(**evt)
 

--- a/ion/agents/platform/test/helper.py
+++ b/ion/agents/platform/test/helper.py
@@ -174,7 +174,8 @@ class HelperTestMixin:
         self.assertIn(attr_id, dic)
         val = dic[attr_id]
         self.assertEquals(InvalidResponse.ATTRIBUTE_ID, val,
-                          "attr_id=%r, val=%r" % (attr_id, val))
+                          "attr_id=%r, val=%r but expected=%r" % (
+                          attr_id, val, InvalidResponse.ATTRIBUTE_ID))
 
     def _verify_attribute_value_out_of_range(self, attr_id, dic):
         """
@@ -184,7 +185,8 @@ class HelperTestMixin:
         self.assertIn(attr_id, dic)
         val = dic[attr_id]
         self.assertEquals(InvalidResponse.ATTRIBUTE_VALUE_OUT_OF_RANGE, val,
-                          "attr_id=%r, val=%r" % (attr_id, val))
+                          "attr_id=%r, val=%r but expected=%r" % (
+                          attr_id, val, InvalidResponse.ATTRIBUTE_VALUE_OUT_OF_RANGE))
 
     def _verify_not_writable_attribute_id(self, attr_id, dic):
         """

--- a/ion/agents/platform/util/network_util.py
+++ b/ion/agents/platform/util/network_util.py
@@ -142,10 +142,9 @@ class NetworkUtil(object):
 
             def build_and_add_attrs_to_node(attrs, pn):
                 for attr_defn in attrs:
-                    assert 'attr_id' in attr_defn
+                    attr_id = _get_attr_id(attr_defn)
                     assert 'monitor_cycle_seconds' in attr_defn
                     assert 'units' in attr_defn
-                    attr_id = attr_defn['attr_id']
                     pn.add_attribute(AttrNode(attr_id, attr_defn))
 
             def build_node(platObj, parent_node):
@@ -460,10 +459,9 @@ class NetworkUtil(object):
 
         def _add_attrs_to_platform_node(attrs, pn):
             for attr_defn in attrs:
-                assert 'attr_id' in attr_defn
+                attr_id = _get_attr_id(attr_defn)
                 assert 'monitor_cycle_seconds' in attr_defn
                 assert 'units' in attr_defn
-                attr_id = attr_defn['attr_id']
                 pn.add_attribute(AttrNode(attr_id, attr_defn))
 
         def _add_ports_to_platform_node(ports, pn):
@@ -531,3 +529,16 @@ class NetworkUtil(object):
         build_platform_node(CFG, ndef._dummy_root)
 
         return ndef
+
+
+def _get_attr_id(attr_defn):
+    if 'attr_id' in attr_defn:
+        attr_id = attr_defn['attr_id']
+    elif 'attr_name' in attr_defn and 'attr_instance' in attr_defn:
+        attr_id = "%s|%s" % (attr_defn['attr_name'], attr_defn['attr_instance'])
+    else:
+        raise PlatformDefinitionException(
+            "Attribute definition does now include 'attr_name' nor 'attr_instance'. "
+            "attr_defn = %s" % attr_defn)
+
+    return attr_id


### PR DESCRIPTION
- generate_test_event implemented in the simulator
- use FQDN for the URL (listener) when testing against real endpoint (so they can resolve the http server)
- initial adjustment related with the identification of platform attributes (based on composition of attr_name and attr_instance)
- use local port 5000 for the event listener (previously 12021): 5000 is more convenient as it is also the default for the gateway_service.
- properly parse listener url for event notification in simulator
- RSNPlatformDriver no longer launches own HTTP server for reception of external OMS events (this functionality is provided by ServiceGatewayService) -- it only registers the corresponding listener URL.
- remove now obsolete dispatch of reception of external event and its publication to the CI in the platform_agent -- this functionality is now provided by the gateway service.
- use DeviceStatusEvent (instead of DeviceEvent) for the internal diagnostics handling

_all_ platform related unit and int tests passing.
