### PR TITLE
TEST - Adds timeout to activate_data_product in preload

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -3040,7 +3040,8 @@ Reason: %s
             self._register_id(row[COL_ID], res_id, res_obj)
 
             if not self.debug and get_typed_value(row['persist_data'], targettype="bool"):
-                dpms_client.activate_data_product_persistence(res_id, headers=headers)
+                timeout = self.CFG.get_safe('endpoint.receive.timeout', 30)
+                dpms_client.activate_data_product_persistence(res_id, headers=headers, timeout=timeout)
 
         self._resource_assign_org(row, res_id)
         self._resource_advance_lcs(row, res_id)


### PR DESCRIPTION
This is in response to `ion/services/dm/test/test_dm_extended.py:TestDMExtended.test_provenance_graph` failing because of a premature timeout in the ion_loader.
