### PR TITLE
fix OOIION-1564 remove the 'network' property for platform ports

### DIFF
--- a/ion/agents/platform/rsn/oms_util.py
+++ b/ion/agents/platform/rsn/oms_util.py
@@ -117,7 +117,7 @@ class RsnOmsUtil(object):
                     "not a dict: %s" % (platform_id, ports))
 
             for port_id, dic in ports.iteritems():
-                port = PortNode(port_id, dic['network'])
+                port = PortNode(port_id)
                 port.set_state(dic['state'])
                 pnode.add_port(port)
 

--- a/ion/agents/platform/rsn/simulator/network.yml
+++ b/ion/agents/platform/rsn/simulator/network.yml
@@ -6,6 +6,9 @@
 #
 # Noteworthy changes:
 #
+# 2013-12-06: remove 'network' attribute for platform ports (per change in
+# the CI-OMS spec a while ago)
+#
 # 2012-12-31: systematic renaming: "Node.._attr_1" -> "input_voltage" per
 # definition in the "Parameter definitions" spreadsheet and in preparation for
 # IOC demo.
@@ -41,9 +44,7 @@ network:
     monitor_cycle_seconds: 5
   ports:
   - port_id: ShoreStation_port_1
-    network: ShoreStation_port_1_IP
   - port_id: ShoreStation_port_2
-    network: ShoreStation_port_2_IP
   subplatforms:
   - platform_id: L3-UPS1
     platform_types: []
@@ -97,9 +98,7 @@ network:
       monitor_cycle_seconds: 5
     ports:
     - port_id: Node1A_port_1
-      network: Node1A_port_1_IP
     - port_id: Node1A_port_2
-      network: Node1A_port_2_IP
     subplatforms:
     - platform_id: MJ01A
       platform_types: []
@@ -122,9 +121,7 @@ network:
         monitor_cycle_seconds: 5
       ports:
       - port_id: MJ01A_port_1
-        network: MJ01A_port_1_IP
       - port_id: MJ01A_port_2
-        network: MJ01A_port_2_IP
     - platform_id: Node1B
       platform_types: []
       attrs:
@@ -147,9 +144,7 @@ network:
         monitor_cycle_seconds: 5
       ports:
       - port_id: Node1B_port_1
-        network: Node1B_port_1_IP
       - port_id: Node1B_port_2
-        network: Node1B_port_2_IP
       subplatforms:
       - platform_id: Node1C
         platform_types: []
@@ -173,9 +168,7 @@ network:
           monitor_cycle_seconds: 5
         ports:
         - port_id: Node1C_port_1
-          network: Node1C_port_1_IP
         - port_id: Node1C_port_2
-          network: Node1C_port_2_IP
         subplatforms:
         - platform_id: Node1D
           platform_types: []
@@ -218,9 +211,7 @@ network:
             monitor_cycle_seconds: 10
           ports:
           - port_id: Node1D_port_1
-            network: Node1D_port_1_IP
           - port_id: Node1D_port_2
-            network: Node1D_port_2_IP
           subplatforms:
           - platform_id: MJ01C
             platform_types: []
@@ -263,9 +254,7 @@ network:
               monitor_cycle_seconds: 4
             ports:
             - port_id: MJ01C_port_1
-              network: MJ01C_port_1_IP
             - port_id: MJ01C_port_2
-              network: MJ01C_port_2_IP
             subplatforms:
             - platform_id: LJ01D
               platform_types: []
@@ -307,10 +296,8 @@ network:
                 group: pressure
                 monitor_cycle_seconds: 4
               ports:
-              - port_id: '1'
-                network: LJ01D_port_1_IP
-              - port_id: '2'
-                network: LJ01D_port_2_IP
+              - port_id: 1
+              - port_id: 2
         - platform_id: LV01C
           platform_types: []
           attrs:
@@ -332,9 +319,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: LV01C_port_1
-            network: LV01C_port_1_IP
           - port_id: LV01C_port_2
-            network: LV01C_port_2_IP
           subplatforms:
           - platform_id: PC01B
             platform_types: []
@@ -357,9 +342,7 @@ network:
               monitor_cycle_seconds: 5
             ports:
             - port_id: PC01B_port_1
-              network: PC01B_port_1_IP
             - port_id: PC01B_port_2
-              network: PC01B_port_2_IP
             subplatforms:
             - platform_id: SC01B
               platform_types: []
@@ -382,9 +365,7 @@ network:
                 monitor_cycle_seconds: 5
               ports:
               - port_id: SC01B_port_1
-                network: SC01B_port_1_IP
               - port_id: SC01B_port_2
-                network: SC01B_port_2_IP
               subplatforms:
               - platform_id: SF01B
                 platform_types: []
@@ -407,9 +388,7 @@ network:
                   monitor_cycle_seconds: 5
                 ports:
                 - port_id: SF01B_port_1
-                  network: SF01B_port_1_IP
                 - port_id: SF01B_port_2
-                  network: SF01B_port_2_IP
           - platform_id: LJ01C
             platform_types: []
             attrs:
@@ -431,9 +410,7 @@ network:
               monitor_cycle_seconds: 5
             ports:
             - port_id: LJ01C_port_1
-              network: LJ01C_port_1_IP
             - port_id: LJ01C_port_2
-              network: LJ01C_port_2_IP
       - platform_id: LV01B
         platform_types: []
         attrs:
@@ -455,9 +432,7 @@ network:
           monitor_cycle_seconds: 5
         ports:
         - port_id: LV01B_port_1
-          network: LV01B_port_1_IP
         - port_id: LV01B_port_2
-          network: LV01B_port_2_IP
         subplatforms:
         - platform_id: LJ01B
           platform_types: []
@@ -480,9 +455,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: LJ01B_port_1
-            network: LJ01B_port_1_IP
           - port_id: LJ01B_port_2
-            network: LJ01B_port_2_IP
         - platform_id: MJ01B
           platform_types: []
           attrs:
@@ -504,9 +477,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: MJ01B_port_1
-            network: MJ01B_port_1_IP
           - port_id: MJ01B_port_2
-            network: MJ01B_port_2_IP
     - platform_id: LV01A
       platform_types: []
       attrs:
@@ -528,9 +499,7 @@ network:
         monitor_cycle_seconds: 5
       ports:
       - port_id: LV01A_port_1
-        network: LV01A_port_1_IP
       - port_id: LV01A_port_2
-        network: LV01A_port_2_IP
       subplatforms:
       - platform_id: LJ01A
         platform_types: []
@@ -553,9 +522,7 @@ network:
           monitor_cycle_seconds: 5
         ports:
         - port_id: LJ01A_port_1
-          network: LJ01A_port_1_IP
         - port_id: LJ01A_port_2
-          network: LJ01A_port_2_IP
       - platform_id: PC01A
         platform_types: []
         attrs:
@@ -577,9 +544,7 @@ network:
           monitor_cycle_seconds: 5
         ports:
         - port_id: PC01A_port_1
-          network: PC01A_port_1_IP
         - port_id: PC01A_port_2
-          network: PC01A_port_2_IP
         subplatforms:
         - platform_id: SC01A
           platform_types: []
@@ -602,9 +567,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: SC01A_port_1
-            network: SC01A_port_1_IP
           - port_id: SC01A_port_2
-            network: SC01A_port_2_IP
           subplatforms:
           - platform_id: SF01A
             platform_types: []
@@ -627,9 +590,7 @@ network:
               monitor_cycle_seconds: 5
             ports:
             - port_id: SF01A_port_1
-              network: SF01A_port_1_IP
             - port_id: SF01A_port_2
-              network: SF01A_port_2_IP
   - platform_id: Node5A
     platform_types: []
     attrs:
@@ -652,9 +613,7 @@ network:
       monitor_cycle_seconds: 5
     ports:
     - port_id: Node5A_port_1
-      network: Node5A_port_1_IP
     - port_id: Node5A_port_2
-      network: Node5A_port_2_IP
     subplatforms:
     - platform_id: Node3A
       platform_types: []
@@ -678,9 +637,7 @@ network:
         monitor_cycle_seconds: 5
       ports:
       - port_id: Node3A_port_1
-        network: Node3A_port_1_IP
       - port_id: Node3A_port_2
-        network: Node3A_port_2_IP
       subplatforms:
       - platform_id: Node3B
         platform_types: []
@@ -704,9 +661,7 @@ network:
           monitor_cycle_seconds: 5
         ports:
         - port_id: Node3B_port_1
-          network: Node3B_port_1_IP
         - port_id: Node3B_port_2
-          network: Node3B_port_2_IP
         subplatforms:
         - platform_id: MJ03F
           platform_types: []
@@ -729,9 +684,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: MJ03F_port_1
-            network: MJ03F_port_1_IP
           - port_id: MJ03F_port_2
-            network: MJ03F_port_2_IP
         - platform_id: MJ03E
           platform_types: []
           attrs:
@@ -753,9 +706,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: MJ03E_port_1
-            network: MJ03E_port_1_IP
           - port_id: MJ03E_port_2
-            network: MJ03E_port_2_IP
         - platform_id: MJ03D
           platform_types: []
           attrs:
@@ -777,9 +728,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: MJ03D_port_1
-            network: MJ03D_port_1_IP
           - port_id: MJ03D_port_2
-            network: MJ03D_port_2_IP
         - platform_id: MJ03C
           platform_types: []
           attrs:
@@ -801,9 +750,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: MJ03C_port_1
-            network: MJ03C_port_1_IP
           - port_id: MJ03C_port_2
-            network: MJ03C_port_2_IP
         - platform_id: MJ03B
           platform_types: []
           attrs:
@@ -825,9 +772,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: MJ03B_port_1
-            network: MJ03B_port_1_IP
           - port_id: MJ03B_port_2
-            network: MJ03B_port_2_IP
       - platform_id: MJ03A
         platform_types: []
         attrs:
@@ -849,9 +794,7 @@ network:
           monitor_cycle_seconds: 5
         ports:
         - port_id: MJ03A_port_1
-          network: MJ03A_port_1_IP
         - port_id: MJ03A_port_2
-          network: MJ03A_port_2_IP
       - platform_id: LV03A
         platform_types: []
         attrs:
@@ -873,9 +816,7 @@ network:
           monitor_cycle_seconds: 5
         ports:
         - port_id: LV03A_port_1
-          network: LV03A_port_1_IP
         - port_id: LV03A_port_2
-          network: LV03A_port_2_IP
         subplatforms:
         - platform_id: LJ03A
           platform_types: []
@@ -898,9 +839,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: LJ03A_port_1
-            network: LJ03A_port_1_IP
           - port_id: LJ03A_port_2
-            network: LJ03A_port_2_IP
         - platform_id: PC03A
           platform_types: []
           attrs:
@@ -922,9 +861,7 @@ network:
             monitor_cycle_seconds: 5
           ports:
           - port_id: PC03A_port_1
-            network: PC03A_port_1_IP
           - port_id: PC03A_port_2
-            network: PC03A_port_2_IP
           subplatforms:
           - platform_id: SC03A
             platform_types: []
@@ -947,9 +884,7 @@ network:
               monitor_cycle_seconds: 5
             ports:
             - port_id: SC03A_port_1
-              network: SC03A_port_1_IP
             - port_id: SC03A_port_2
-              network: SC03A_port_2_IP
             subplatforms:
             - platform_id: SF03A
               platform_types: []
@@ -972,6 +907,4 @@ network:
                 monitor_cycle_seconds: 5
               ports:
               - port_id: SF03A_port_1
-                network: SF03A_port_1_IP
               - port_id: SF03A_port_2
-                network: SF03A_port_2_IP

--- a/ion/agents/platform/rsn/simulator/oms_simulator.py
+++ b/ion/agents/platform/rsn/simulator/oms_simulator.py
@@ -217,8 +217,7 @@ class CIOMSSimulator(CIOMSClient):
 
         ports = {}
         for port_id, port in self._pnodes[platform_id].ports.iteritems():
-            ports[port_id] = {'network': port.network,
-                              'state'  : port.state}
+            ports[port_id] = {'state'  : port.state}
 
         return {platform_id: ports}
 

--- a/ion/agents/platform/rsn/test/oms_test_mixin.py
+++ b/ion/agents/platform/rsn/test/oms_test_mixin.py
@@ -170,7 +170,6 @@ class OmsTestMixin(HelperTestMixin):
         ports = self._get_platform_ports(platform_id)
         for port_id, info in ports.iteritems():
             self.assertIsInstance(info, dict)
-            self.assertIn('network', info)
             self.assertIn('state',   info)
 
     def test_ak_get_platform_ports_invalid_platform_id(self):

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -252,6 +252,7 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
     @classmethod
     def setUpClass(cls):
         HelperTestMixin.setUpClass()
+        cls._pp = pprint.PrettyPrinter()
 
     def setUp(self):
 
@@ -309,10 +310,9 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
             pnode = self._network_definition.pnodes[platform_id]
             dic = {}
             for port_id, port in pnode.ports.iteritems():
-                dic[port_id] = dict(port_id=port_id,
-                                    network=port.network)
+                dic[port_id] = dict(port_id=port_id)
             self._platform_ports[platform_id] = dic
-        log.trace("_platform_ports: %s", self._platform_attributes)
+        log.trace("_platform_ports: %s", self._pp.pformat(self._platform_ports))
 
         self._async_data_result = AsyncResult()
         self._data_subscribers = []
@@ -333,8 +333,6 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
 
         # see _set_receive_timeout
         self._receive_timeout = 177
-
-        self._pp = pprint.PrettyPrinter()
 
     def _set_receive_timeout(self):
         """
@@ -1645,7 +1643,6 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         self.assertIsInstance(ports, dict)
         for port_id, info in ports.iteritems():
             self.assertIsInstance(info, dict)
-            self.assertIn('network', info)
             self.assertIn('state', info)
         return ports
 

--- a/ion/agents/platform/util/network.py
+++ b/ion/agents/platform/util/network.py
@@ -119,8 +119,8 @@ class AttrNode(BaseNode):
         # properties:
         hash_obj.update("attribute_properties:")
         for key in sorted(self.defn.keys()):
-            val = self.defn[key]
-            hash_obj.update("%s=%s;" % (key, val))
+                val = self.defn[key]
+                hash_obj.update("%s=%s;" % (key, val))
     
         return hash_obj.hexdigest()
         
@@ -130,28 +130,22 @@ class PortNode(BaseNode):
     Represents a platform port.
 
     self._port_id
-    self._network = value of the network associated to the port, eg., "10.30.78.x"
     self._instruments = { instrument_id: InstrumentNode, ... }
 
     """
-    def __init__(self, port_id, network):
+    def __init__(self, port_id):
         BaseNode.__init__(self)
-        self._port_id = port_id
-        self._network = network
+        self._port_id = str(port_id)
         self._instruments = {}
         self._state = None
 
     def __repr__(self):
-        return "PortNode{id=%s, network=%s}" % (
-            self._port_id, self._network)
+        return "PortNode{id=%s}" % (
+            self._port_id)
 
     @property
     def port_id(self):
         return self._port_id
-
-    @property
-    def network(self):
-        return self._network
 
     @property
     def state(self):
@@ -186,10 +180,6 @@ class PortNode(BaseNode):
             return "Port IDs are different: %r != %r" % (
                 self.port_id, other.port_id)
 
-        if self.network != other.network:
-            return "Port network values are different: %r != %r" % (
-                self.network, other.network)
-
         if self.state != other.state:
             return "Port state values are different: %r != %r" % (
                 self.state, other.state)
@@ -213,9 +203,6 @@ class PortNode(BaseNode):
 
         # id:
         hash_obj.update("port_id=%s;" % self.port_id)
-
-        # network:
-        hash_obj.update("port_network=%s;" % self.network)
 
         # state:
         hash_obj.update("port_state=%s;" % self.state)

--- a/ion/agents/platform/util/network_util.py
+++ b/ion/agents/platform/util/network_util.py
@@ -129,10 +129,8 @@ class NetworkUtil(object):
             def build_and_add_ports_to_node(ports, pn):
                 for port_info in ports:
                     assert 'port_id' in port_info
-                    assert 'network' in port_info
                     port_id = port_info['port_id']
-                    network = port_info['network']
-                    port = PortNode(port_id, network)
+                    port = PortNode(port_id)
                     port.set_state(port_info.get('state', None))
                     if 'instruments' in port_info:
                         for instrument in port_info['instruments']:
@@ -236,7 +234,6 @@ class NetworkUtil(object):
                 lines.append('  ports:')
                 for port_id, port in pnode.ports.iteritems():
                     lines.append('  - port_id: %s' % port_id)
-                    lines.append('    network: %s' % port.network)
 
                     # instruments
                     if len(port.instruments):
@@ -474,11 +471,8 @@ class NetworkUtil(object):
             for port_info in ports:
                 if not 'port_id' in port_info:
                     raise PlatformDefinitionException("_add_ports_to_platform_node(): 'port_id' not in port_info")
-                if not 'network' in port_info:
-                    raise PlatformDefinitionException("_add_ports_to_platform_node(): 'network' not in port_info")
                 port_id = port_info['port_id']
-                network = port_info['network']
-                port = PortNode(port_id, network)
+                port = PortNode(port_id)
                 pn.add_port(port)
 
         def build_platform_node(CFG, parent_node):

--- a/ion/agents/platform/util/test/test_network_util.py
+++ b/ion/agents/platform/util/test/test_network_util.py
@@ -174,10 +174,8 @@ class Test(IonUnitTestCase):
                               'dvr_cls': 'RSNPlatformDriver',
                               'dvr_mod': 'ion.agents.platform.rsn.rsn_platform_driver',
                               'oms_uri': 'embsimulator',
-                              'ports': {'Node1D_port_1': {'network': 'Node1D_port_1_IP',
-                                                          'port_id': 'Node1D_port_1'},
-                                        'Node1D_port_2': {'network': 'Node1D_port_2_IP',
-                                                          'port_id': 'Node1D_port_2'}},
+                              'ports': {'Node1D_port_1': {'port_id': 'Node1D_port_1'},
+                                        'Node1D_port_2': {'port_id': 'Node1D_port_2'}},
                               },
 
 
@@ -203,10 +201,8 @@ class Test(IonUnitTestCase):
                                                                                 'dvr_cls': 'RSNPlatformDriver',
                                                                                 'dvr_mod': 'ion.agents.platform.rsn.rsn_platform_driver',
                                                                                 'oms_uri': 'embsimulator',
-                                                                                'ports': {'MJ01C_port_1': {'network': 'MJ01C_port_1_IP',
-                                                                                                           'port_id': 'MJ01C_port_1'},
-                                                                                          'MJ01C_port_2': {'network': 'MJ01C_port_2_IP',
-                                                                                                           'port_id': 'MJ01C_port_2'}}},
+                                                                                'ports': {'MJ01C_port_1': {'port_id': 'MJ01C_port_1'},
+                                                                                          'MJ01C_port_2': {'port_id': 'MJ01C_port_2'}}},
 
                                                               'children': {'d0203cb9eb844727b7a8eea77db78e89': {'agent': {'resource_id': 'd0203cb9eb844727b7a8eea77db78e89'},
                                                                                                                 'platform_config': {'platform_id': 'LJ01D'},
@@ -250,10 +246,8 @@ class Test(IonUnitTestCase):
                                                                                                                                   'dvr_cls': 'RSNPlatformDriver',
                                                                                                                                   'dvr_mod': 'ion.agents.platform.rsn.rsn_platform_driver',
                                                                                                                                   'oms_uri': 'embsimulator',
-                                                                                                                                  'ports': {'LJ01D_port_1': {'network': 'LJ01D_port_1_IP',
-                                                                                                                                                             'port_id': '1'},
-                                                                                                                                            'LJ01D_port_2': {'network': 'LJ01D_port_2_IP',
-                                                                                                                                                             'port_id': '2'}}},
+                                                                                                                                  'ports': {'LJ01D_port_1': {'port_id': '1'},
+                                                                                                                                            'LJ01D_port_2': {'port_id': '2'}}},
                                                                                                                 'children': {},
                                                                                                                 }
                                                               }


### PR DESCRIPTION
to reflect corresponding removal in the CI-OMS interface specification.

Usual tests ok, except ion.agents.platform.rsn.test.test_rsn_platform_driver, which has already been failing apparently upon previous changes related with OOIION-1495 (still under investigation)
