### PR TITLE
OOIION-1694: Handle [None] being returned from read_states()

### DIFF
--- a/ion/services/sa/instrument/instrument_management_service.py
+++ b/ion/services/sa/instrument/instrument_management_service.py
@@ -1684,7 +1684,7 @@ class InstrumentManagementService(BaseInstrumentManagementService):
         dsm = DeviceStateManager()
         state_list = dsm.read_states([taskable_resource_id])
 
-        if state_list and 'state' in state_list[0] and 'current' in state_list[0]['state']:
+        if state_list and filter(None, state_list) and 'state' in state_list[0] and 'current' in state_list[0]['state']:
             cur_state = state_list[0]['state']['current']
             if cur_state in resource_agent_state_labels:
                 retval.value = resource_agent_state_labels[cur_state]


### PR DESCRIPTION
@edwardhunter

The `strict=False` parameter is being is passed to `read_doc_mult` in this execution chain. This can potentially result in a list being returned that contains `None` values (ie. `[None]`). `get_operational_state` is not taking this into account. It is only catching the case when `[]` (False) is returned, not when `[None]` (not False) is returned. 

https://jira.oceanobservatories.org/tasks/browse/OOIION-1694
