### PR TITLE
enhance create_attachment policy

### DIFF
--- a/ion/processes/bootstrap/load_system_policy.py
+++ b/ion/processes/bootstrap/load_system_policy.py
@@ -452,15 +452,26 @@ class LoadSystemPolicy(ImmediateProcess):
             </Target>
 
             <Condition>
-                <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:not">
-
-                    <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of">
-                        <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
-                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DELETE</AttributeValue>
+                <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:and">
+                    <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:not">
+                        <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of">
+                            <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
+                                <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DELETE</AttributeValue>
+                            </Apply>
+                            <ActionAttributeDesignator
+                                AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-verb"
+                                DataType="http://www.w3.org/2001/XMLSchema#string"/>
                         </Apply>
-                        <ActionAttributeDesignator
-                             AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-verb"
-                             DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                    </Apply>
+                    <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:not">
+                        <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of">
+                            <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
+                                <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">create_attachment</AttributeValue>
+                            </Apply>
+                            <ActionAttributeDesignator
+                                AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id"
+                                DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                        </Apply>
                     </Apply>
                 </Apply>
             </Condition>
@@ -471,6 +482,81 @@ class LoadSystemPolicy(ImmediateProcess):
             'Permit these operations in the Resource Registry Service for the proper roles',
             policy_text, headers=sa_user_header)
 
+
+        ##############
+
+        policy_text = '''
+            <Rule RuleId="%s" Effect="Permit">
+            <Description>
+                %s
+            </Description>
+
+            <Target>
+
+                <Resources>
+                    <Resource>
+                        <ResourceMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">resource_registry</AttributeValue>
+                            <ResourceAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:resource:resource-id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                        </ResourceMatch>
+                    </Resource>
+                </Resources>
+                <Actions>
+                    <Action>
+                        <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">create_attachment</AttributeValue>
+                            <ActionAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                        </ActionMatch>
+                    </Action>
+                </Actions>
+
+                <Subjects>
+                    <Subject>
+                        <SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">INSTRUMENT_OPERATOR</AttributeValue>
+                            <SubjectAttributeDesignator
+                                 AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-role-id"
+                                 DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                        </SubjectMatch>
+                    </Subject>
+                    <Subject>
+                        <SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">OBSERVATORY_OPERATOR</AttributeValue>
+                            <SubjectAttributeDesignator
+                                 AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-role-id"
+                                 DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                        </SubjectMatch>
+                    </Subject>
+                    <Subject>
+                        <SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">DATA_OPERATOR</AttributeValue>
+                            <SubjectAttributeDesignator
+                                 AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-role-id"
+                                 DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                        </SubjectMatch>
+                    </Subject>
+                    <Subject>
+                        <SubjectMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+                            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ORG_MANAGER</AttributeValue>
+                            <SubjectAttributeDesignator
+                                 AttributeId="urn:oasis:names:tc:xacml:1.0:subject:subject-role-id"
+                                 DataType="http://www.w3.org/2001/XMLSchema#string"/>
+                        </SubjectMatch>
+                    </Subject>
+                </Subjects>
+
+            </Target>
+            <Condition>
+                <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:evaluate-function">
+                    <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">check_attachment_policy</AttributeValue>
+                    <ActionAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:param-dict" DataType="http://www.w3.org/2001/XMLSchema#dict"/>
+                </Apply>
+            </Condition>
+        </Rule> '''
+
+        policy_id = policy_client.create_service_access_policy('resource_registry', 'RR_create_attachment_Operation',
+            'Permit create attachment operation only in the context of the org to which the user belongs',
+            policy_text, headers=sa_user_header)
 
         ##############
 

--- a/ion/services/coi/resource_registry_service.py
+++ b/ion/services/coi/resource_registry_service.py
@@ -6,7 +6,7 @@ __license__ = 'Apache 2.0'
 from pyon.core.exception import ServerError
 from pyon.ion.resregistry import ResourceRegistryServiceWrapper
 from pyon.public import log, OT
-from pyon.core.governance import ORG_MANAGER_ROLE, OBSERVATORY_OPERATOR, INSTRUMENT_OPERATOR, GovernanceHeaderValues, has_org_role
+from pyon.core.governance import ORG_MANAGER_ROLE, DATA_OPERATOR, OBSERVATORY_OPERATOR, INSTRUMENT_OPERATOR, GovernanceHeaderValues, has_org_role
 from pyon.public import RT, PRED
 from pyon.core.exception import Inconsistent
 from interface.services.coi.iresource_registry_service import BaseResourceRegistryService
@@ -209,24 +209,24 @@ class ResourceRegistryService(BaseResourceRegistryService):
         resource_id = message.resource_id
 
         resource = self.resource_registry.read(resource_id)
-
         # Allow attachment to an org
         if resource.type_ == 'Org':
-            if (has_org_role(gov_values.actor_roles, resource.org_governance_name, [ORG_MANAGER_ROLE, INSTRUMENT_OPERATOR, OBSERVATORY_OPERATOR])):
+
+            if (has_org_role(gov_values.actor_roles, resource.org_governance_name, [ORG_MANAGER_ROLE, INSTRUMENT_OPERATOR, OBSERVATORY_OPERATOR, DATA_OPERATOR])):
                 return True, ''
 
         # Allow actor to add attachment to his own UserInfo
         elif resource.type_ == 'UserInfo':
+
             actor_identity,_ = self.resource_registry.find_subjects(subject_type=RT.ActorIdentity, predicate=PRED.hasInfo, object=resource_id, id_only=False)
-            if actor_identity == headers['ion-actor-id']:
+            if actor_identity[0]._id == headers['ion-actor-id']:
                 return True, ''
         # Allow actor to add attachment to any resource in an org where the actor has appropriate role
         else:
-            orgs,_ = self.resource_registry.find_subjects(subject_type=RT.Org, predicate=PRED.hasResource, object=resource_id, id_only=False)
 
+            orgs,_ = self.resource_registry.find_subjects(subject_type=RT.Org, predicate=PRED.hasResource, object=resource_id, id_only=False)
             for org in orgs:
-                log.debug(gov_values.actor_roles)
-                if (has_org_role(gov_values.actor_roles, org.org_governance_name, [ORG_MANAGER_ROLE, INSTRUMENT_OPERATOR, OBSERVATORY_OPERATOR])):
+                if (has_org_role(gov_values.actor_roles, org.org_governance_name, [ORG_MANAGER_ROLE, INSTRUMENT_OPERATOR, OBSERVATORY_OPERATOR, DATA_OPERATOR])):
                     return True, ''
 
 

--- a/ion/services/coi/resource_registry_service.py
+++ b/ion/services/coi/resource_registry_service.py
@@ -3,12 +3,12 @@
 
 __author__ = 'Thomas R. Lennan, Michael Meisinger, Stephen Henrie'
 __license__ = 'Apache 2.0'
-import types
-from pyon.core.exception import BadRequest, ServerError
-from pyon.ion.resource import ExtendedResourceContainer
+from pyon.core.exception import ServerError
 from pyon.ion.resregistry import ResourceRegistryServiceWrapper
 from pyon.public import log, OT
-
+from pyon.core.governance import ORG_MANAGER_ROLE, OBSERVATORY_OPERATOR, INSTRUMENT_OPERATOR, GovernanceHeaderValues, has_org_role
+from pyon.public import RT, PRED
+from pyon.core.exception import Inconsistent
 from interface.services.coi.iresource_registry_service import BaseResourceRegistryService
 
 # The following decorator is needed because the couchdb client used in the RR backend
@@ -191,3 +191,43 @@ class ResourceRegistryService(BaseResourceRegistryService):
         return self.resource_registry.prepare_resource_support(resource_type=resource_type, resource_id=resource_id)
 
 
+##
+    ##
+    ##  GOVERNANCE FUNCTION
+    ##
+    ##
+
+
+    def check_attachment_policy(self, process, message, headers):
+
+        try:
+            gov_values = GovernanceHeaderValues(headers=headers, process=process, resource_id_required=False)
+
+        except Inconsistent, ex:
+            return False, ex.message
+
+        resource_id = message.resource_id
+
+        resource = self.resource_registry.read(resource_id)
+
+        # Allow attachment to an org
+        if resource.type_ == 'Org':
+            if (has_org_role(gov_values.actor_roles, resource.org_governance_name, [ORG_MANAGER_ROLE, INSTRUMENT_OPERATOR, OBSERVATORY_OPERATOR])):
+                return True, ''
+
+        # Allow actor to add attachment to his own UserInfo
+        elif resource.type_ == 'UserInfo':
+            actor_identity,_ = self.resource_registry.find_subjects(subject_type=RT.ActorIdentity, predicate=PRED.hasInfo, object=resource_id, id_only=False)
+            if actor_identity == headers['ion-actor-id']:
+                return True, ''
+        # Allow actor to add attachment to any resource in an org where the actor has appropriate role
+        else:
+            orgs,_ = self.resource_registry.find_subjects(subject_type=RT.Org, predicate=PRED.hasResource, object=resource_id, id_only=False)
+
+            for org in orgs:
+                log.debug(gov_values.actor_roles)
+                if (has_org_role(gov_values.actor_roles, org.org_governance_name, [ORG_MANAGER_ROLE, INSTRUMENT_OPERATOR, OBSERVATORY_OPERATOR])):
+                    return True, ''
+
+
+        return False, '%s(%s) has been denied since the user is not a member in any org to which the resource id %s belongs ' % (process.name, gov_values.op, resource_id)


### PR DESCRIPTION
these are purely policy changes but require code to be written in resource_registry. please review.

current policy only allows attachment to orgs, UserInfo, and resources that have an "hasResource" association with a relevant org,
