### PR TITLE
fix OOIION-1305

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -76,7 +76,7 @@ class PlatformAgentState(BaseEnum):
     IDLE              = ResourceAgentState.IDLE
     STOPPED           = ResourceAgentState.STOPPED
     COMMAND           = ResourceAgentState.COMMAND
-    MONITORING        = 'PLATFORM_AGENT_STATE_MONITORING'
+    MONITORING        = 'PLATFORM_AGENT_STATE_AUTOSAMPLE'
     LAUNCHING         = 'PLATFORM_AGENT_STATE_LAUNCHING'
     LOST_CONNECTION   = ResourceAgentState.LOST_CONNECTION
 
@@ -103,8 +103,8 @@ class PlatformAgentEvent(BaseEnum):
     EXECUTE_RESOURCE          = ResourceAgentEvent.EXECUTE_RESOURCE
     GET_RESOURCE_STATE        = ResourceAgentEvent.GET_RESOURCE_STATE
 
-    START_MONITORING          = 'PLATFORM_AGENT_START_MONITORING'
-    STOP_MONITORING           = 'PLATFORM_AGENT_STOP_MONITORING'
+    START_MONITORING          = 'PLATFORM_AGENT_START_AUTOSAMPLE'
+    STOP_MONITORING           = 'PLATFORM_AGENT_STOP_AUTOSAMPLE'
     LAUNCH_COMPLETE           = 'PLATFORM_AGENT_LAUNCH_COMPLETE'
 
     LOST_CONNECTION           = ResourceAgentEvent.LOST_CONNECTION

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -28,7 +28,6 @@ from ion.services.sa.observatory.observatory_management_service import INSTRUMEN
 
 from ion.agents.platform.exceptions import PlatformException
 from ion.agents.platform.platform_driver_event import AttributeValueDriverEvent
-from ion.agents.platform.platform_driver_event import ExternalEventDriverEvent
 from ion.agents.platform.platform_driver_event import StateChangeDriverEvent
 from ion.agents.platform.platform_driver_event import AsyncAgentEvent
 from ion.agents.platform.exceptions import CannotInstantiateDriverException


### PR DESCRIPTION
https://jira.oceanobservatories.org/tasks/browse/OOIION-1305.

do renaming corresponding to "monitoring" state and associated commands so they are exposed as "autosample" instead of "monitoring". Renamed done for the values of the relevant variables, not to the variables themselves. 
