### PR TITLE
ooiion-1374 Platform agent must manage port power for child devices : add test and defaults 

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -2614,7 +2614,7 @@ class PlatformAgent(ResourceAgent):
                             instruments_with_errors=instruments_with_errors)
 
         # then myself:
-        self._go_inactive_this_platform()
+        self._go_inactive_this_platform(recursion=recursion)
         return None
 
     def _run(self, recursion):

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -742,9 +742,12 @@ class PlatformAgentConfigurationBuilder(AgentConfigurationBuilder):
         log.debug(' port assignments for platform  %s', port_assignments)
 
         # Create driver config.
-        add_driver_config = {
-            'ports' : port_assignments,
-        }
+        if 'attributes' in driver_config and driver_config['attributes']:
+            add_driver_config = { 'ports' : port_assignments, }
+        else:
+            #attributes should be an empty dict if none are provided
+            add_driver_config = { 'ports' : port_assignments, 'attributes' : {}, }
+
         self._augment_dict("Platform Agent driver_config", driver_config, add_driver_config)
 
         return driver_config


### PR DESCRIPTION
Updates for this bug after additional testing 
- add test (must run locally) for RSN hardware
- set default for driver_config.attributes 
- add a recursion param to go_inactive

@jamie-cyber1 please review
@crueda please review
