### PR TITLE
ooiion-1361 Platform Agent should transition child devices into autosample mode

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -35,6 +35,7 @@ from ion.agents.platform.util.network_util import NetworkUtil
 from ion.agents.agent_alert_manager import AgentAlertManager
 
 from ion.agents.platform.platform_driver import PlatformDriverEvent, PlatformDriverState
+from ion.core.includes.mi import DriverEvent
 
 
 from pyon.util.containers import DotDict
@@ -423,10 +424,10 @@ class PlatformAgent(ResourceAgent):
 
         # get PlatformNode corresponding to this agent:
         self._pnode = self._network_definition.pnodes[self._platform_id]
-        if self._pnode.platform_id != self._platform_id:     
+        if self._pnode.platform_id != self._platform_id:
             msg = "PlatformAgent._validate_configuration: platform ID %r not equal to ID %r of node." % (self._platform_id, self._pnode.platform_id)
             log.error(msg)
-            
+
         log.debug("PlatformAgent._validate_configuration: self._pnode = %s" %self._pnode)
 
         self._children_resource_ids = self._get_children_resource_ids()
@@ -506,7 +507,7 @@ class PlatformAgent(ResourceAgent):
             self._fsm.on_event(PlatformAgentEvent.LAUNCH_COMPLETE)
         except:
             log.exception("PlatformAgent %r: _children_launch greenlet, fsm exception for LAUNCH_COMPLETE event", self._platform_id)
-            
+
         log.info("PlatformAgent %r: _children_launch greenlet stopping", self._platform_id)
 
     def _get_children_resource_ids(self):
@@ -636,7 +637,7 @@ class PlatformAgent(ResourceAgent):
         """
         log.debug("%r: triggering driver event CONNECT", self._platform_id)
         self._trigger_driver_event(PlatformDriverEvent.CONNECT)
-        
+
         self._asp.reset_connection()
 
     def _go_inactive_this_platform(self):
@@ -665,7 +666,7 @@ class PlatformAgent(ResourceAgent):
         log.debug("%r: resetting this platform", self._platform_id)
 
         if self._platform_resource_monitor:
-            self._stop_resource_monitoring()
+            self._stop_resource_monitoring(recursion=True)
 
         if self._plat_driver:
             # disconnect driver if connected:
@@ -677,7 +678,7 @@ class PlatformAgent(ResourceAgent):
             self._plat_driver.destroy()
             self._plat_driver = None
             self._resource_schema = {}
-            
+
         if self._asp:
             self._asp.reset()
 
@@ -868,7 +869,7 @@ class PlatformAgent(ResourceAgent):
 
         if self._platform_id is None:
             msg = "PlatformAgent._create_driver: must know platform_id to create driver"
-            log.error(msg)  
+            log.error(msg)
             raise CannotInstantiateDriverException(msg)
 
         if log.isEnabledFor(logging.DEBUG):
@@ -911,7 +912,7 @@ class PlatformAgent(ResourceAgent):
         if PlatformDriverState.DISCONNECTED != curr_state:
             msg = "PlatformAgent._configure_driver: expected driver state to be %s but got %s" % (
                   PlatformDriverState.DISCONNECTED, curr_state)
-            log.error(msg)  
+            log.error(msg)
             raise PlatformDriverException(msg)
 
         self._resource_schema = self._plat_driver.get_config_metadata()
@@ -927,7 +928,7 @@ class PlatformAgent(ResourceAgent):
         """
         if self._plat_driver is None:
             msg = "PlatformAgent._get_attribute_values: _create_driver must be called first"
-            log.error(msg)  
+            log.error(msg)
             raise PlatformDriverException(msg)
         kwargs = dict(attrs=attrs)
         result = self._plat_driver.get_resource(**kwargs)
@@ -936,7 +937,7 @@ class PlatformAgent(ResourceAgent):
     def _set_attribute_values(self, attrs):
         if self._plat_driver is None:
             msg = "PlatformAgent._set_attribute_values: _create_driver must be called first"
-            log.error(msg)  
+            log.error(msg)
             raise PlatformDriverException(msg)
         kwargs = dict(attrs=attrs)
         result = self._plat_driver.set_resource(**kwargs)
@@ -1184,13 +1185,19 @@ class PlatformAgent(ResourceAgent):
             log.debug("%r: _execute_agent: cmd=%r %s=%r ...",
                       self._platform_id, cmd.command, poi, sub_id)
 
-            time_start = time.time()
+        time_start = time.time()
+
+        if ResourceAgentEvent.has(cmd.command) or PlatformAgentEvent.has(cmd.command):
             retval = a_client.execute_agent(cmd, timeout=self._timeout)
+        elif DriverEvent.has(cmd.command) :
+            retval = a_client.execute_resource(cmd, timeout=self._timeout)
+        else:
+            log.error('_execute_agent invalid command: %s is not ResourceAgentEvent or DriverEvent', cmd)
+
+        if log.isEnabledFor(logging.DEBUG):
             elapsed_time = time.time() - time_start
             log.debug("%r: _execute_agent: cmd=%r %s=%r elapsed_time=%s",
                       self._platform_id, cmd.command, poi, sub_id, elapsed_time)
-        else:
-            retval = a_client.execute_agent(cmd, timeout=self._timeout)
 
         return retval
 
@@ -1552,7 +1559,7 @@ class PlatformAgent(ResourceAgent):
         """
         subplatform_ids = self._get_subplatform_ids()
         if set(subplatform_ids) != set(self._pa_clients.keys()) :
-            raise PlatformException("PlatformAgent._subplatforms_execute_agent: platform ids %s does not equal pa client ids %s ", 
+            raise PlatformException("PlatformAgent._subplatforms_execute_agent: platform ids %s does not equal pa client ids %s ",
                                     subplatform_ids, self._pa_clients.keys())
 
         children_with_errors = {}
@@ -1706,6 +1713,39 @@ class PlatformAgent(ResourceAgent):
 
         return children_with_errors
 
+    def _subplatforms_start_streaming(self):
+        """
+        Executes START_MONITORING with recursion=True on all my sub-platforms.
+
+        @return dict with children having caused some error. Empty if all
+                children were processed OK.
+        """
+        # pass recursion=True to each sub-platform
+        kwargs = dict(recursion=True)
+        cmd = AgentCommand(command=PlatformAgentEvent.START_MONITORING, kwargs=kwargs)
+        children_with_errors = self._subplatforms_execute_agent(
+            command=cmd,
+            expected_state=PlatformAgentState.MONITORING)
+
+        return children_with_errors
+
+    def _subplatforms_stop_streaming(self):
+        """
+        Executes STOP_MONITORING with recursion=True on all my sub-platforms.
+
+        @return dict with children having caused some error. Empty if all
+                children were processed OK.
+        """
+        # pass recursion=True to each sub-platform
+        kwargs = dict(recursion=True)
+        cmd = AgentCommand(command=PlatformAgentEvent.STOP_MONITORING, kwargs=kwargs)
+        children_with_errors = self._subplatforms_execute_agent(
+            command=cmd,
+            expected_state=PlatformAgentState.COMMAND)
+
+        return children_with_errors
+
+
     def _shutdown_and_terminate_subplatform(self, subplatform_id):
         """
         Executes SHUTDOWN with recursion=True on the given sub-platform and
@@ -1809,7 +1849,7 @@ class PlatformAgent(ResourceAgent):
         """
         subplatform_ids = self._get_subplatform_ids()
         if set(subplatform_ids) != set(self._pa_clients.keys()) :
-            raise PlatformException("PlatformAgent._subplatforms_shutdown_and_terminate: platform ids %s does not equal pa client ids %s ", 
+            raise PlatformException("PlatformAgent._subplatforms_shutdown_and_terminate: platform ids %s does not equal pa client ids %s ",
                                     subplatform_ids, self._pa_clients.keys())
 
         children_with_errors = {}
@@ -1970,7 +2010,7 @@ class PlatformAgent(ResourceAgent):
         if i_resource_id is None:
             log.error("PlatformAgent._launch_instrument_agent: agent.resource_id must be present for child %r" % instrument_id)
             return
-              
+
         if i_resource_id != instrument_id:
             log.error("PlatformAgent._launch_instrument_agent: agent.resource_id %r must be equal to %r" % (i_resource_id, instrument_id))
             return
@@ -2026,7 +2066,7 @@ class PlatformAgent(ResourceAgent):
 
             state = ia_client.get_agent_state()
             if ResourceAgentState.UNINITIALIZED != state:
-                log.error("PlatformAgent._launch_instrument_agent: child instrument %r started but state is not %s, it is %s" 
+                log.error("PlatformAgent._launch_instrument_agent: child instrument %r started but state is not %s, it is %s"
                           % (instrument_id, ResourceAgentState.UNINITIALIZED, state))
 
         # here, instrument agent process is running.
@@ -2105,7 +2145,7 @@ class PlatformAgent(ResourceAgent):
         """
         instrument_ids = self._get_instrument_ids()
         if set(instrument_ids) != set(self._ia_clients.keys()) :
-            raise PlatformException("PlatformAgent._instruments_execute_agent: instrument ids %s does not equal ia client ids %s ", 
+            raise PlatformException("PlatformAgent._instruments_execute_agent: instrument ids %s does not equal ia client ids %s ",
                                     instrument_ids, self._ia_clients.keys())
 
         children_with_errors = {}
@@ -2245,6 +2285,35 @@ class PlatformAgent(ResourceAgent):
 
         return children_with_errors
 
+
+    def _instruments_start_streaming(self):
+        """
+        Executes START_AUTOSAMPLE on all my instruments.
+
+        @return dict with children having caused some error. Empty if all
+                children were processed OK.
+        """
+
+        expected_state = None
+        children_with_errors = self._instruments_execute_agent(
+            command=DriverEvent.START_AUTOSAMPLE,
+            expected_state=expected_state)
+
+        return children_with_errors
+
+    def _instruments_stop_streaming(self):
+        """
+        Executes STOP_AUTOSAMPLE on all my instruments.
+
+        @return dict with children having caused some error. Empty if all
+                children were processed OK.
+        """
+        children_with_errors = self._instruments_execute_agent(
+            command=DriverEvent.STOP_AUTOSAMPLE,
+            expected_state=ResourceAgentState.COMMAND)
+
+        return children_with_errors
+
     def _shutdown_and_terminate_instrument(self, instrument_id):
         """
         Executes RESET on the instrument and then terminates it.
@@ -2349,7 +2418,7 @@ class PlatformAgent(ResourceAgent):
         """
         instrument_ids = self._get_instrument_ids()
         if set(instrument_ids) != set(self._ia_clients.keys()) :
-            raise PlatformException("PlatformAgent._instruments_shutdown_and_terminate: instrument ids %s does not equal ia client ids %s ", 
+            raise PlatformException("PlatformAgent._instruments_shutdown_and_terminate: instrument ids %s does not equal ia client ids %s ",
                                     instrument_ids, self._ia_clients.keys())
 
         instruments_with_errors = {}
@@ -2443,7 +2512,7 @@ class PlatformAgent(ResourceAgent):
                 #
                 # Do not proceed further with initialization of children.
                 #
-                msg = ("%r: exception while waiting for children to be launched. " 
+                msg = ("%r: exception while waiting for children to be launched. "
                        "Not proceeding with initialization of children." %self._platform_id)
                 log.exception(msg)
                 raise PlatformException(msg)
@@ -2804,17 +2873,45 @@ class PlatformAgent(ResourceAgent):
         self._clear_this_platform()
         return None
 
-    ##############################################################
-    # main operations *not* involving commands to child agents
-    ##############################################################
 
-    def _start_resource_monitoring(self):
+    def _start_resource_monitoring(self, recursion):
         """
         Starts resource monitoring.
+
+        STREAMING is dispatched in a bottom-up fashion:
+        - if recursion is True, "stream" the children
+        - then "stream" this platform itself.
+
+
+        @param recursion  If True, children are sent the START_STREAMING command
+                          (with corresponding recursion parameter set to True
+                           in the case of platforms).
+
+        @return None if all went ok; otherwise a dict
+                {"subplatforms_with_errors": dict, "instruments_with_errors": dict},
+                where each entry is a dict indicating any errors generated by
+                the corresp children.
         """
+
+
+        if recursion:
+            # first sub-platforms:
+            subplatforms_with_errors = self._subplatforms_start_streaming()
+
+            # we proceed with instruments even if some sub-platforms failed.
+
+            # then my own instruments:
+            instruments_with_errors = self._instruments_start_streaming()
+
+            if len(subplatforms_with_errors) or len(instruments_with_errors):
+                log.warning("%r: some sub-platforms or instruments failed to start streaming. "
+                          "subplatforms_with_errors=%s "
+                          "instruments_with_errors=%s",
+                          self._platform_id, subplatforms_with_errors, instruments_with_errors)
+
         if self._plat_driver is None:
             msg = "PlatformAgent._start_resource_monitoring: _create_driver must be called first"
-            log.error(msg)  
+            log.error(msg)
             raise PlatformDriverException(msg)
 
         self._platform_resource_monitor = PlatformResourceMonitor(
@@ -2823,14 +2920,30 @@ class PlatformAgent(ResourceAgent):
 
         self._platform_resource_monitor.start_resource_monitoring()
 
-    def _stop_resource_monitoring(self):
+    def _stop_resource_monitoring(self, recursion):
         """
         Stops resource monitoring.
         """
+
+        if recursion:
+            # first sub-platforms:
+            subplatforms_with_errors = self._subplatforms_stop_streaming()
+
+            # we proceed with instruments even if some sub-platforms failed.
+
+            # then my own instruments:
+            instruments_with_errors = self._instruments_stop_streaming()
+
+            if len(subplatforms_with_errors) or len(instruments_with_errors):
+                log.warning("%r: some sub-platforms or instruments failed to stop streaming. "
+                          "subplatforms_with_errors=%s "
+                          "instruments_with_errors=%s",
+                          self._platform_id, subplatforms_with_errors, instruments_with_errors)
+
         if self._platform_resource_monitor is None:
             log.error("PlatformAgent._stop_resource_monitoring: _start_resource_monitoring must be called first")
             return
-        
+
         self._platform_resource_monitor.destroy()
         self._platform_resource_monitor = None
 
@@ -3193,8 +3306,10 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
+        recursion = self._get_recursion_parameter("_handler_command_start_resource_monitoring", args, kwargs)
+
         try:
-            result = self._start_resource_monitoring()
+            result = self._start_resource_monitoring(recursion)
 
             next_state = PlatformAgentState.MONITORING
 
@@ -3212,8 +3327,10 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
+        recursion = self._get_recursion_parameter("_handler_command_stop_resource_monitoring", args, kwargs)
+
         try:
-            result = self._stop_resource_monitoring()
+            result = self._stop_resource_monitoring(recursion)
 
             next_state = PlatformAgentState.COMMAND
 
@@ -3281,13 +3398,14 @@ class PlatformAgent(ResourceAgent):
             log.error("PlatformAgent._handler_lost_connection_autoreconnect: %r: Exception while trying CONNECT: %s", self._platform_id, e)
             return None, None
 
-        if driver_state != PlatformDriverState.CONNECTED: 
-            log.error("PlatformAgent._handler_lost_connection_autoreconnect: %r: driver state not %s, it is %s", 
+        if driver_state != PlatformDriverState.CONNECTED:
+            log.error("PlatformAgent._handler_lost_connection_autoreconnect: %r: driver state not %s, it is %s",
                       self._platform_id, PlatformDriverState.CONNECTED, driver_state)
             return None, None
 
         if self._state_when_lost == PlatformAgentState.MONITORING:
-            self._start_resource_monitoring()
+            recursion = self._get_recursion_parameter("_handler_lost_connection_autoreconnect", args, kwargs)
+            self._start_resource_monitoring(recursion)
 
         next_state = self._state_when_lost
 
@@ -3347,7 +3465,7 @@ class PlatformAgent(ResourceAgent):
                   self._platform_id, self._state_when_lost)
 
         if self._platform_resource_monitor:
-            self._stop_resource_monitoring()
+            self._stop_resource_monitoring(recursion=False)
 
         return PlatformAgentState.LOST_CONNECTION, None
 
@@ -3506,4 +3624,3 @@ class PlatformAgent(ResourceAgent):
         self._fsm.add_handler(PlatformAgentState.LOST_CONNECTION, PlatformAgentEvent.AUTORECONNECT, self._handler_lost_connection_autoreconnect)
         self._fsm.add_handler(PlatformAgentState.LOST_CONNECTION, PlatformAgentEvent.GO_INACTIVE, self._handler_lost_connection_go_inactive)
         self._fsm.add_handler(PlatformAgentState.LOST_CONNECTION, PlatformAgentEvent.GET_RESOURCE_STATE, self._handler_get_resource_state)
-

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -1604,8 +1604,9 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         retval = self._execute_agent(cmd)
         self._assert_state(PlatformAgentState.COMMAND)
 
-    def _start_resource_monitoring(self):
-        cmd = AgentCommand(command=PlatformAgentEvent.START_MONITORING)
+    def _start_resource_monitoring(self, recursion=True):
+        kwargs = dict(recursion=recursion)
+        cmd = AgentCommand(command=PlatformAgentEvent.START_MONITORING, kwargs=kwargs)
         retval = self._execute_agent(cmd)
         self._assert_state(PlatformAgentState.MONITORING)
 
@@ -1623,8 +1624,9 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         self.assertTrue(len(self._events_received) >= 1)
         log.info("Received events: %s", len(self._events_received))
 
-    def _stop_resource_monitoring(self):
-        cmd = AgentCommand(command=PlatformAgentEvent.STOP_MONITORING)
+    def _stop_resource_monitoring(self, recursion=True):
+        kwargs = dict(recursion=recursion)
+        cmd = AgentCommand(command=PlatformAgentEvent.STOP_MONITORING, kwargs=kwargs)
         retval = self._execute_agent(cmd)
         self._assert_state(PlatformAgentState.COMMAND)
 

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -100,6 +100,52 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
         self._run_startup_commands()
 
+
+    def test_single_platform_with_instruments_streaming(self):
+        #
+        # basic test of launching a single platform with an instrument
+        #
+        self._set_receive_timeout()
+
+        p_root = self._set_up_single_platform_with_some_instruments(['SBE37_SIM_01', 'SBE37_SIM_02'])
+        self._start_platform(p_root)
+        self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(self._run_shutdown_commands)
+
+        self._run_startup_commands()
+
+        self._start_resource_monitoring()
+
+        self._wait_for_a_data_sample()
+
+        i_obj1 = self._get_instrument('SBE37_SIM_01')
+        #check that the instrument is in streaming mode.
+        _ia_client1 = self._create_resource_agent_client(i_obj1.instrument_device_id)
+        state1 = _ia_client1.get_agent_state()
+        self.assertEquals(state1, ResourceAgentState.STREAMING)
+
+        i_obj2 = self._get_instrument('SBE37_SIM_02')
+        #check that the instrument is in streaming mode.
+        _ia_client2 = self._create_resource_agent_client(i_obj2.instrument_device_id)
+        state2 = _ia_client2.get_agent_state()
+        self.assertEquals(state2, ResourceAgentState.STREAMING)
+
+        log.debug('test_single_platform_with_instruments_streaming  checked streaming started')
+
+        self._stop_resource_monitoring()
+
+        log.debug('test_single_platform_with_instruments_streaming  _stop_resource_monitoring')
+
+        #check that the instrument is NOT in streaming mode.
+        state1 = _ia_client1.get_agent_state()
+        self.assertEquals(state1, ResourceAgentState.COMMAND)
+
+        state2 = _ia_client2.get_agent_state()
+        self.assertEquals(state2, ResourceAgentState.COMMAND)
+
+        log.debug('test_single_platform_with_instruments_streaming  checked streaming stopped')
+
+
     def test_instrument_first_then_platform(self):
         #
         # An instrument is launched first (including its associated port

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -130,11 +130,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         state2 = _ia_client2.get_agent_state()
         self.assertEquals(state2, ResourceAgentState.STREAMING)
 
-        log.debug('test_single_platform_with_instruments_streaming  checked streaming started')
-
         self._stop_resource_monitoring()
-
-        log.debug('test_single_platform_with_instruments_streaming  _stop_resource_monitoring')
 
         #check that the instrument is NOT in streaming mode.
         state1 = _ia_client1.get_agent_state()
@@ -142,8 +138,6 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
         state2 = _ia_client2.get_agent_state()
         self.assertEquals(state2, ResourceAgentState.COMMAND)
-
-        log.debug('test_single_platform_with_instruments_streaming  checked streaming stopped')
 
 
     def test_instrument_first_then_platform(self):


### PR DESCRIPTION
... when it receives the start_autosample command. Add ops in PlatformAgent consistent with pattern to allow start_autosample/stop_autosample to be recursive in the same way that other commands are propogated to child devices. Add test to verify that the child devices enter streaming mode then exit as expected.

@jamie-cyber1  please review
@carueda        please review
