### PR TITLE
fix OOIION-1372; includes new specific test

### DIFF
--- a/ion/agents/platform/platform_resource_monitor.py
+++ b/ion/agents/platform/platform_resource_monitor.py
@@ -4,7 +4,7 @@
 @package ion.agents.platform.platform_resource_monitor
 @file    ion/agents/platform/platform_resource_monitor.py
 @author  Carlos Rueda
-@brief   Platform resource monitoring
+@brief   Platform resource monitoring handling for all the associated attributes
 """
 
 __author__ = 'Carlos Rueda'

--- a/ion/agents/platform/resource_monitor.py
+++ b/ion/agents/platform/resource_monitor.py
@@ -4,7 +4,7 @@
 @package ion.agents.platform.resource_monitor
 @file    ion/agents/platform/resource_monitor.py
 @author  Carlos Rueda
-@brief   Platform resource monitoring
+@brief   Platform resource monitoring for a set of attributes having same rate
 """
 
 __author__ = 'Carlos Rueda'
@@ -33,10 +33,14 @@ _STREAM_NAME = "parsed"
 # Since "ION system time" is in milliseconds, this delta is in milliseconds.
 _DELTA_TIME = 10
 
+# _MULT_INTERVAL: for any request, the from_time parameter will be at most
+# _MULT_INTERVAL * _rate_secs in the past wrt current time (OOIION-1372):
+_MULT_INTERVAL = 3
+
 
 class ResourceMonitor(object):
     """
-    Monitor for specific attributes in a given platform.
+    Monitor for specific attributes having the same nominal monitoring rate.
     """
 
     def __init__(self, platform_id, rate_secs, attr_defns,
@@ -64,15 +68,17 @@ class ResourceMonitor(object):
         self._attr_defns = attr_defns
         self._notify_driver_event = notify_driver_event
 
-        # corresponding attribute IDs to be retrieved and "ION System time"
-        # compliant timestamp of last retrieved value for each attribute:
+        # corresponding attribute IDs to be retrieved
         self._attr_ids = []
-        self._last_ts = {}
+        # and "ION System time" compliant timestamp of last retrieved value for
+        # each attribute:
+        self._last_ts_millis = {}
+
         for attr_defn in self._attr_defns:
             if 'attr_id' in attr_defn:
                 attr_id = attr_defn['attr_id']
                 self._attr_ids.append(attr_id)
-                self._last_ts[attr_id] = None
+                self._last_ts_millis[attr_id] = None
             else:
                 log.warn("%r: 'attr_id' key expected in attribute definition: %s",
                          self._platform_id, attr_defn)
@@ -134,20 +140,33 @@ class ResourceMonitor(object):
         # CGSN so eventually adjustments may be needed.
         #
 
-        current_time_secs = current_time_millis() / 1000.0
+        # note that the "from_time" parameter in each pair (attr_id, from_time)
+        # for the _get_attribute_values call below, is in millis in UNIX epoch.
+
+        curr_time_millis = current_time_millis()
+
+        # minimum value for the from_time parameter (OOIION-1372):
+        min_from_time = curr_time_millis - 1000 * _MULT_INTERVAL * self._rate_secs
+        # this corresponds to (_MULT_INTERVAL * self._rate_secs) ago.
 
         # determine each from_time for the request:
         attrs = []
         for attr_id in self._attr_ids:
-            if self._last_ts[attr_id] is None:
-                # Arbitrarily setting from_time to current system time minus a few seconds:
-                # TODO: determine actual criteria here.
-                win_size_secs = 5
-                from_time = current_time_secs - win_size_secs
+            if self._last_ts_millis[attr_id] is None:
+                # Very first request for this attribute. Use min_from_time:
+                from_time = min_from_time
 
             else:
-                # note that int(x) returns a long object if needed.
-                from_time = int(self._last_ts[attr_id]) + _DELTA_TIME
+                # We've already got values for this attribute. Use the latest
+                # timestamp + _DELTA_TIME as a basis for the new request:
+                from_time = int(self._last_ts_millis[attr_id]) + _DELTA_TIME
+
+                # but adjust it if it goes too far in the past:
+                if from_time < min_from_time:
+                    from_time = min_from_time
+
+            log.trace("test_resource_monitoring_recent: attr_id=%s, from_time=%s, %s millis ago",
+                      attr_id, from_time, curr_time_millis - from_time)
 
             attrs.append((attr_id, from_time))
 
@@ -227,14 +246,14 @@ class ResourceMonitor(object):
         corresponding event to platform agent.
         """
 
-        # update _last_ts for each retrieved attribute:
+        # update _last_ts_millis for each retrieved attribute:
         for attr_id, attr_vals in vals_dict.iteritems():
 
             _, ntp_ts = attr_vals[-1]
 
-            # update _last_ts based on ntp_ts: note that timestamps are reported
+            # update _last_ts_millis based on ntp_ts: note that timestamps are reported
             # in NTP so we need to convert it to ION system time for a subsequent request:
-            self._last_ts[attr_id] = ntp_2_ion_ts(ntp_ts)
+            self._last_ts_millis[attr_id] = ntp_2_ion_ts(ntp_ts)
 
         # finally, notify the values event:
         driver_event = AttributeValueDriverEvent(self._platform_id,


### PR DESCRIPTION
Fix https://jira.oceanobservatories.org/tasks/browse/OOIION-1372

(new PR because had some trouble with conflicts with the previous one).

test_resource_monitoring_recent is the specific test:

```
bin/nosetests -sv --nologcapture ion/agents/platform/test/test_platform_agent_with_rsn.py:TestPlatformAgent.test_resource_monitoring_recent
...
2013-12-05 08:30:11,056 INFO Dummy-7 ion.agents.platform.test.test_platform_agent_with_rsn:747 test_resource_monitoring_recent: using attr_id='input_bus_current': monitor_cycle_seconds=5
2013-12-05 08:30:11,056 INFO Dummy-7 ion.agents.platform.test.test_platform_agent_with_rsn:753 test_resource_monitoring_recent: sleeping for 30 secs before resuming monitoring
...
2013-12-05 08:30:41,057 INFO Dummy-7 ion.agents.platform.test.test_platform_agent_with_rsn:762 test_resource_monitoring_recent: re-starting monitoring
...
2013-12-05 08:30:53,877 INFO Dummy-7 ion.agents.platform.test.test_platform_agent_with_rsn:785 test_resource_monitoring_recent: sample received, min_reported_time_millis=1386261044000
```

@MauriceManning please review
