### PR TITLE
Adds better logging to registration

### DIFF
--- a/ion/processes/data/registration/registration_process.py
+++ b/ion/processes/data/registration/registration_process.py
@@ -267,6 +267,10 @@ class RegistrationProcess(StandaloneProcess):
 
         cov.close()
 
+        if not result:
+            log.error("Attempted to register empty dataset\nDims: %s\nDatasets: %s", dims, datasets)
+
+
         return result
 
     def get_ioos_category(self, var_name, units):


### PR DESCRIPTION
For some reason empty strings are being returned by the XML formatter, this should help determine why.
