### PR TITLE
rename "PLATFORM_AGENT_SHUTDOWN" -> "PLATFORM_AGENT_SHUTDOWN_CHILDREN" f...

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -91,7 +91,7 @@ class PlatformAgentEvent(BaseEnum):
     GO_ACTIVE                 = ResourceAgentEvent.GO_ACTIVE
     GO_INACTIVE               = ResourceAgentEvent.GO_INACTIVE
     RUN                       = ResourceAgentEvent.RUN
-    SHUTDOWN                  = 'PLATFORM_AGENT_SHUTDOWN'
+    SHUTDOWN                  = 'PLATFORM_AGENT_SHUTDOWN_CHILDREN'
 
     CLEAR                     = ResourceAgentEvent.CLEAR
     PAUSE                     = ResourceAgentEvent.PAUSE


### PR DESCRIPTION
...or the platform shutdown command.  

https://jira.oceanobservatories.org/tasks/browse/OOIION-1303

NOTE: the resulting message is still the current one (just OK). A more qualified message like saying how many children were shutdown, or that no children were running is not implemented yet.
