### PR TITLE
Fixes key error for dataset_temporal_bounds

### DIFF
--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -325,14 +325,20 @@ class DatasetManagementService(BaseDatasetManagementService):
 
     def dataset_bounds_by_axis(self, dataset_id='', axis=None):
         bounds = self.dataset_bounds(dataset_id)
-        return bounds[axis]
+        if bounds and axis and axis in bounds:
+            return bounds[axis]
+        return {}
 
     def dataset_temporal_bounds(self, dataset_id):
         dataset = self.read_dataset(dataset_id)
+        if not dataset:
+            return {}
         pdict = ParameterDictionary.load(dataset.parameter_dictionary)
         temporal_parameter = pdict.temporal_parameter_name
         units = pdict.get_temporal_context().uom
         bounds = self.dataset_bounds(dataset_id)
+        if not bounds:
+            return {}
         bounds = bounds[temporal_parameter or 'time']
         bounds = [TimeUtils.units_to_ts(units, i) for i in bounds]
         return bounds
@@ -357,7 +363,9 @@ class DatasetManagementService(BaseDatasetManagementService):
 
     def dataset_extents_by_axis(self, dataset_id='', axis=None):
         extents = self.dataset_extents(dataset_id)
-        return extents[axis]
+        if extents and axis and axis in extents:
+            return extents[axis]
+        return {}
 
     def dataset_size(self,dataset_id='', in_bytes=False):
         self.read_dataset(dataset_id) # Validates proper dataset

--- a/ion/services/dm/test/test_dm_extended.py
+++ b/ion/services/dm/test/test_dm_extended.py
@@ -885,3 +885,13 @@ class TestDMExtended(DMTestCase):
         data_product_id = self.create_data_product('CTDBP-NO Parsed', stream_def_id=stream_def_id)
         self.activate_data_product(data_product_id)
         breakpoint(locals(), globals())
+
+    @attr("INT")
+    def test_empty_dataset(self):
+        data_product_id = self.make_ctd_data_product()
+
+        dataset_id = self.RR2.find_dataset_id_of_data_product_using_has_dataset(data_product_id)
+
+        bounds = self.dataset_management.dataset_temporal_bounds(dataset_id)
+        self.assertEquals(bounds, {})
+


### PR DESCRIPTION
The metadata queries now return an empty dict if there is no data.

Associated with the email thread: `Getting Error when trying to retrieve an empty coverage?`
No Jira bug assigned.
