### PR TITLE
Safer EEAgent heartbeat greenlet handling, updates OOIION-1753

### DIFF
--- a/ion/agents/cei/execution_engine_agent.py
+++ b/ion/agents/cei/execution_engine_agent.py
@@ -109,8 +109,8 @@ class HeartBeater(object):
         self._factory = factory
         self.process = process
         self.process_id = process_id
-        self._publisher = Publisher()
         self._pd_name = CFG.eeagent.get('heartbeat_queue', 'heartbeat_queue')
+        self._publisher = Publisher(to_name=self._pd_name)
 
         self._factory.set_state_change_callback(
             self._state_change_callback, None)
@@ -163,7 +163,6 @@ class HeartBeater(object):
             message = dict(
                 beat=beat, eeagent_id=self.process_id,
                 resource_id=self._CFG.agent.resource_id)
-            to_name = self._pd_name
 
             if self._log.isEnabledFor(logging.DEBUG):
                 processes = beat.get('processes')
@@ -174,7 +173,7 @@ class HeartBeater(object):
                 self._log.debug("Sending heartbeat to %s %s",
                                 self._pd_name, processes_str)
 
-            self._publisher.publish(message, to_name=to_name)
+            self._publisher.publish(message)
         except Exception:
             self._log.exception("beat failed")
 

--- a/ion/agents/cei/execution_engine_agent.py
+++ b/ion/agents/cei/execution_engine_agent.py
@@ -64,7 +64,7 @@ class ExecutionEngineAgent(SimpleResourceAgent):
             self.heartbeat_thread, self._heartbeat_thread_event = looping_call(0.1, self.heartbeater.poll)
         else:
             self.heartbeat_thread = None
-            self._heartbeat_threaad_event = None
+            self._heartbeat_thread_event = None
 
     def on_quit(self):
         if self._heartbeat_thread_event is not None:

--- a/ion/agents/cei/test/test_eeagent.py
+++ b/ion/agents/cei/test/test_eeagent.py
@@ -392,6 +392,7 @@ class ExecutionEngineAgentPyonIntTest(IonIntegrationTestCase):
 
         assert False, "Process %s took too long to get to %s, had %s" % (upid, desired_state, last_state)
 
+
     @needs_eeagent
     def test_basics(self):
         u_pid = "test0"
@@ -782,6 +783,15 @@ class ExecutionEngineAgentPyonIntTest(IonIntegrationTestCase):
         self.eea_client.terminate_process(u_pid, round)
         state = self.eea_client.dump_state().result
         get_proc_for_upid(state, u_pid)
+
+    @attr('broken')
+    @needs_eeagent
+    def test_broken(self):
+        for i in range(50):
+            print 'rount %d' % i
+            self.container.terminate_process(self._eea_pid)
+            self._start_eeagent()
+            gevent.sleep(1)
 
 
 @attr('INT', group='cei')

--- a/ion/agents/cei/util.py
+++ b/ion/agents/cei/util.py
@@ -1,9 +1,14 @@
 import gevent
+from gevent.event import Event
 
+def looping_call(interval, callable):
+    """
+    Returns a greenlet running your callable in a loop and an Event you can set
+    to terminate the loop cleanly.
+    """
+    ev = Event()
+    def loop(interval, callable):
+        while not ev.wait(timeout=interval):
+            callable()
+    return gevent.spawn(loop, interval, callable), ev
 
-def looping_call(interval, callable):                                            
-    def loop(interval, callable):                                                
-        while True:                                                              
-            gevent.sleep(interval)                                               
-            callable()                                                           
-    return gevent.spawn(loop, interval, callable)   


### PR DESCRIPTION
The EEAgent heartbeat was using messaging and was being `.kill()`'d at any random point in execution on termination.  This results in possible full messaging/container failure.
