### PR TITLE
CIDEVSTC-276 - Adds basic graph generation for parameter-based provenance

### DIFF
--- a/ion/services/dm/test/dm_test_case.py
+++ b/ion/services/dm/test/dm_test_case.py
@@ -19,7 +19,7 @@ from interface.services.dm.iuser_notification_service import UserNotificationSer
 from interface.services.ans.iworkflow_management_service import WorkflowManagementServiceClient
 from interface.services.ans.ivisualization_service import VisualizationServiceClient
 
-from pyon.public import RT
+from pyon.public import RT, PRED
 from interface.objects import DataProduct
 from ion.services.dm.utility.granule_utils import time_series_domain
 from ion.util.enhanced_resource_registry_client import EnhancedResourceRegistryClient
@@ -96,6 +96,8 @@ class DMTestCase(IonIntegrationTestCase):
         if data_products:
             return data_products[0]
         return None
+    def dataset_of_data_product(self, data_product_id):
+        return self.resource_registry.find_objects(data_product_id, PRED.hasDataset, id_only=True)[0][0]
 
 class Streamer(object):
     def __init__(self, data_product_id, interval=1, simple_time=False, connection=False):

--- a/ion/services/dm/utility/provenance.py
+++ b/ion/services/dm/utility/provenance.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+'''
+@file ion/services/dm/utility/provenance.py
+
+Contains an assortment of utilities for determining provenance
+'''
+
+from coverage_model import ParameterFunctionType
+
+'''
+An example of using graph()
+
+Here's the output of the CTDMO data product's parameter dictionary
+
+><> graph(pdict, 'seawater_density')
+-->
+{'cc_lat': {},
+ 'cc_lon': {},
+ 'sci_water_pracsal': {'seawater_conductivity': {'conductivity': {}},
+  'seawater_pressure': {'cc_p_range': {}, 'pressure': {}},
+  'seawater_temperature': {'temperature': {}}},
+ 'seawater_pressure': {'cc_p_range': {}, 'pressure': {}},
+ 'seawater_temperature': {'temperature': {}}}
+'''
+
+def graph(pdict, param_name):
+    '''
+    Essentially a depth-first-search of the dependency 
+    tree for a particular parameter.
+
+    Returns a dictionary where the key is the named parameter
+    and the nested values are the dependencies. If a named 
+    parameter does not contain a value, it is not a function.
+    '''
+    # if param_name is an integer, then just return it
+    if not isinstance(param_name, basestring):
+        return {}
+    # get the parameter context
+    ctx = pdict[param_name]
+    # we only care about parameter functions
+    if not isinstance(ctx.param_type, ParameterFunctionType):
+        return {}
+
+    # the parameter map describes what the function needs
+    pmap = ctx.param_type.function.param_map
+    retval = {}
+    deps = pmap.values()
+    # Recursively determine the graph for each dependency
+    
+    for d in deps:
+        retval[d] = graph(pdict, d)
+
+    return retval
+


### PR DESCRIPTION
This pull request contains code that provides a generic interface to generating a graph (in python dict) of the parameter dependencies. I think that this is the first step towards getting provenance solved from a coverage model perspective.
