### PR TITLE
OOIION-1760 Fixes service-client None issue with discovery

### DIFF
--- a/ion/services/dm/presentation/discovery_service.py
+++ b/ion/services/dm/presentation/discovery_service.py
@@ -69,7 +69,8 @@ class DiscoveryService(BaseDiscoveryService):
         query_request = parser.parse(query_string)
         return query_request
 
-    def request(self, query=None, id_only=True, search_args={}):
+    def request(self, query=None, id_only=True, search_args=None):
+        search_args = search_args or {} # Service clients don't pass empty dicts they pass None or NULL
         if not query:
             raise BadRequest('No request query provided')
 


### PR DESCRIPTION
Service clients don't pass empty dictionaries. They pass None (or null in JSON). Service implementors need to account for this by specifying keyword arguments that would normally default to an empty dictionary as None and then accepting either a dictionary object or None.
