### PR TITLE
OOIION-1359 Dataset with 22k timesteps takes greater than 20s to retrieve

### DIFF
--- a/ion/processes/data/replay/replay_process.py
+++ b/ion/processes/data/replay/replay_process.py
@@ -135,7 +135,9 @@ class ReplayProcess(BaseReplayProcess):
         for k,v in vdict.iteritems():
             if k == coverage.temporal_parameter_name:
                 continue
-            rdt[k] = v
+            # The values have already been inside a coverage so we know they're safe and they exist, so they can be inserted directly.
+            rdt._rd[k] = v
+            #rdt[k] = v
 
         return rdt
 

--- a/ion/services/dm/test/test_dm_extended.py
+++ b/ion/services/dm/test/test_dm_extended.py
@@ -65,6 +65,14 @@ class TestDMExtended(DMTestCase):
         self.activate_data_product(data_product_id)
         return data_product_id, stream_def_id
 
+    def make_ctd_data_product(self):
+        pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict')
+        stream_def_id = self.create_stream_definition('ctd', parameter_dictionary_id=pdict_id)
+        data_product_id = self.create_data_product('ctd', stream_def_id=stream_def_id)
+        self.activate_data_product(data_product_id)
+        return data_product_id
+
+
     def preload_beta(self):
         config = DotDict()
         config.op = 'load'
@@ -671,6 +679,26 @@ class TestDMExtended(DMTestCase):
         testval = ccov.get_value_dictionary(param_list=['time', 'temp'], domain_slice=(0,120))
         np.testing.assert_array_equal(testval['time'], np.concatenate([np.arange(20,40), np.arange(60,80), np.arange(100,120)]))
         
+    @attr("UTIL")
     def test_locking_contention(self):
         pass
+
+    @attr("UTIL")
+    def test_large_perf(self):
+        self.preload_ui()
+        data_product_id = self.make_ctd_data_product()
+        dataset_id = self.RR2.find_dataset_id_of_data_product_using_has_dataset(data_product_id)
+
+        cov = DatasetManagementService._get_simplex_coverage(dataset_id)
+        cov.insert_timesteps(22000)
+        value_array = np.arange(22000)
+        cov.set_parameter_values('time', value_array)
+        cov.set_parameter_values('temp', value_array)
+        cov.set_parameter_values('conductivity', value_array)
+        cov.set_parameter_values('pressure', value_array)
+
+
+        #self.data_retriever.retrieve(dataset_id)
+        breakpoint(locals(), globals())
+
 


### PR DESCRIPTION
Fixes slowness in Coverage -> RDT
Values coming directly from the coverage model are already vetted and
are capable of being safely stored in another coverage so we don't ened
to rely on the RDT checks and verification subroutines, we can just set
the value arrays directly. Major speed increase.
