### PR TITLE
OOIION-1760

### DIFF
--- a/ion/services/dm/presentation/discovery_service.py
+++ b/ion/services/dm/presentation/discovery_service.py
@@ -81,7 +81,7 @@ class DiscoveryService(BaseDiscoveryService):
             raise BadRequest('Unsuported request. %s' % query)
 
         # if count requested, run id_only query without limit/skip
-        count = search_args.get("count", False)
+        count = search_args and search_args.get("count", False)
         if count:
             """Only return the count of ID only search"""
             query.pop("limit", None)


### PR DESCRIPTION
Check to make sure search_args is defined before accessing it.  Why search_args is undefined is probably a better question to answer, but at least checking for it 1st prevents ubuntu from gracelessly failing a search.
