### PR TITLE
complete OOIION-987 : now also use remove_endpoint

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -1208,12 +1208,7 @@ class PlatformAgent(ResourceAgent):
 
         @param sub   subscriber
         """
-        #self.remove_endpoint(sub) -- why this is making tests fail?
-        # TODO determine whether self.remove_endpoint is the appropriate call
-        # here and if so, how it should be used. For now, calling sub.close()
-        # (this only change made the difference between successful tests and
-        # failing tests that actually never exited -- I had to kill them).
-        sub.close()
+        self.remove_endpoint(sub)
 
     def _prepare_await_state(self, origin, state):
         """

--- a/ion/agents/platform/status_manager.py
+++ b/ion/agents/platform/status_manager.py
@@ -124,11 +124,13 @@ class StatusManager(object):
         self.aparam_rollup_status, self.aparam_child_agg_status.
         """
         def stop_es(origin, es):
+            log.debug("%r: destroying event subscriber: origin=%r; es=%r",
+                      self._platform_id, origin, es)
             try:
                 self._agent._destroy_event_subscriber(es)
             except Exception as ex:
-                log.warn("%r: error destroying event subscriber: origin=%r: %s",
-                         self._platform_id, origin, ex)
+                log.warn("%r: error destroying event subscriber: origin=%r; es=%r: %s",
+                         self._platform_id, origin, es, ex)
 
         with self._lock:
             self._active = False
@@ -141,6 +143,7 @@ class StatusManager(object):
             for status_name in AggregateStatusType._str_map.keys():
                 self.aparam_rollup_status[status_name] = DeviceStatusType.STATUS_UNKNOWN
 
+            log.debug("%r: about to destroy %d event subscribers", self._platform_id, len(ess))
             for origin, es in ess.iteritems():
                 stop_es(origin, es)
 


### PR DESCRIPTION
https://jira.oceanobservatories.org/tasks/browse/OOIION-987

remove_endpoint is working now  (it didn't by the time original work was done on that jira).

Also, the "Listen channel (xxx) close did not respond in time, giving up" warnings," are gone.
