### PR TITLE
TEST - Fixes test_transform_worker

### DIFF
--- a/ion/processes/data/transforms/test/test_transform_worker.py
+++ b/ion/processes/data/transforms/test/test_transform_worker.py
@@ -266,6 +266,7 @@ class TestTransformWorker(IonIntegrationTestCase):
             dp_details.function = pfunction_obj.function
             dp_details.arguments = pfunction_obj.arguments
             dp_details.argument_map=dp_obj.argument_map
+            dp_details.uri = pfunction_obj.uri
             config[dp_id] = dp_details
 
         return config

--- a/ion/processes/data/transforms/test/test_transform_worker.py
+++ b/ion/processes/data/transforms/test/test_transform_worker.py
@@ -130,6 +130,7 @@ class TestTransformWorker(IonIntegrationTestCase):
             function='add_arrays',
             module="ion_example.add_arrays",
             arguments=['arr1', 'arr2'],
+            uri='http://sddevrepo.oceanobservatories.org/releases/ion_example-0.1-py2.7.egg' ,
             function_type=TransformFunctionType.TRANSFORM
 
             )

--- a/ion/processes/data/transforms/transform_worker.py
+++ b/ion/processes/data/transforms/transform_worker.py
@@ -141,8 +141,6 @@ class TransformWorker(TransformStreamListener):
                     module = importlib.import_module(dataprocess_info.get_safe('module', '') )
                 except ImportError:
                     # Download and install the egg
-                    print dataprocess_info
-                    print vars(dataprocess_info)
                     egg = self.download_egg(dataprocess_info.get_safe('uri',''))
                     pkg_resources.working_set.add_entry(egg)
                     module = importlib.import_module(dataprocess_info.get_safe('module', '') )


### PR DESCRIPTION
Fixes the broken test.
- Places EGG URI in the info record
- Downloads egg at import phase

The test failed because of `ImportError: No module named ion_example.add_arrays`
This PR fixes that issue.
