### PR TITLE
OOIION-1504: Fix deployment in OOI preload

### DIFF
--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -364,6 +364,8 @@ class UserNotificationEventsTest(PyonTestCase):
     ]
 
     def test_get_recent_events(self):
+        self.uns.CFG = Mock()
+        self.uns.CFG.get_safe = Mock(return_value=1000)
         self._load_mock_events(self.event_list1)
 
         res_list = self.uns.get_recent_events(resource_id="ID_1")

--- a/ion/services/dm/presentation/user_notification_service.py
+++ b/ion/services/dm/presentation/user_notification_service.py
@@ -493,13 +493,15 @@ class UserNotificationService(BaseUserNotificationService):
 
         return event
 
-    def get_recent_events(self, resource_id='', limit=2000):
+    def get_recent_events(self, resource_id='', limit=0):
         """
         Get recent events for use in extended resource computed attribute
         @param resource_id str
-        @param limit int
+        @param limit int (if 0 is given
         @retval ComputedListValue with value list of 4-tuple with Event objects
         """
+        if limit == 0:
+            limit = int(self.CFG.get_safe("service.user_notification.max_events_limit", 1000))
         return self.get_events(resource_id=resource_id, limit=limit, offset=0)
 
     def get_events(self, resource_id='', limit=10, offset=0):

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -255,6 +255,7 @@ class AgentConfigurationBuilder(object):
         pdict_stream_defs = self.RR2.find_stream_definition_ids_by_parameter_dictionary_using_has_parameter_dictionary(pdict_id)
         stream_def_id = self.RR2.find_stream_definition_id_of_data_product_using_has_stream_definition(dp_id)
         result = stream_def_id if stream_def_id in pdict_stream_defs else None
+
         return result
 
 
@@ -277,19 +278,19 @@ class AgentConfigurationBuilder(object):
         data_product_objs = self.RR2.find_data_products_of_instrument_device_using_has_output_product(device_id)
 
         stream_config = {}
-        for d in data_product_objs:
-            stream_def_id = self.RR2.find_stream_definition_id_of_data_product_using_has_stream_definition(d._id)
+        for dp in data_product_objs:
+            stream_def_id = self.RR2.find_stream_definition_id_of_data_product_using_has_stream_definition(dp._id)
             for stream_name, stream_info_dict in streams_dict.items():
                 # read objects from cache to be compared
                 pdict = self.RR2.find_resource_by_name(RT.ParameterDictionary, stream_info_dict.get('param_dict_name'))
-                stream_def_id = self._find_streamdef_for_dp_and_pdict(d._id, pdict._id)
+                stream_def_id = self._find_streamdef_for_dp_and_pdict(dp._id, pdict._id)
 
                 if stream_def_id:
                     #model_param_dict = self.RR2.find_resources_by_name(RT.ParameterDictionary,
                     #                                         stream_info_dict.get('param_dict_name'))[0]
                     #model_param_dict = self._get_param_dict_by_name(stream_info_dict.get('param_dict_name'))
                     #stream_route = self.RR2.read(product_stream_id).stream_route
-                    product_stream_id = self.RR2.find_stream_id_of_data_product_using_has_stream(d._id)
+                    product_stream_id = self.RR2.find_stream_id_of_data_product_using_has_stream(dp._id)
                     stream_def = psm.read_stream_definition(stream_def_id)
                     stream_route = psm.read_stream_route(stream_id=product_stream_id)
 
@@ -303,12 +304,15 @@ class AgentConfigurationBuilder(object):
                     stream_config[stream_name] = {  'routing_key'           : stream_route.routing_key,  # TODO: Serialize stream_route together
                                                     'stream_id'             : product_stream_id,
                                                     'stream_definition_ref' : stream_def_id,
-                                                    'stream_def_dict'       : stream_def_dict,
+                                                    'stream_def_dict'       : stream_def_dict,  # This is very large
                                                     'exchange_point'        : stream_route.exchange_point,
                                                     # TODO: This is redundant and very large - the param dict is in the stream_def_dict ???
                                                     'parameter_dictionary'  : stream_def.parameter_dictionary,
 
                     }
+        if len(stream_config) < len(streams_dict):
+            log.warn("Found only %s matching streams by stream definition (%s) than %s defined in the agent (%s).",
+                     len(stream_config), stream_config.keys(), len(streams_dict), streams_dict.keys())
 
         log.debug("Stream config generated")
         log.trace("generate_stream_config: %s", stream_config)

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -306,8 +306,8 @@ class AgentConfigurationBuilder(object):
                                                     'stream_definition_ref' : stream_def_id,
                                                     'stream_def_dict'       : stream_def_dict,  # This is very large
                                                     'exchange_point'        : stream_route.exchange_point,
-                                                    # TODO: This is redundant and very large - the param dict is in the stream_def_dict ???
-                                                    'parameter_dictionary'  : stream_def.parameter_dictionary,
+                                                    # This is redundant and very large - the param dict is in the stream_def_dict
+                                                    #'parameter_dictionary'  : stream_def.parameter_dictionary,
 
                     }
         if len(stream_config) < len(streams_dict):

--- a/ion/services/sa/observatory/deployment_activator.py
+++ b/ion/services/sa/observatory/deployment_activator.py
@@ -42,7 +42,7 @@ class DeploymentOperatorFactory(object):
         new_object_type = self.creation_type()
 
         # a bundled, integrated platform
-        if OT.RemotePlatformDeploymentContext == deployment_context_type:
+        if deployment_context_type in (OT.RemotePlatformDeploymentContext, OT.MobileAssetDeploymentContext):
             return new_object_type(self.clients,
                                    deployment_obj,
                                    allow_children=True,

--- a/ion/services/sa/observatory/observatory_util.py
+++ b/ion/services/sa/observatory/observatory_util.py
@@ -311,21 +311,22 @@ class ObservatoryUtil(object):
                 child_sites[res_id] = res_obj or self.RR.read(res_id) if include_sites else None
 
             site_devices = self.get_device_relations(child_sites.keys())
-            device_list = [tup[1] for key,dev_list in site_devices.iteritems() if dev_list for tup in dev_list]
+            device_list = list({tup[1] for key,dev_list in site_devices.iteritems() if dev_list for tup in dev_list})
 
         elif res_type in [RT.PlatformDevice, RT.InstrumentDevice]:
             # See if current device has child devices
-            device_list = self.get_child_devices(res_id)
+            device_list = list(set(self.get_child_devices(res_id)))
 
         else:
             raise BadRequest("Unsupported resource type: %s" % res_type)
 
-        res_list = device_list + child_sites.keys() if child_sites is not None else []
-        device_dps = self.get_resource_data_products(res_list)
         device_objs = self.RR.read_mult(device_list) if include_devices else None
 
+        res_list = device_list + child_sites.keys() if child_sites is not None else []
+        device_dps = self.get_resource_data_products(res_list)
+
         if include_data_products:
-            dpid_list = [dp_id for device_id, dp_list in device_dps.iteritems() if dp_list is not None for dp_id in dp_list if dp_id is not None]
+            dpid_list = list({dp_id for device_id, dp_list in device_dps.iteritems() if dp_list is not None for dp_id in dp_list if dp_id is not None})
             dpo_list = self.RR.read_mult(dpid_list)
             dp_objs = dict(zip(dpid_list, dpo_list))
         else:

--- a/ion/util/enhanced_resource_registry_client.py
+++ b/ion/util/enhanced_resource_registry_client.py
@@ -59,7 +59,7 @@ class EnhancedResourceRegistryClient(object):
 
     def __init__(self, rr_client):
         self.id = id(self)
-        log.info("EnhancedResourceRegistryClient[%s] init", self.id)
+        log.debug("EnhancedResourceRegistryClient[%s] init", self.id)
         self.RR = rr_client
 
         log.debug("Generating lookup tables for %s resources and their labels", len(RT.values()))


### PR DESCRIPTION
Please merge ion-definitions first
- Distinguish deployments by node type
- Enable deployment of MobileAssetDeploymentContext
- Add check to IMS/DAMS for persistence enabled before activation of platform (data) agent
- Set UNS max events limit to 2000 in ion-definitions
- Returns of get_site_data_products unique
