### PR TITLE
OOIION-1552 Fix handling of recursion parameter in the platform agent's FSM handler

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -1212,6 +1212,12 @@ class PlatformAgent(ResourceAgent):
     def _get_recursion_parameter(self, method_name, *args, **kwargs):
         """
         Utility to extract the 'recursion' parameter.
+
+        @param method_name   for logging purposes
+        @param *args         as received by FSM handler (not used)
+        @param *kwargs       as received by FSM handler
+        @return              The boolean value of the 'recursion' parameter in
+                             kwargs; True by default.
         """
         recursion = kwargs.get('recursion', None)
         if recursion is None:
@@ -2982,7 +2988,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_uninitialized_initialize", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_uninitialized_initialize", *args, **kwargs)
 
         next_state = PlatformAgentState.INACTIVE
         result = self._initialize(recursion)
@@ -3000,7 +3006,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_inactive_reset", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_inactive_reset", *args, **kwargs)
 
         next_state = PlatformAgentState.UNINITIALIZED
         result = self._reset(recursion)
@@ -3017,7 +3023,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_inactive_go_active", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_inactive_go_active", *args, **kwargs)
 
         next_state = PlatformAgentState.IDLE
         result = self._go_active(recursion)
@@ -3035,7 +3041,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_idle_reset", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_idle_reset", *args, **kwargs)
 
         next_state = PlatformAgentState.UNINITIALIZED
         result = self._reset(recursion)
@@ -3052,7 +3058,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_idle_go_inactive", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_idle_go_inactive", *args, **kwargs)
 
         next_state = PlatformAgentState.INACTIVE
         result = self._go_inactive(recursion)
@@ -3069,7 +3075,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_idle_run", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_idle_run", *args, **kwargs)
 
         next_state = PlatformAgentState.COMMAND
         result = self._run(recursion)
@@ -3087,7 +3093,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_stopped_reset", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_stopped_reset", *args, **kwargs)
 
         next_state = PlatformAgentState.UNINITIALIZED
         result = self._reset(recursion)
@@ -3104,7 +3110,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                       self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_stopped_go_inactive", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_stopped_go_inactive", *args, **kwargs)
 
         next_state = PlatformAgentState.INACTIVE
         result = self._go_inactive(recursion)
@@ -3122,7 +3128,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_stopped_resume", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_stopped_resume", *args, **kwargs)
 
         next_state = PlatformAgentState.COMMAND
         result = self._resume(recursion)
@@ -3140,7 +3146,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_stopped_clear", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_stopped_clear", *args, **kwargs)
 
         next_state = PlatformAgentState.IDLE
         result = self._clear(recursion)
@@ -3161,7 +3167,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_command_reset", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_command_reset", *args, **kwargs)
 
         next_state = PlatformAgentState.UNINITIALIZED
         result = self._reset(recursion)
@@ -3179,7 +3185,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_command_clear", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_command_clear", *args, **kwargs)
 
         next_state = PlatformAgentState.IDLE
         result = self._clear(recursion)
@@ -3197,7 +3203,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_command_pause", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_command_pause", *args, **kwargs)
 
         next_state = PlatformAgentState.STOPPED
         result = self._pause(recursion)
@@ -3314,7 +3320,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_command_start_resource_monitoring", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_start_resource_monitoring", *args, **kwargs)
 
         try:
             result = self._start_resource_monitoring(recursion)
@@ -3335,7 +3341,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                 self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_command_stop_resource_monitoring", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_stop_resource_monitoring", *args, **kwargs)
 
         try:
             result = self._stop_resource_monitoring(recursion)
@@ -3412,7 +3418,7 @@ class PlatformAgent(ResourceAgent):
             return None, None
 
         if self._state_when_lost == PlatformAgentState.MONITORING:
-            recursion = self._get_recursion_parameter("_handler_lost_connection_autoreconnect", args, kwargs)
+            recursion = self._get_recursion_parameter("_handler_lost_connection_autoreconnect", *args, **kwargs)
             self._start_resource_monitoring(recursion)
 
         next_state = self._state_when_lost
@@ -3429,7 +3435,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                       self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_lost_connection_reset", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_lost_connection_reset", *args, **kwargs)
 
         next_state = PlatformAgentState.UNINITIALIZED
         result = self._reset(recursion)
@@ -3446,7 +3452,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                       self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_lost_connection_go_inactive", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_lost_connection_go_inactive", *args, **kwargs)
 
         next_state = PlatformAgentState.INACTIVE
         result = self._go_inactive(recursion)
@@ -3484,7 +3490,7 @@ class PlatformAgent(ResourceAgent):
             log.trace("%r/%s args=%s kwargs=%s",
                       self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        recursion = self._get_recursion_parameter("_handler_shutdown", args, kwargs)
+        recursion = self._get_recursion_parameter("_handler_shutdown", *args, **kwargs)
 
         next_state = PlatformAgentState.UNINITIALIZED
         result = self._shutdown(recursion)
@@ -3632,4 +3638,3 @@ class PlatformAgent(ResourceAgent):
         self._fsm.add_handler(PlatformAgentState.LOST_CONNECTION, PlatformAgentEvent.AUTORECONNECT, self._handler_lost_connection_autoreconnect)
         self._fsm.add_handler(PlatformAgentState.LOST_CONNECTION, PlatformAgentEvent.GO_INACTIVE, self._handler_lost_connection_go_inactive)
         self._fsm.add_handler(PlatformAgentState.LOST_CONNECTION, PlatformAgentEvent.GET_RESOURCE_STATE, self._handler_get_resource_state)
-

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -9,7 +9,6 @@
 from interface.objects import ComputedIntValue, ComputedValueAvailability, ComputedListValue, ComputedDictValue
 from ion.services.sa.test.helpers import any_old
 from pyon.ion.resource import RT
-from ion.agents.instrument.instrument_agent import InstrumentAgentState
 from interface.objects import AggregateStatusType, DeviceStatusType
 
 __author__ = 'Carlos Rueda, Maurice Manning, Ian Katz'
@@ -24,8 +23,13 @@ __license__ = 'Apache 2.0'
 
 # developer conveniences:
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_platform
+# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_deployed_platform
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_hierarchy
+# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_hierarchy_recursion_false
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_platform_with_an_instrument
+# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_ims_instrument_status
+# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_ims_platform_status
+# bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_platform_with_an_instrument_and_deployments
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_platform_with_instruments_streaming
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_instrument_first_then_platform
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_13_platforms_and_1_instrument
@@ -60,18 +64,18 @@ class FakeProcess(LocalContextMixin):
 @unittest.skipIf((not os.getenv('PYCC_MODE', False)) and os.getenv('CEI_LAUNCH_TEST', False), 'Skip until tests support launch port agent configurations.')
 class TestPlatformLaunch(BaseIntTestPlatform):
 
-    def _run_startup_commands(self):
+    def _run_startup_commands(self, recursion=True):
         self._ping_agent()
-        self._initialize()
-        self._go_active()
-        self._run()
+        self._initialize(recursion)
+        self._go_active(recursion)
+        self._run(recursion)
 
-    def _run_shutdown_commands(self):
+    def _run_shutdown_commands(self, recursion=True):
         try:
-            self._go_inactive()
-            self._reset()
+            self._go_inactive(recursion)
+            self._reset(recursion)
         finally:  # attempt shutdown anyway
-            self._shutdown()
+            self._shutdown(True)  # NOTE: shutdown always with recursion=True
 
     def test_single_platform(self):
         #
@@ -123,6 +127,27 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         self.addCleanup(self._run_shutdown_commands)
 
         self._run_startup_commands()
+
+    def test_hierarchy_recursion_false(self):
+        #
+        # As with test_hierarchy but with recursion=False.
+        # There are no particular asserts here, but the test should complete
+        # fine and the logs should show that the recursion parameter is properly
+        # reflected with value false in the root platform, except for the
+        # final shutdown as we want a graceful shutdown of the whole hierarchy.
+        #
+        self._set_receive_timeout()
+
+        p_root = self._create_small_hierarchy()
+        self._start_platform(p_root)
+        self.addCleanup(self._stop_platform, p_root)
+
+        def shutdown_commands():
+            self._run_shutdown_commands(recursion=False)
+
+        self.addCleanup(shutdown_commands)
+
+        self._run_startup_commands(recursion=False)
 
     def test_single_platform_with_an_instrument(self):
         #


### PR DESCRIPTION
So the recursion parameter is properly captured in the platform agent's FSM handlers.

Includes specific test exercising recursion=False with a small platform hierarchy: ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_hierarchy_recursion_false

Fixes specific jira: https://jira.oceanobservatories.org/tasks/browse/OOIION-1552

@MauriceManning please review/merge.
