### PR TITLE
CIDEVSTC-43 - Adds replay support for transforms

### DIFF
--- a/ion/processes/data/transforms/test/test_transform_worker.py
+++ b/ion/processes/data/transforms/test/test_transform_worker.py
@@ -212,7 +212,8 @@ class TestTransformWorker(IonIntegrationTestCase):
         #two data processes using one transform and one DPD
 
         dp1_func_output_dp_id, dp2_func_output_dp_id =  self.create_output_data_products()
-        configuration = { 'argument_map':{'a':'salinity'}, 'output_param' : None }
+        argument_map= {"a": "salinity"}
+
 
         # Set up DPD and DP #2 - array add function
         tf_obj = IonObject(RT.TransformFunction,
@@ -235,8 +236,8 @@ class TestTransformWorker(IonIntegrationTestCase):
         self.dataprocessclient.assign_stream_definition_to_data_process_definition(self.stream_def_id, self.add_array_dpd_id, binding='validate_salinity_array' )
 
         # Create the data process
-        dp1_data_process_id = self.dataprocessclient.create_data_process_new(data_process_definition_id=self.add_array_dpd_id, in_data_product_ids=[self.input_dp_id],
-                                                                             out_data_product_ids=[dp1_func_output_dp_id], configuration=configuration)
+        dp1_data_process_id = self.dataprocessclient.create_data_process_new(data_process_definition_id=self.add_array_dpd_id, inputs=[self.input_dp_id],
+                                                                             outputs=[dp1_func_output_dp_id], argument_map=argument_map)
         self.damsclient.register_process(dp1_data_process_id)
         self.addCleanup(self.dataprocessclient.delete_data_process, dp1_data_process_id)
 
@@ -248,7 +249,9 @@ class TestTransformWorker(IonIntegrationTestCase):
         #two data processes using one transform and one DPD
 
         dp1_func_output_dp_id, dp2_func_output_dp_id =  self.create_output_data_products()
-        configuration = { 'argument_map':{'arr1':'conductivity', 'arr2':'pressure'}, 'output_param' : 'salinity' }
+        argument_map = {"arr1": "conductivity", "arr2": "pressure"}
+        output_param = "salinity"
+
 
         # Set up DPD and DP #2 - array add function
         tf_obj = IonObject(RT.TransformFunction,
@@ -272,14 +275,14 @@ class TestTransformWorker(IonIntegrationTestCase):
         self.dataprocessclient.assign_stream_definition_to_data_process_definition(self.stream_def_id, self.add_array_dpd_id, binding='add_array_func' )
 
         # Create the data process
-        dp1_data_process_id = self.dataprocessclient.create_data_process_new(data_process_definition_id=self.add_array_dpd_id, in_data_product_ids=[self.input_dp_id],
-                                                                             out_data_product_ids=[dp1_func_output_dp_id], configuration=configuration)
+        dp1_data_process_id = self.dataprocessclient.create_data_process_new(data_process_definition_id=self.add_array_dpd_id, inputs=[self.input_dp_id],
+                                                                             outputs=[dp1_func_output_dp_id], argument_map=argument_map, out_param_name=output_param)
         self.damsclient.register_process(dp1_data_process_id)
         self.addCleanup(self.dataprocessclient.delete_data_process, dp1_data_process_id)
 
         # Create the data process
-        dp2_func_data_process_id = self.dataprocessclient.create_data_process_new(data_process_definition_id=self.add_array_dpd_id, in_data_product_ids=[self.input_dp_id],
-                                                                                  out_data_product_ids=[dp2_func_output_dp_id], configuration=configuration)
+        dp2_func_data_process_id = self.dataprocessclient.create_data_process_new(data_process_definition_id=self.add_array_dpd_id, inputs=[self.input_dp_id],
+                                                                                  outputs=[dp2_func_output_dp_id], argument_map=argument_map, out_param_name=output_param)
         self.damsclient.register_process(dp2_func_data_process_id)
         self.addCleanup(self.dataprocessclient.delete_data_process, dp2_func_data_process_id)
 
@@ -361,7 +364,7 @@ class TestTransformWorker(IonIntegrationTestCase):
 
         self.addCleanup(es.stop)
 
-    def validate_test_event(self, *args, **kwargs):
+    def validate_transform_event(self, *args, **kwargs):
         """
         This method is a callback function for receiving DataProcessStatusEvent.
         """
@@ -375,7 +378,7 @@ class TestTransformWorker(IonIntegrationTestCase):
 
     def start_event_transform_listener(self):
 
-        es = EventSubscriber(event_type=OT.DeviceStatusAlertEvent, callback=self.validate_test_event)
+        es = EventSubscriber(event_type=OT.DeviceStatusAlertEvent, callback=self.validate_transform_event)
         es.start()
 
         self.addCleanup(es.stop)

--- a/ion/processes/data/transforms/transform_worker.py
+++ b/ion/processes/data/transforms/transform_worker.py
@@ -150,14 +150,17 @@ class TransformWorker(TransformStreamListener):
                 out_stream_definition, output_parameter = self.retrieve_dp_output_params(dp_id)
 
                 if out_stream_definition and output_parameter:
-                    rdt = RecordDictionaryTool(stream_definition_id=out_stream_definition)
+                    rdt_out = RecordDictionaryTool(stream_definition_id=out_stream_definition)
                     publisher = self._publisher_map.get(dp_id,'')
 
-                    rdt[ output_parameter ] = result
+                    for param in rdt:
+                        if param in rdt_out:
+                            rdt_out[param] = rdt[param]
+                    rdt_out[ output_parameter ] = result
 
                     if publisher:
                         log.debug('output rdt: %s',rdt)
-                        publisher.publish(rdt.to_granule())
+                        publisher.publish(rdt_out.to_granule())
                     else:
                         log.error('Publisher not found for data process %s', dp_id)
 

--- a/ion/processes/data/transforms/transform_worker.py
+++ b/ion/processes/data/transforms/transform_worker.py
@@ -229,6 +229,7 @@ class TransformWorker(TransformStreamListener):
 
         dpms_client = DataProcessManagementServiceClient()
 
+        print 'looking at', stream_id
         dataprocess_details_list = dpms_client.read_data_process_for_stream(stream_id)
 
         dataprocess_ids = []

--- a/ion/processes/data/transforms/transform_worker.py
+++ b/ion/processes/data/transforms/transform_worker.py
@@ -74,14 +74,6 @@ class TransformWorker(TransformStreamListener):
 
 
 
-        url = 'http://sddevrepo.oceanobservatories.org/releases/ion_example-0.1-py2.7.egg'
-        filepath = self.download_egg(url)
-        print filepath
-        import pkg_resources
-        pkg_resources.working_set.add_entry('ion_example-0.1-py2.7.egg')
-        from ion_example.add_arrays import add_arrays
-
-
     def on_quit(self): #pragma no cover
         self.event_publisher.close()
         if self.subscriber_thread:
@@ -151,8 +143,9 @@ class TransformWorker(TransformStreamListener):
                 try:
                     result = function(*args)
                     log.debug('recv_packet  result: %s',result)
-                except Exception, e:
-                    log.error('Error running transform %s with args %s. Exception: %s', dp_id, args, e)
+                except:
+                    log.error('Error running transform %s with args %s.', dp_id, args, exc_info=True)
+                    raise
 
                 out_stream_definition, output_parameter = self.retrieve_dp_output_params(dp_id)
 

--- a/ion/services/dm/inventory/data_retriever_service.py
+++ b/ion/services/dm/inventory/data_retriever_service.py
@@ -189,12 +189,7 @@ class DataRetrieverService(BaseDataRetrieverService):
 
     def replay_data_process(self, dataset_id, query, delivery_format, replay_stream_id):
         dataset = self.clients.dataset_management.read_dataset(dataset_id=dataset_id)
-        datastore_name = dataset.datastore_name
         delivery_format = delivery_format or {}
-
-        view_name = dataset.view_name
-        key_id = dataset.primary_view_key
-        # Make a new definition container
 
 
         replay = Replay()
@@ -207,10 +202,7 @@ class DataRetrieverService(BaseDataRetrieverService):
         replay._rev = rev
         config = {'process':{
             'query':query,
-            'datastore_name':datastore_name,
             'dataset_id':dataset_id,
-            'view_name':view_name,
-            'key_id':key_id,
             'delivery_format':delivery_format,
             'publish_streams':{'output':replay_stream_id}
             }

--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -13,6 +13,7 @@ from pyon.public import RT, log, OT, PRED, CFG
 from pyon.util.containers import DotDict
 from pyon.util.poller import poll
 from pyon.util.int_test import IonIntegrationTestCase
+from pyon.container.cc import Container
 
 from ion.processes.data.replay.replay_client import ReplayClient
 from ion.services.dm.ingestion.test.ingestion_management_test import IngestionManagementIntTest
@@ -808,7 +809,9 @@ class TestDMEnd2End(IonIntegrationTestCase):
 
 
 class DatasetMonitor(object):
-    def __init__(self, dataset_id):
+    def __init__(self, dataset_id=None, data_product_id=None):
+        if data_product_id and not dataset_id:
+            dataset_id = Container.instance.resource_registry.find_objects(data_product_id, PRED.hasDataset, id_only=True)[0][0]
         self.dataset_id = dataset_id
         self.event = Event()
 

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -27,7 +27,6 @@ from coverage_model import ParameterContext, ParameterFunctionType, ParameterDic
 from ion.processes.data.replay.replay_client import ReplayClient
 
 from pyon.util.arg_check import validate_is_instance
-from pyon.util.breakpoint import debug_wrapper, breakpoint
 from ion.util.module_uploader import RegisterModulePreparerPy
 import inspect
 import os
@@ -367,6 +366,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         #todo: out publishers can be either stream or event
         #todo: determine if/how routing tables will be managed
         dpd_obj = self.read_data_process_definition(data_process_definition_id)
+        configuration = DotDict(configuration or {})
         if dpd_obj.data_process_type == DataProcessTypeEnum.PARAMETER_FUNCTION:
             # A different kind of data process
             # this function creates a data process resource for each data product and appends the parameter
@@ -449,7 +449,6 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         self.clients.resource_registry.create_association(subject=data_process_id, predicate=PRED.hasProcess, object=transform_worker_pid)
         return exchange_name
 
-    @debug_wrapper
     def _initialize_retrieve_process(self, data_process_definition, in_data_product_ids, out_data_product_ids, configuration, argument_map, out_param_name):
         '''
         Initializes a retreive process
@@ -973,7 +972,6 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         return data_proc_obj
 
 
-    @debug_wrapper
     def read_data_process_for_stream(self, stream_id="", worker_process_id=""):
         dataprocess_details_list = []
 
@@ -987,9 +985,6 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         if replay_id:
             dataprocess_ids.extend(self._get_data_process_from_replay(replay_id))
 
-        import threading
-        print threading.current_thread().name 
-        print 'IDS:', dataprocess_ids
 
         #create a dict of information for each data process assoc with this stream is
         for dataprocess_id in dataprocess_ids:

--- a/ion/services/sa/test/test_data_process_functions.py
+++ b/ion/services/sa/test/test_data_process_functions.py
@@ -202,6 +202,7 @@ class TestDataProcessFunctions(DMTestCase):
 
         # Setup replay
         self.data_process_management.activate_data_process(data_process_id)
+        breakpoint(locals(), globals())
 
     def create_data_process_logger(self, data_product_id, argument_map):
         '''
@@ -216,7 +217,7 @@ class TestDataProcessFunctions(DMTestCase):
                            name='stream_logger',
                            description='',
                            function='stream_logger',
-                           module='ion.processes.data.transforms.test.test_transform_worker',
+                           module='ion.services.sa.test.test_data_process_functions',
                            arguments=['x'],
                            function_type=TransformFunctionType.TRANSFORM)
         func_id = self.data_process_management.create_transform_function(tf_obj)
@@ -227,11 +228,14 @@ class TestDataProcessFunctions(DMTestCase):
                             name='stream_logger',
                             description='logs some stream stuff',
                             data_process_type=DataProcessTypeEnum.RETRIEVE_PROCESS)
+        configuration = DotDict()
+        configuration.publish_limit = 1000
         dpd_id = self.data_process_management.create_data_process_definition_new(dpd_obj, func_id)
         data_process_id = self.data_process_management.create_data_process_new(
                             data_process_definition_id=dpd_id, 
                             inputs=[data_product_id], 
                             outputs=[clone_id], 
+                            configuration=configuration,
                             argument_map=argument_map, 
                             out_param_name=out_name) 
         return data_process_id

--- a/ion/services/sa/test/test_data_process_functions.py
+++ b/ion/services/sa/test/test_data_process_functions.py
@@ -201,6 +201,7 @@ class TestDataProcessFunctions(DMTestCase):
         self.assertTrue(dataset_monitor.wait())
 
         # Setup replay
+        self.data_process_management.activate_data_process(data_process_id)
 
     def create_data_process_logger(self, data_product_id, argument_map):
         '''
@@ -225,10 +226,14 @@ class TestDataProcessFunctions(DMTestCase):
         dpd_obj = IonObject(RT.DataProcessDefinition,
                             name='stream_logger',
                             description='logs some stream stuff',
-                            data_process_type=DataProcessTypeEnum.TRANSFORM_PROCESS)
+                            data_process_type=DataProcessTypeEnum.RETRIEVE_PROCESS)
         dpd_id = self.data_process_management.create_data_process_definition_new(dpd_obj, func_id)
-        data_process_id = self.data_process_management.create_data_process_new(dpd_id, in_data_product_ids=[data_product_id], out_data_product_ids=[clone_id], 
-                                                                         argument_map=argument_map, out_param_name=out_name) 
+        data_process_id = self.data_process_management.create_data_process_new(
+                            data_process_definition_id=dpd_id, 
+                            inputs=[data_product_id], 
+                            outputs=[clone_id], 
+                            argument_map=argument_map, 
+                            out_param_name=out_name) 
         return data_process_id
 
     def clone_data_product(self, data_product_id):


### PR DESCRIPTION
[CIDEVSTC-43](https://jira.oceanobservatories.org/tasks/browse/CIDEVSTC-43)
- Implements the service support and transform support for RETRIEVE_PROCESS
- Adds and manages associations between Data Processes and Replay instances
- Tests retrieving data from data product and running transform.
