### PR TITLE
Moves the metadata about coverages into the object store

### DIFF
--- a/ion/core/containerui.py
+++ b/ion/core/containerui.py
@@ -754,12 +754,6 @@ def _process_cmd_agent_execute(resource_id, res_obj=None):
     res_str = get_formatted_value(res_dict, fieldtype="dict")
     return res_str
 
-def _process_cmd_last_granule(resource_id, res_obj=None):
-    from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
-    dpms_cl = DataProductManagementServiceClient()
-    response = dpms_cl.get_last_update(res_obj)
-    return "Last Update: " + str(response)
-
 def _process_cmd_deploy(resource_id, res_obj=None):
     li_id = get_arg('deploy')
     from interface.services.sa.iinstrument_management_service import InstrumentManagementServiceClient

--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -203,6 +203,9 @@ class ScienceGranuleIngestionWorker(TransformStreamListener, BaseIngestionWorker
         last_values = doc['last_values']
         rough_size = doc['size']
         for k,v in rdt.iteritems():
+            if k not in bounds:
+                continue
+
             v = v[:].flatten() # Get the numpy representation (dense array).
             # Update the bounds
             l_min = np.min(v)

--- a/ion/services/ans/visualization_service.py
+++ b/ion/services/ans/visualization_service.py
@@ -556,7 +556,7 @@ class VisualizationService(BaseVisualizationService):
         #dp_meta_data['time_bounds'] = [float(ntplib.ntp_to_system_time(i)) for i in time_bounds]
         time_bounds = self.clients.dataset_management.dataset_temporal_bounds(ds_ids[0])
         dp_meta_data['time_bounds'] = time_bounds
-        dp_meta_data['time_steps'] = self.clients.dataset_management.dataset_extents(ds_ids[0])['time'][0]
+        dp_meta_data['time_steps'] = self.clients.dataset_management.dataset_extents_by_axis(ds_ids[0], 'time')
 
         # use the associations to get to the parameter dict
         parameter_display_names = {}

--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -332,7 +332,7 @@ class DatasetManagementService(BaseDatasetManagementService):
         temporal_parameter = pdict.temporal_parameter_name
         units = pdict.get_temporal_context().uom
         bounds = self.dataset_bounds(dataset_id)
-        bounds = bounds[temporal_parameter]
+        bounds = bounds[temporal_parameter or 'time']
         bounds = [TimeUtils.units_to_ts(units, i) for i in bounds]
         return bounds
 
@@ -344,9 +344,13 @@ class DatasetManagementService(BaseDatasetManagementService):
         except NotFound:
             return {}
         if parameters is not None:
-            retval = {}
-            for p in parameters:
-                retval[p] = doc['extents'][p]
+            if isinstance(parameters, list):
+                retval = {}
+                for p in parameters:
+                    retval[p] = doc['extents'][p]
+                return retval
+            elif isinstance(parameters, basestring):
+                return doc['extents'][parameters]
         return doc['extents']
 
 

--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -176,7 +176,7 @@ class TestDMEnd2End(IonIntegrationTestCase):
         done = False
         with gevent.Timeout(40):
             while not done:
-                extents = self.dataset_management.dataset_extents(dataset_id, 'time')[0]
+                extents = self.dataset_management.dataset_extents(dataset_id, 'time')
                 granule = self.data_retriever.retrieve_last_data_points(dataset_id, 1)
                 rdt     = RecordDictionaryTool.load_from_granule(granule)
                 if rdt['time'] and rdt['time'][0] != rdt._pdict.get_context('time').fill_value and extents >= data_size:
@@ -574,8 +574,7 @@ class TestDMEnd2End(IonIntegrationTestCase):
         self.assertTrue(success)
 
 
-    @attr('LOCOINT')
-    @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Host requires file-system access to coverage files, CEI mode does not support.')
+    @unittest.skip('deprecated')
     def test_correct_time(self):
 
         # There are 2208988800 seconds between Jan 1 1900 and Jan 1 1970, i.e. 

--- a/ion/services/sa/product/test/test_coverage.py
+++ b/ion/services/sa/product/test/test_coverage.py
@@ -194,10 +194,6 @@ class TestDataProductManagementServiceCoverage(IonIntegrationTestCase):
         #log.debug("get extension")
         #self.DPMS.get_data_product_extension(dp_id)
 
-        log.debug("getting last update")
-        lastupdate = self.DPMS.get_last_update(dp_id)
-        self.assertEqual({}, lastupdate) # should be no updates to a new data product
-
         log.debug("prepare resource support")
         support = self.DPMS.prepare_data_product_support(dp_id)
         self.assertIsNotNone(support)


### PR DESCRIPTION
- Adds new method to dataset management to deal with latest data (and
  changes).
- Updates ingestion and dataset management to use the object store for
  metedata, avoids loading a coverage at all cost for metadata.
- Updates visualization and data product mgmt to use new format.
- Test(s)

Part of [OOIION-1401](https://jira.oceanobservatories.org/tasks/browse/OOIION-1401)
