### PR TITLE
CIDEVSTC-99 - Adds WKT qmatcher to ds_discovery

### DIFF
--- a/ion/services/dm/presentation/ds_discovery.py
+++ b/ion/services/dm/presentation/ds_discovery.py
@@ -210,6 +210,23 @@ class DatastoreDiscovery(object):
         else:
             return qb.overlaps_bbox(geom_col, top_left[0], bottom_right[1], bottom_right[0], top_left[1])
 
+    def _qmatcher_geo_wkt(self, query, qb):
+        query_exp = query.get("query", query)
+        field = query_exp.get("field", None)
+        wkt = query_exp.get("wkt", None)
+        if not (field and wkt):
+            return
+
+        geom_col = COL_MAP.get(field, DQ.RA_GEOM)
+        buf = query_exp.get("buffer", None)
+        range_op = query_exp.get("cmpop", None)
+        if range_op == "contains":
+            return qb.contains_wkt(geom_col, wkt, buf)
+        elif range_op == "within":
+            return qb.within_wkt(geom_col, wkt, buf)
+        else:
+            return qb.overlaps_wkt(geom_col, wkt, buf)
+
     def _qmatcher_geo_vert(self, query, qb):
         query_exp = query.get("query", query)
         field = query_exp.get("field", None)

--- a/ion/services/dm/presentation/ds_discovery.py
+++ b/ion/services/dm/presentation/ds_discovery.py
@@ -41,6 +41,7 @@ class DatastoreDiscovery(object):
                            self._qmatcher_field_time,
                            self._qmatcher_fieldeq,
                            self._qmatcher_geo_loc,
+                           self._qmatcher_geo_wkt,
                            self._qmatcher_geo_vert,
                           ]
 

--- a/ion/services/dm/presentation/test/discovery_test.py
+++ b/ion/services/dm/presentation/test/discovery_test.py
@@ -389,6 +389,40 @@ class DiscoveryQueryTest(IonIntegrationTestCase):
         result  = self.discovery.parse(search_string, id_only=False)
         self.assertEquals(len(result), 1)
 
+
+        # Geospatial - WKT (a box 4,4 to 4,14 to 14,14 to 14,4, to 4,4 overlaps DP1 but is not contained by it or does not have it within)
+        query_str = "{'and': [], 'or': [], 'query': {'wkt': 'POLYGON((4 4,4 14,14 14,14 4,4 4))', 'field': 'geospatial_bounds', 'index': 'resources_index', 'cmpop': 'overlaps'}}"
+        query_obj = eval(query_str)
+        result  = self.discovery.query(query_obj, id_only=False)
+        print result
+        self.assertEquals(len(result), 1)
+
+        query_str = "{'and': [], 'or': [], 'query': {'wkt': 'POLYGON((4 4,4 14,14 14,14 4,4 4))', 'field': 'geospatial_bounds', 'index': 'resources_index', 'cmpop': 'contains'}}"
+        query_obj = eval(query_str)
+        result  = self.discovery.query(query_obj, id_only=False)
+        print result
+        self.assertEquals(len(result), 0)
+
+        query_str = "{'and': [], 'or': [], 'query': {'wkt': 'POLYGON((4 4,4 14,14 14,14 4,4 4))', 'field': 'geospatial_bounds', 'index': 'resources_index', 'cmpop': 'within'}}"
+        query_obj = eval(query_str)
+        result  = self.discovery.query(query_obj, id_only=False)
+        print result
+        self.assertEquals(len(result), 0)
+
+        # -- with buffer (eg. point with radius CIRCLE)
+        query_str = "{'and': [], 'or': [], 'query': {'wkt': 'POINT(10.0 10.0)', 'buffer': 1.0, 'field': 'geospatial_point_center', 'index': 'resources_index', 'cmpop': 'within'}}"
+        query_obj = eval(query_str)
+        result  = self.discovery.query(query_obj, id_only=False)
+        self.assertEquals(len(result), 1)
+
+        query_str = "{'and': [], 'or': [], 'query': {'wkt': 'POINT(10.0 10.0)', 'buffer': 1.0, 'field': 'geospatial_point_center', 'index': 'resources_index', 'cmpop': 'contains'}}"
+        query_obj = eval(query_str)
+        result  = self.discovery.query(query_obj, id_only=False)
+        self.assertEquals(len(result), 0)
+
+
+
+
         # ----------------------------------------------------
         # Vertical search
 


### PR DESCRIPTION
M112 T133 - Adds qmatcher to ds_discovery

WKT matcher takes WKT string and optionally a buffer (in degrees). Circle is a point with radius size of buffer. Example {'wkt':'POINT(-70 40)', 'buffer':1.0} creates a circle centered on 40N,70W with a radius of 1.0 degrees.

Method (and buffer) works for all valid WKT shapes.

Needs https://github.com/ooici/pyon/pull/469 merged
