### PR TITLE
elasticsearch limit added to query_geo_bbox

### DIFF
--- a/ion/services/dm/presentation/discovery_service.py
+++ b/ion/services/dm/presentation/discovery_service.py
@@ -560,6 +560,7 @@ class DiscoveryService(BaseDiscoveryService):
                 field        = query['field'],
                 top_left     = query['top_left'],
                 bottom_right = query['bottom_right'],
+                limit        = limit,
                 id_only      = id_only,
             )
             if query.get('limit'):


### PR DESCRIPTION
no limit was specified in the ES call so was defaulting to 10 (internal ES default)

fixes OOIION-1528
