### PR TITLE
CIDEVSTC-43	Implement data process management service extensions

### DIFF
--- a/ion/services/sa/process/test/test_int_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_int_data_process_management_service.py
@@ -1113,7 +1113,8 @@ class TestDataProcessManagementPrime(IonIntegrationTestCase):
         self.publish_to_data_product(instrument_data_product_id)
         
         self.assertTrue(validated.wait(10))
-        
+
+    @unittest.skip('Not used in R2 and architecture deprecated in R3')
     def test_older_transform(self):
         input_data_product_id = self.ctd_plain_input_data_product()
 
@@ -1172,6 +1173,7 @@ class TestDataProcessManagementPrime(IonIntegrationTestCase):
         stream_def_ids, _ = self.resource_registry.find_resources(name=name, restype=RT.StreamDefinition, id_only=True)
         return stream_def_ids[0]
 
+    @unittest.skip('Not used in R2 and architecture deprecated in R3')
     def test_actors(self):
         input_data_product_id = self.ctd_plain_input_data_product()
         output_data_product_id = self.ctd_plain_density()


### PR DESCRIPTION
skip data process tests that are outdated in R3 and not used in R2

@jamie-cyber1  please review
