### PR TITLE
OOIION-1382 Adds better exception logging to ingestion

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -391,6 +391,15 @@ class ScienceGranuleIngestionWorker(TransformStreamListener, BaseIngestionWorker
                 finally:
                     self._bad_coverages[stream_id] = 1
                     raise CorruptionError(e.message)
+            except IndexError as e:
+                log.error("Value set: %s", v[:])
+                data_products, _ = self.container.resource_registry.find_subjects(object=stream_id, predicate=PRED.hasStream, subject_type=RT.DataProduct)
+                for data_product in data_products:
+                    log.exception("Index exception with %s, trying to insert %s into coverage with shape %s", 
+                                  data_product.name,
+                                  k,
+                                  v.shape)
+
     
         if 'ingestion_timestamp' in coverage.list_parameters():
             t_now = time.time()


### PR DESCRIPTION
Also adds test to verify that the PREST Configuration data product
doesn't get stuck on pressure_sensor_range anymore.

Part of [OOIION-1382](https://jira.oceanobservatories.org/tasks/browse/OOIION-1382)
