### PR TITLE
fix OOIION-1608 list index out of range

### DIFF
--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -1302,6 +1302,7 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
             # create only if not already created:
             if instr_key in self._setup_instruments:
                 i_obj = self._setup_instruments[instr_key]
+                i_objs.append(i_obj)
                 log.debug("instrument was already created = %r (%s)",
                           i_obj.instrument_agent_instance_id, instr_key)
             else:


### PR DESCRIPTION
https://jira.oceanobservatories.org/tasks/browse/OOIION-1608

The test test_13_platforms_and_01_instruments now completes fine. But note that this test (and others in the same file) are currently skipped by default per OOIION-1297.
