### PR TITLE
OOIION-1623 Remove CheckSync from platform driver interface 

### DIFF
--- a/ion/agents/platform/rsn/rsn_platform_driver.py
+++ b/ion/agents/platform/rsn/rsn_platform_driver.py
@@ -58,7 +58,8 @@ class RSNPlatformDriverCapability(BaseEnum):
     DISCONNECT_INSTRUMENT     = RSNPlatformDriverEvent.DISCONNECT_INSTRUMENT
     TURN_ON_PORT              = RSNPlatformDriverEvent.TURN_ON_PORT
     TURN_OFF_PORT             = RSNPlatformDriverEvent.TURN_OFF_PORT
-    CHECK_SYNC                = RSNPlatformDriverEvent.CHECK_SYNC
+#    OOIION-1623 Remove until Check Sync requirements fully defined
+#    CHECK_SYNC                = RSNPlatformDriverEvent.CHECK_SYNC
 
 
 class RSNPlatformDriver(PlatformDriver):
@@ -231,13 +232,14 @@ class RSNPlatformDriver(PlatformDriver):
                         }
                 }
             }
-        commands[RSNPlatformDriverEvent.CHECK_SYNC] = \
-            {
-                "display_name" : "Check Platform Hierarchy",
-                "description" : "Verify the platform hierarchy is consistent with OMS.",
-                "args" : [],
-                "kwargs" : {}
-            }
+        # OOIION-1623 Remove until Check Sync requirements fully defined
+        #commands[RSNPlatformDriverEvent.CHECK_SYNC] = \
+        #    {
+        #        "display_name" : "Check Platform Hierarchy",
+        #        "description" : "Verify the platform hierarchy is consistent with OMS.",
+        #        "args" : [],
+        #        "kwargs" : {}
+        #    }
         self._resource_schema['parameters'] = parameters
         self._resource_schema['commands'] = commands
 

--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -393,7 +393,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
             RSNPlatformDriverEvent.DISCONNECT_INSTRUMENT,
             RSNPlatformDriverEvent.TURN_ON_PORT,
             RSNPlatformDriverEvent.TURN_OFF_PORT,
-            RSNPlatformDriverEvent.CHECK_SYNC
+#            RSNPlatformDriverEvent.CHECK_SYNC           #OOIION-1623 Remove until Check Sync requirements fully defined
         ]
 
         ##################################################################


### PR DESCRIPTION
Remove CheckSync from platform driver interface until this capability is fully defined with RSN/OMS team.

@edwardhunter please review

@carueda please review
