### PR TITLE
Fixes test failure on centos machines

### DIFF
--- a/ion/processes/data/registration/test/test_registration_process.py
+++ b/ion/processes/data/registration/test/test_registration_process.py
@@ -51,9 +51,9 @@ class RegistrationProcessTest(IonIntegrationTestCase):
         for n in metadata.childNodes:
             if n.nodeType != 3:
                 if n.attributes["name"].value == "title":
-                    self.assertEquals('product_name', n.childNodes[0].nodeValue)
+                    self.assertIn('product_name', n.childNodes[0].nodeValue)
                 if n.attributes["name"].value == "institution":
-                    self.assertEquals('OOI', n.childNodes[0].nodeValue)
+                    self.assertIn('OOI', n.childNodes[0].nodeValue)
                 if n.attributes["name"].value == "infoUrl":
                     self.assertIn(self.rp.pydap_url+cov.name, n.childNodes[0].nodeValue)
         parameters = []


### PR DESCRIPTION
Fixes broken test on CentOS machines

```
======================================================================
FAIL: test_get_dataset_to_xml (test_registration_process.RegistrationProcessTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/buildbot-runner/cloud_1/coi_nightly/build/ion/processes/data/registration/test/test_registration_process.py", line 54, in test_get_dataset_to_xml
    self.assertEquals('product_name', n.childNodes[0].nodeValue)
AssertionError: 'product_name' != u'\n\t\t\tproduct_name\n\t\t'
```
