### PR TITLE
Fixes two data product related tests

### DIFF
--- a/ion/services/dm/inventory/test/test_dataset_management.py
+++ b/ion/services/dm/inventory/test/test_dataset_management.py
@@ -38,10 +38,8 @@ class DatasetManagementIntTest(IonIntegrationTestCase):
         
         ds_obj.name = 'something different'
         self.dataset_management.update_dataset(ds_obj)
-        self.dataset_management.register_dataset(dataset_id)
         ds_obj2 = self.dataset_management.read_dataset(dataset_id)
         self.assertEquals(ds_obj.name, ds_obj2.name)
-        self.assertTrue(ds_obj2.registered)
     
     def test_context_crud(self):
         context_ids = self.create_contexts()

--- a/ion/services/sa/product/test/test_data_product_management_service_integration.py
+++ b/ion/services/sa/product/test/test_data_product_management_service_integration.py
@@ -356,8 +356,6 @@ class TestDataProductManagementServiceIntegration(IonIntegrationTestCase):
         tempwat_dp = DataProduct(name='TEMPWAT')
         tempwat_dp_id = self.dpsc_cli.create_data_product(tempwat_dp, stream_definition_id=simple_stream_def_id, parent_data_product_id=dp_id)
         self.addCleanup(self.dpsc_cli.delete_data_product, tempwat_dp_id)
-        self.dpsc_cli.activate_data_product_persistence(tempwat_dp_id)
-        self.addCleanup(self.dpsc_cli.suspend_data_product_persistence, tempwat_dp_id)
         # Check that the streams associated with the data product are persisted with
         stream_ids, _ =  self.rrclient.find_objects(dp_id,PRED.hasStream,RT.Stream,True)
         for stream_id in stream_ids:


### PR DESCRIPTION
Fixes the following failed tests:
- `ion.services.dm.inventory.test.test_dataset_management:DatasetManagementIntTest.test_dataset_crud`
- `ion.services.sa.product.test.test_data_product_management_service_integration:TestDataProductManagementServiceIntegration.test_derived_data_product`

register_dataset no longer takes advantage of the registered attribute
for a dataset resource, so the test no longer needs to verify that.

activate_data_product on a derived data product is now automatic during
creation. Calling activate_data_product on a derived data product
results in a BadRequest being raised, so this test got patched.
