### PR TITLE
OOIION-1343: Extension to import_dataset tool to stop data agents / REL2.0

### DIFF
--- a/ion/processes/data/import_dataset.py
+++ b/ion/processes/data/import_dataset.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 """
-Ask container to start an external dataset agent and put it into streaming mode
-so it will read and relay data from the file into a data product.
+Control an external dataset agent.
+Supports the following ops:
+- start: via DAMS service call, start agent instance and subsequently put it into streaming mode (optionally)
+- stop: via DAMS service call, stop agent instance
 
 If using an external dataset, must have resources already defined in the system (ie- preload):
     ExternalDataset (implies also ExternalDatasetModel, ParameterDictionary, ParameterDefinitions)
@@ -16,66 +18,118 @@ If using an instrument, must have resources already defined in the system:
 
 invoke with command like this:
     bin/pycc -x ion.processes.data.import_dataset.ImportDataset dataset='External CTD Dataset'
-    bin/pycc -x ion.process.data.import_dataset.ImportDataset instrument_device='CTDPF'
+    bin/pycc -x ion.processes.data.import_dataset.ImportDataset instrument='CTDPF'
+    bin/pycc -x ion.processes.data.import_dataset.ImportDataset device_name='uuid' op=start activate=False
+    bin/pycc -x ion.processes.data.import_dataset.ImportDataset agent_name='uuid' op=stop
 """
 
-__author__ = 'Michael Meisinger, Ian Katz, Thomas Lennan'
+__author__ = 'Michael Meisinger, Ian Katz'
 
-
-from pyon.core.bootstrap import get_service_registry
-from pyon.core.exception import ConfigNotFound
-from pyon.public import ImmediateProcess
-from interface.objects import AgentCommand
-from pyon.public import RT, log, PRED
 from pyon.agent.agent import ResourceAgentClient, ResourceAgentEvent
-from ion.services.sa.acquisition.test.test_bulk_data_ingestion import FakeProcess
+from pyon.public import RT, log, PRED, ImmediateProcess, BadRequest, NotFound
+
 from ion.core.includes.mi import DriverEvent
 
-class ImportDataset(ImmediateProcess):
+from interface.objects import AgentCommand
+from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceProcessClient
+
+
+class DataAgentControl(ImmediateProcess):
     def on_start(self):
         rr = self.container.resource_registry
 
-        name = self.CFG.get("dataset")
-        if name: # We are looking for an external dataset!
-            log.trace("Looking for an external dataset with name %s", name)
-            objects,_ = rr.find_resources(RT.ExternalDataset)
-            filtered_objs = [obj for obj in objects if obj.name == name]
-            if (filtered_objs) == []:
-                raise ConfigNotFound("No appropriate ExternalDataset objects loaded")
-            external_dataset = filtered_objs[0]
-    
-            instance_id = rr.read_object(subject=external_dataset._id,
-                                         predicate=PRED.hasAgentInstance,
-                                         object_type=RT.ExternalDatasetAgentInstance,
-                                         id_only=True)
-            dams = get_service_registry().services['data_acquisition_management'].client(process=self)
-            dams.start_external_dataset_agent_instance(instance_id)
-            client = ResourceAgentClient(external_dataset._id, process=FakeProcess())
-        else:
-            name = self.CFG.get("instrument")
-            
-        if name: # We are looking for an instrument device!
-            log.trace("Looking for an instrument device with name %s", name)
-            objects,_ = rr.find_resources(RT.InstrumentDevice)
-            filtered_objs = [obj for obj in objects if obj.name == name]
-            if (filtered_objs) == []:
-                raise ConfigNotFound("No appropriate InstrumentDevice objects loaded")
-            instrument_device = filtered_objs[0]
-            log.trace("Found instrument device: %s", instrument_device)
-    
-            instance_id = rr.read_object(subject=instrument_device._id,
-                                         predicate=PRED.hasAgentInstance,
-                                         object_type=RT.ExternalDatasetAgentInstance,
-                                         id_only=True)
-            dams = get_service_registry().services['data_acquisition_management'].client(process=self)
-            proc_id = dams.start_external_dataset_agent_instance(instance_id)
-            client = ResourceAgentClient(instrument_device._id, process=FakeProcess())
-        else:
-            raise ConfigNotFound("Could not find dataset or instrument_device value name")
+        op = self.CFG.get("op", "start")
+        dataset_name = self.CFG.get("dataset", None)
+        device_name = self.CFG.get("device_name", None) or self.CFG.get("instrument", None)
+        agent_name = self.CFG.get("agent_name", None)
+        resource_name = dataset_name or device_name or agent_name
 
-        log.info('Activating agent...')
-        client.execute_agent(AgentCommand(command=ResourceAgentEvent.INITIALIZE))
-        client.execute_agent(AgentCommand(command=ResourceAgentEvent.GO_ACTIVE))
-        client.execute_agent(AgentCommand(command=ResourceAgentEvent.RUN))
-        client.execute_resource(command=AgentCommand(command=DriverEvent.START_AUTOSAMPLE))
-        log.info('Now reading: %s', name)
+        if not resource_name:
+            raise BadRequest("Must provide ExternalDataset, Device or ExternalDatasetAgentInstance resource name or id")
+
+        print resource_name, type(resource_name)
+
+        resource = None
+        try:
+            log.debug("Looking for a resource with id %s", dataset_name)
+            resource = rr.read(resource_name)
+        except NotFound:
+            pass
+
+        if not resource:
+            if dataset_name:
+                log.debug("Looking for an ExternalDataset with name %s", dataset_name)
+                objects,_ = rr.find_resources(RT.ExternalDataset, name=dataset_name, id_only=False)
+            elif device_name:
+                log.debug("Looking for an InstrumentDevice or PlatformDevice with name %s", dataset_name)
+                objects,_ = rr.find_resources(RT.InstrumentDevice, name=device_name, id_only=False)
+                if not objects:
+                    objects,_ = rr.find_resources(RT.PlatformDevice, name=device_name, id_only=False)
+            elif agent_name:
+                log.debug("Looking for an ExternalDatasetAgentInstance with name %s", dataset_name)
+                objects,_ = rr.find_resources(RT.ExternalDatasetAgentInstance, name=agent_name, id_only=False)
+
+            if not objects:
+                raise BadRequest("Could not find resource with name %s", resource_name)
+            elif len(objects) > 1:
+                log.warn("More than one resource found with name %s. Using id=%s", dataset_name, objects[0])
+            resource = objects[0]
+
+        if resource.type_ in (RT.ExternalDataset, RT.InstrumentDevice, RT.PlatformDevice):
+            resource_id = resource._id
+            eda_instance_id = rr.read_object(subject=resource_id,
+                                         predicate=PRED.hasAgentInstance,
+                                         object_type=RT.ExternalDatasetAgentInstance,
+                                         id_only=True)
+
+        elif resource.type_ == RT.ExternalDatasetAgentInstance:
+            eda_instance_id = resource._id
+            resource_id = rr.read_subject(object=eda_instance_id,
+                                         predicate=PRED.hasAgentInstance,
+                                         id_only=True)
+
+        else:
+            raise BadRequest("Unexpected resource type: %s", resource.type_)
+
+        if op == "start" or op == "load":
+            self._start_agent(eda_instance_id, resource_id)
+        elif op == "stop":
+            self._stop_agent(eda_instance_id, resource_id)
+        else:
+            raise BadRequest("Operation %s unknown", op)
+
+
+    def _start_agent(self, eda_instance_id, resource_id):
+        log.info('Starting agent...')
+        dams = DataAcquisitionManagementServiceProcessClient(process=self)
+        dams.start_external_dataset_agent_instance(eda_instance_id)
+        log.info('Agent started!')
+
+        activate = self.CFG.get("activate", True)
+        if activate:
+            log.info('Activating agent...')
+            client = ResourceAgentClient(resource_id, process=self)
+            client.execute_agent(AgentCommand(command=ResourceAgentEvent.INITIALIZE))
+            client.execute_agent(AgentCommand(command=ResourceAgentEvent.GO_ACTIVE))
+            client.execute_agent(AgentCommand(command=ResourceAgentEvent.RUN))
+            client.execute_resource(command=AgentCommand(command=DriverEvent.START_AUTOSAMPLE))
+
+            log.info('Agent active!')
+
+    def _stop_agent(self, eda_instance_id, resource_id):
+        try:
+            client = ResourceAgentClient(resource_id, process=self)
+        except NotFound:
+            log.warn("Agent for resource %s seems not running", resource_id)
+
+        log.info('Stopping agent...')
+        dams = DataAcquisitionManagementServiceProcessClient(process=self)
+        try:
+            dams.stop_external_dataset_agent_instance(eda_instance_id)
+        except NotFound:
+            log.warn("Agent for resource %s not found", resource_id)
+
+        log.info('Agent stopped!')
+
+
+ImportDataset = DataAgentControl


### PR DESCRIPTION
Extends the command line tool (see comments) to provide 2 operations:
- start (existing, the default): start dataset agent
- stop: stop dataset agent

Extended the number of arguments supported to also include ids and agents
