### PR TITLE
CIDEVSTC-278 Adds inspection for data process definitions

### DIFF
--- a/ion/services/dm/test/dm_test_case.py
+++ b/ion/services/dm/test/dm_test_case.py
@@ -62,6 +62,7 @@ class DMTestCase(IonIntegrationTestCase):
         self.user_notification = UserNotificationServiceClient()
         self.workflow_management = WorkflowManagementServiceClient()
         self.visualization = VisualizationServiceClient()
+        self.ph = ParameterHelper(self.dataset_management, self.addCleanup)
 
     def create_stream_definition(self, *args, **kwargs):
         stream_def_id = self.pubsub_management.create_stream_definition(*args, **kwargs)
@@ -98,6 +99,13 @@ class DMTestCase(IonIntegrationTestCase):
         return None
     def dataset_of_data_product(self, data_product_id):
         return self.resource_registry.find_objects(data_product_id, PRED.hasDataset, id_only=True)[0][0]
+    
+    def make_ctd_data_product(self):
+        pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict')
+        stream_def_id = self.create_stream_definition('ctd', parameter_dictionary_id=pdict_id)
+        data_product_id = self.create_data_product('ctd', stream_def_id=stream_def_id)
+        self.activate_data_product(data_product_id)
+        return data_product_id
 
 class Streamer(object):
     def __init__(self, data_product_id, interval=1, simple_time=False, connection=False):

--- a/ion/services/dm/test/test_dm_extended.py
+++ b/ion/services/dm/test/test_dm_extended.py
@@ -91,6 +91,15 @@ class TestDMExtended(DMTestCase):
         config.categories='ParameterFunctions,ParameterDefs,ParameterDictionary'
         self.container.spawn_process('preloader', 'ion.processes.bootstrap.ion_loader', 'IONLoader', config)
 
+    def preload_full_beta(self):
+        config = DotDict()
+        config.op = 'load'
+        config.loadui=True
+        config.ui_path =  "http://userexperience.oceanobservatories.org/database-exports/Candidates"
+        config.attachments = "res/preload/r2_ioc/attachments"
+        config.scenario = 'BETA'
+        self.container.spawn_process('preloader', 'ion.processes.bootstrap.ion_loader', 'IONLoader', config)
+
     def preload_alpha(self):
         config = DotDict()
         config.cfg = 'res/preload/r2_ioc/config/ooi_alpha.yml'
@@ -1096,6 +1105,16 @@ class TestDMExtended(DMTestCase):
         try:
             from growl import growl
             growl("Alpha", "Loaded")
+        except ImportError:
+            pass
+        breakpoint(locals(), globals())
+    
+    @attr("UTIL")
+    def test_beta(self):
+        self.preload_full_beta()
+        try:
+            from growl import growl
+            growl("Beta", "Loaded")
         except ImportError:
             pass
         breakpoint(locals(), globals())

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -111,11 +111,12 @@ class DataProcessManagementService(BaseDataProcessManagementService):
                tf1.uri           == tf2.uri    and \
                tf1.function_type == tf2.function_type
 
-    def create_transform_function(self, transform_function=''):
+    def create_transform_function(self, transform_function=None):
         '''
         Creates a new transform function
         '''
-
+        if not transform_function:
+            raise BadRequest("Improper TransformFunction specified")
         return self.RR2.create(transform_function, RT.TransformFunction)
 
     def read_transform_function(self, transform_function_id=''):
@@ -161,9 +162,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
             return dpd_id
 
         elif isinstance(function_definition, TransformFunction):
-            # TODO: Need service methods for this stuff
             data_process_definition.data_process_type = DataProcessTypeEnum.TRANSFORM_PROCESS
-
             dpd_id, _ = self.clients.resource_registry.create(data_process_definition)
             self.clients.resource_registry.create_association(subject=dpd_id, object=function_id, predicate=PRED.hasTransformFunction)
             return dpd_id
@@ -349,6 +348,8 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         #todo: determine if/how routing tables will be managed
         dpd_obj = self.read_data_process_definition(data_process_definition_id)
         if dpd_obj.data_process_type == DataProcessTypeEnum.PARAMETER_FUNCTION:
+            # A different kind of data process
+            # this function creates a data process resource for each data product and appends the parameter
             return self._initialize_parameter_function(data_process_definition_id, in_data_product_ids, argument_map, out_param_name)
             
 

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -397,7 +397,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
     # Inspection 
     #--------------------------------------------------------------------------------
 
-    def inspect_data_process_definition(self, data_process_definition_id):
+    def inspect_data_process_definition(self, data_process_definition_id=''):
         '''
         Returns the source code for the data process definition 
         '''

--- a/ion/services/sa/product/data_product_management_service.py
+++ b/ion/services/sa/product/data_product_management_service.py
@@ -149,7 +149,9 @@ class DataProductManagementService(BaseDataProductManagementService):
             dp = DataProcess()
             dp.name = 'Data Process %s for Data Product %s' % ( dpd.name, data_product.name )
             # TODO: This is a stub until DPD is ready
-            self.clients.resource_registry.create(dp)
+            dp_id, _ = self.clients.resource_registry.create(dp)
+            self.clients.resource_registry.create_association(dpd._id, PRED.hasDataProcess, dp_id)
+            self.clients.resource_registry.create_association(dp_id, PRED.hasOutputProduct, data_product._id)
 
 
 

--- a/ion/services/sa/test/test_data_process_functions.py
+++ b/ion/services/sa/test/test_data_process_functions.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+__author__ = 'Luke'
+from ion.services.dm.test.dm_test_case import DMTestCase
+from ion.processes.data.replay.replay_process import RetrieveProcess
+from ion.services.dm.utility.granule import RecordDictionaryTool
+from ion.services.dm.test.test_dm_end_2_end import DatasetMonitor
+from ion.services.dm.utility.provenance import graph
+from coverage_model import ParameterFunctionType, ParameterDictionary, PythonFunction, ParameterContext
+from ion.processes.data.transforms.transform_worker import TransformWorker
+from interface.objects import DataProcessDefinition
+from nose.plugins.attrib import attr
+from pyon.util.breakpoint import breakpoint
+from datetime import datetime, timedelta
+import os
+import unittest
+import numpy as np
+import time
+import calendar
+
+class TestDataProcessFunctions(DMTestCase):
+
+    @attr('INT')
+    def test_retrieve_process(self):
+        data_product_id = self.make_ctd_data_product()
+        dataset_id = self.RR2.find_dataset_id_of_data_product_using_has_dataset(data_product_id)
+        dataset_monitor = DatasetMonitor(dataset_id)
+        self.addCleanup(dataset_monitor.stop)
+
+        rdt = self.ph.rdt_for_data_product(data_product_id)
+        date0 = datetime(2014, 1, 1, 0, 0) # 2014-01-01T00:00Z
+        time0 = calendar.timegm(date0.timetuple()) + 2208988800 # NTP
+        rdt['time'] = np.arange(time0, time0+30)
+        rdt['temp'] = np.arange(30)
+        self.ph.publish_rdt_to_data_product(data_product_id, rdt)
+        self.assertTrue(dataset_monitor.wait())
+        dataset_monitor.event.clear()
+        retrieve_process = RetrieveProcess(dataset_id)
+        rdt = retrieve_process.retrieve(date0, date0 + timedelta(hours=1))
+        np.testing.assert_array_equal(rdt['temp'], np.arange(30))
+
+    @attr('INT')
+    def test_append_parameter(self):
+        # Make a CTDBP Data Product
+        data_product_id = self.make_ctd_data_product()
+        dataset_id = self.RR2.find_dataset_id_of_data_product_using_has_dataset(data_product_id)
+        dataset_monitor = DatasetMonitor(dataset_id)
+        self.addCleanup(dataset_monitor.stop)
+
+        # Throw some data in it
+        rdt = self.ph.rdt_for_data_product(data_product_id)
+        rdt['time'] = np.arange(30)
+        rdt['temp'] = np.arange(30)
+        rdt['pressure'] = np.arange(30)
+        self.ph.publish_rdt_to_data_product(data_product_id, rdt)
+        self.assertTrue(dataset_monitor.wait())
+        dataset_monitor.event.clear()
+
+        # Grab the egg
+        egg_url = 'http://sddevrepo.oceanobservatories.org/releases/ion_example-0.1-py2.7.egg' 
+        egg_path = TransformWorker.download_egg(egg_url)
+        import pkg_resources
+        pkg_resources.working_set.add_entry(egg_path)
+        self.addCleanup(os.remove, egg_path)
+
+        # Make a parameter function
+        owner = 'ion_example.add_arrays'
+        func = 'add_arrays'
+        arglist = ['a', 'b']
+        pfunc = PythonFunction('add_arrays', owner, func, arglist, None, None)
+
+        pfunc_dump = pfunc.dump()
+        pfunc_id = self.dataset_management.create_parameter_function('add_arrays', pfunc_dump, 'Adds two arrays')
+        self.addCleanup(self.dataset_management.delete_parameter_function, pfunc_id)
+
+        # Make a context (instance of the function)
+        pfunc.param_map = {'a':'temp', 'b':'pressure'}
+        ctxt = ParameterContext('array_sum', param_type=ParameterFunctionType(pfunc))
+        ctxt_dump = ctxt.dump()
+        ctxt_id = self.dataset_management.create_parameter_context('array_sum', ctxt_dump)
+        self.dataset_management.add_parameter_to_dataset(ctxt_id, dataset_id)
+
+        granule = self.data_retriever.retrieve(dataset_id)
+        rdt = RecordDictionaryTool.load_from_granule(granule)
+        np.testing.assert_array_equal(rdt['array_sum'], np.arange(0,60,2))
+
+    @attr('INT')
+    def test_add_parameter_function(self):
+        # Make a CTDBP Data Product
+        data_product_id = self.make_ctd_data_product()
+        dataset_id = self.RR2.find_dataset_id_of_data_product_using_has_dataset(data_product_id)
+        dataset_monitor = DatasetMonitor(dataset_id)
+        self.addCleanup(dataset_monitor.stop)
+
+        # Throw some data in it
+        rdt = self.ph.rdt_for_data_product(data_product_id)
+        rdt['time'] = np.arange(30)
+        rdt['temp'] = np.arange(30)
+        rdt['pressure'] = np.arange(30)
+        self.ph.publish_rdt_to_data_product(data_product_id, rdt)
+        self.assertTrue(dataset_monitor.wait())
+        dataset_monitor.event.clear()
+
+        #--------------------------------------------------------------------------------
+        # This is what the user defines either via preload or through the UI
+        #--------------------------------------------------------------------------------
+        # Where the egg is
+        egg_url = 'http://sddevrepo.oceanobservatories.org/releases/ion_example-0.1-py2.7.egg' 
+
+        # Make a parameter function
+        owner = 'ion_example.add_arrays'
+        func = 'add_arrays'
+        arglist = ['a', 'b']
+        pfunc = PythonFunction('add_arrays', owner, func, arglist, None, None, egg_url)
+
+        pfunc_dump = pfunc.dump()
+        pfunc_id = self.dataset_management.create_parameter_function('add_arrays', pfunc_dump, 'Adds two arrays')
+        #--------------------------------------------------------------------------------
+        self.addCleanup(self.dataset_management.delete_parameter_function, pfunc_id)
+
+        # Make a data process definition
+        dpd = DataProcessDefinition(name='add_arrays', description='Sums two arrays')
+        dpd_id = self.data_process_management.create_data_process_definition_new(dpd, pfunc_id)
+
+        # TODO: assert assoc exists
+        argmap = {'a':'temp', 'b':'pressure'}
+        dp_id = self.data_process_management.create_data_process_new(dpd_id, [data_product_id], argument_map=argmap, out_param_name='array_sum')
+
+        # Verify that the function worked!
+        granule = self.data_retriever.retrieve(dataset_id)
+        rdt = RecordDictionaryTool.load_from_granule(granule)
+        np.testing.assert_array_equal(rdt['array_sum'], np.arange(0,60,2))
+    
+        # Verify that we can inspect it as well
+        source_code = self.data_process_management.inspect_data_process_definition(dpd_id)
+        self.assertEquals(source_code, 'def add_arrays(a, b):\n    return a+b\n')
+


### PR DESCRIPTION
- Adds method in data_process_management for inspecting the source code of a data process definition
- Adds test for testing the inspection of a well-known dpd and source code
- Refactors TestDMExtended's SA-based tests into a new test class TestDataProcessFunctions

Depends on https://github.com/ooici/ion-definitions/pull/486
