### PR TITLE
Changes logging level for gap logging.

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -420,7 +420,7 @@ class ScienceGranuleIngestionWorker(TransformStreamListener, BaseIngestionWorker
         if not self.ignore_gaps:
             gap_found = self.has_gap(rdt.connection_id, rdt.connection_index)
             if gap_found:
-                log.error('Gap Found!   New connection: (%s,%s)\tOld Connection: (%s,%s)', rdt.connection_id, rdt.connection_index, self.connection_id, self.connection_index)
+                log.warning('Gap Found!   New connection: (%s,%s)\tOld Connection: (%s,%s)', rdt.connection_id, rdt.connection_index, self.connection_id, self.connection_index)
                 self.gap_coverage(stream_id)
 
 


### PR DESCRIPTION
It's expected behavior, and relied upon for proper functionality therefore we don't need to log it as an error, but we'll keep it a warning to let everyone who's reading the logs that it is happening.
