### PR TITLE
fix Ooiion 1551

### DIFF
--- a/ion/agents/platform/rsn/simulator/oms_values.py
+++ b/ion/agents/platform/rsn/simulator/oms_values.py
@@ -109,7 +109,7 @@ def _create_sine_generator(sine_period, gen_period, min_val, max_val):
     return _gen
 
 
-# generators per platform/attribute:
+# generators per platform-ID/attribute-name:
 _plat_attr_generators = {
     # we used to have a couple here, but now none for the moment.
 
@@ -122,7 +122,7 @@ _plat_attr_generators = {
 }
 
 
-# generators per attribute:
+# generators per attribute name:
 _attribute_generators = {
 
     'input_voltage':
@@ -160,18 +160,22 @@ def generate_values(platform_id, attr_id, from_time, to_time):
     inclusive). Times are NTP.
 
     @param platform_id  Platform ID
-    @param attr_id      Attribute ID
+    @param attr_id      Attribute ID. Only the name part is considered. See OOIION-1551.
     @param from_time    lower limit of desired time window
     @param to_time      upper limit of desired time window
     """
 
+    # get the attribute name from the given ID:
+    separator = attr_id.rfind('|')
+    attr_name = attr_id[:separator] if separator >= 0 else attr_id
+
     # try by platform/attribute:
-    if (platform_id, attr_id) in _plat_attr_generators:
-        gen = _plat_attr_generators[(platform_id, attr_id)]
+    if (platform_id, attr_name) in _plat_attr_generators:
+        gen = _plat_attr_generators[(platform_id, attr_name)]
 
     # else: try by the attribute only:
-    elif attr_id in _attribute_generators:
-        gen = _attribute_generators[attr_id]
+    elif attr_name in _attribute_generators:
+        gen = _attribute_generators[attr_name]
 
     else:
         gen = _default_generator

--- a/ion/agents/platform/rsn/test/test_oms_util.py
+++ b/ion/agents/platform/rsn/test/test_oms_util.py
@@ -65,14 +65,14 @@ class Test(IonIntegrationTestCase, HelperTestMixin):
         pnode = ndef.root
 
         self.assertEqual(pnode.platform_id, "ShoreStation")
-        self.assertTrue("ShoreStation_attr_1" in pnode.attrs)
-        self.assertTrue("ShoreStation_port_1" in pnode.ports)
+        self.assertIn("ShoreStation_attr_1|0", pnode.attrs)
+        self.assertIn("ShoreStation_port_1", pnode.ports)
 
         sub_pnodes = pnode.subplatforms
-        self.assertTrue("L3-UPS1" in sub_pnodes)
-        self.assertTrue("Node1A" in sub_pnodes)
-        self.assertTrue("input_voltage" in sub_pnodes["Node1A"].attrs)
-        self.assertTrue("Node1A_port_1" in sub_pnodes["Node1A"].ports)
+        self.assertIn("L3-UPS1",       sub_pnodes)
+        self.assertIn("Node1A",        sub_pnodes)
+        self.assertIn("input_voltage|0", sub_pnodes["Node1A"].attrs)
+        self.assertIn("Node1A_port_1", sub_pnodes["Node1A"].ports)
 
     def _get_checksum(self, platform_id):
         # get checksum from RSN OMS:

--- a/ion/agents/platform/test/helper.py
+++ b/ion/agents/platform/test/helper.py
@@ -99,8 +99,8 @@ class HelperTestMixin:
 
         cls.PLATFORM_ID           = 'Node1D'
         cls.SUBPLATFORM_IDS       = ['MJ01C']
-        cls.ATTR_NAMES            = ['input_voltage', 'input_bus_current']
-        cls.WRITABLE_ATTR_NAMES   = ['input_bus_current']
+        cls.ATTR_NAMES            = ['input_voltage|0', 'input_bus_current|0']
+        cls.WRITABLE_ATTR_NAMES   = ['input_bus_current|0']
         cls.VALID_ATTR_VALUE      = "7"     # within the range
         cls.INVALID_ATTR_VALUE    = "9876"  # out of range
 
@@ -124,8 +124,8 @@ class HelperTestMixin:
             cls.PLATFORM_ID = 'LJ01D'
             print("PLAT_NETWORK=single -> using base platform: %r" % cls.PLATFORM_ID)
             cls.SUBPLATFORM_IDS = []
-            cls.ATTR_NAMES = ['input_voltage', 'input_bus_current']
-            cls.WRITABLE_ATTR_NAMES = ['input_bus_current']
+            cls.ATTR_NAMES = ['input_voltage|0', 'input_bus_current|0']
+            cls.WRITABLE_ATTR_NAMES = ['input_bus_current|0']
 
             cls.PORT_ID = '1'
             cls.INSTRUMENT_ID = 'LJ01D_port_1_instrument_1'

--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -699,8 +699,10 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self._run()
 
         self._start_resource_monitoring()
-        self._wait_for_a_data_sample()
-        self._stop_resource_monitoring()
+        try:
+            self._wait_for_a_data_sample()
+        finally:
+            self._stop_resource_monitoring()
 
     def test_resource_monitoring_recent(self):
         #

--- a/ion/agents/platform/test/test_platform_resource_monitor.py
+++ b/ion/agents/platform/test/test_platform_resource_monitor.py
@@ -76,33 +76,33 @@ class Test(IonUnitTestCase):
         self._verify_attr_grouping(
             platform_id="LJ01D",
             expected_groups={
-                2.5 : ["input_voltage"],
-                4.0 : ["MVPC_pressure_1", "MVPC_temperature"],
-                5.0 : ["input_bus_current"],
+                2.5 : ["input_voltage|0"],
+                4.0 : ["MVPC_pressure_1|0", "MVPC_temperature|0"],
+                5.0 : ["input_bus_current|0"],
             }
         )
 
         self._verify_attr_grouping(
             platform_id="Node1D",
             expected_groups={
-                5.0 : ["input_voltage", "input_bus_current"],
-                10.0 : ["MVPC_pressure_1", "MVPC_temperature"],
+                5.0 : ["input_voltage|0", "input_bus_current|0"],
+                10.0 : ["MVPC_pressure_1|0", "MVPC_temperature|0"],
             }
         )
 
         self._verify_attr_grouping(
             platform_id="MJ01C",
             expected_groups={
-                2.5 : ["input_voltage"],
-                5.0 : ["input_bus_current"],
-                4.0 : ["MVPC_pressure_1", "MVPC_temperature"],
+                2.5 : ["input_voltage|0"],
+                5.0 : ["input_bus_current|0"],
+                4.0 : ["MVPC_pressure_1|0", "MVPC_temperature|0"],
             }
         )
 
         self._verify_attr_grouping(
             platform_id="ShoreStation",
             expected_groups={
-                5.0 : ["ShoreStation_attr_1", "ShoreStation_attr_2"],
+                5.0 : ["ShoreStation_attr_1|0", "ShoreStation_attr_2|0"],
             }
         )
 

--- a/ion/agents/platform/util/network.py
+++ b/ion/agents/platform/util/network.py
@@ -81,12 +81,38 @@ class AttrNode(BaseNode):
     Represents a platform attribute.
     """
     def __init__(self, attr_id, defn):
+        """
+        OOIION-1551:
+        First, get attr_name and attr_instance from the given attr_id (this is
+        the preferred mechanism as it's expected to be of the form
+        "<name>|<instance>") or from properties in defn, and resorting to
+        the given attr_id for the name, and "0" for the instance.
+        Finally, the store attr_id is composed from the name and instance as
+        captured above.
+        """
         BaseNode.__init__(self)
-        self._attr_id = attr_id
+        idx = attr_id.rfind('|')
+        if idx >= 0:
+            self._attr_name     = attr_id[:idx]
+            self._attr_instance = attr_id[idx + 1:]
+        else:
+            self._attr_name     = defn.get('attr_name', attr_id)
+            self._attr_instance = defn.get('attr_instance', "0")
+
+        self._attr_id = "%s|%s" % (self._attr_name, self._attr_instance)
+        defn['attr_id'] = self._attr_id
         self._defn = defn
 
     def __repr__(self):
         return "AttrNode{id=%s, defn=%s}" % (self.attr_id, self.defn)
+
+    @property
+    def attr_name(self):
+        return self._attr_name
+
+    @property
+    def attr_instance(self):
+        return self._attr_instance
 
     @property
     def attr_id(self):
@@ -119,6 +145,7 @@ class AttrNode(BaseNode):
         # properties:
         hash_obj.update("attribute_properties:")
         for key in sorted(self.defn.keys()):
+            if key not in ["attr_name", "attr_instance", "attr_id"]:
                 val = self.defn[key]
                 hash_obj.update("%s=%s;" % (key, val))
     

--- a/ion/agents/platform/util/test/test_network_util.py
+++ b/ion/agents/platform/util/test/test_network_util.py
@@ -264,8 +264,8 @@ class Test(IonUnitTestCase):
         self.assertIn('Node1D', ndef.pnodes)
         Node1D = ndef.pnodes['Node1D']
 
-        common_attr_names = ['MVPC_pressure_1', 'MVPC_temperature',
-                             'input_bus_current',  'input_voltage', ]
+        common_attr_names = ['MVPC_pressure_1|0', 'MVPC_temperature|0',
+                             'input_bus_current|0',  'input_voltage|0', ]
 
         for attr_name in common_attr_names:
             self.assertIn(attr_name, Node1D.attrs)

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -168,6 +168,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         #
         #bin/nosetests -s -v --nologcapture ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_ims_instrument_status
 
+        self._set_receive_timeout()
 
         p_root = self._set_up_single_platform_with_some_instruments(['SBE37_SIM_01'])
         self._start_platform(p_root)


### PR DESCRIPTION
https://jira.oceanobservatories.org/tasks/browse/OOIION-1551

_All_ unit and integration tests for the platform agent completing OK locally and --with-pycc  (except ion.agents.platform.rsn.test.test_rsn_platform_driver:TestRsnPlatformDriver.test  , which has been failing already, see ooiion-1495).

Please review when convenient but merging should wait until after PRR.

@edwardhunter please review
@jamie-cyber1 please review
@MauriceManning please review
