### PR TITLE
CIDEVSTC-278 - Adds test to verify parameter functions can be added and run

### DIFF
--- a/ion/services/dm/inventory/data_retriever_service.py
+++ b/ion/services/dm/inventory/data_retriever_service.py
@@ -158,6 +158,7 @@ class DataRetrieverService(BaseDataRetrieverService):
             data_products, _ = Container.instance.resource_registry.find_subjects(object=dataset_id, predicate=PRED.hasDataset, subject_type=RT.DataProduct)
             for data_product in data_products:
                 log.exception("Data Product %s (%s) had issues reading from the coverage model\nretrieve_oob(dataset_id='%s', query=%s, delivery_format=%s)", data_product.name, data_product._id, dataset_id, query, delivery_format)
+            log.exception('Problems reading from the coverage', exc_info=True)
             raise BadRequest('Problems reading from the coverage')
         return rdt.to_granule()
 


### PR DESCRIPTION
- Adds better exception logging for retrieve and CM operations.
- Adds test for data process/data process definition management of
  parameter functions.
  - Fully functioning!
- Promotes test_append_parameter to INT test
- Small tweaks to data processing to get the test to work: add
  association and typo

[CIDEVSTC-278](https://jira.oceanobservatories.org/tasks/browse/CIDEVSTC-278)
