### PR TITLE
OOIION-1774 Fixes ingestion bug and performance issue

### DIFF
--- a/ion/processes/data/ingestion/science_granule_ingestion_worker.py
+++ b/ion/processes/data/ingestion/science_granule_ingestion_worker.py
@@ -470,7 +470,7 @@ class ScienceGranuleIngestionWorker(TransformStreamListener, BaseIngestionWorker
 
         self.fill_lookup_values(rdt)
         for field in rdt.fields:
-            if rdt[field] is None:
+            if rdt._rd[field] is None:
                 continue
             if not isinstance(rdt.context(field).param_type, SparseConstantType):
                 # We only set sparse values before insert

--- a/ion/services/dm/test/test_dm_extended.py
+++ b/ion/services/dm/test/test_dm_extended.py
@@ -23,8 +23,9 @@ from ion.processes.data.transforms.transform_worker import TransformWorker
 from interface.objects import DataProcessDefinition, InstrumentDevice
 from nose.plugins.attrib import attr
 from pyon.util.breakpoint import breakpoint
+from pyon.event.event import EventSubscriber
 from pyon.util.file_sys import FileSystem
-from pyon.public import IonObject, RT, CFG, PRED
+from pyon.public import IonObject, RT, CFG, PRED, OT
 from pyon.util.containers import DotDict
 from pydap.client import open_url
 from shutil import rmtree
@@ -37,6 +38,7 @@ import unittest
 import numpy as np
 import time
 import gevent
+from gevent.event import Event
 import calendar
 
 class TestDMExtended(DMTestCase):
@@ -1442,5 +1444,39 @@ def rotate_v(u,v,theta):
         dp_ids = self.discovery.query(search_query)
         self.assertIn(data_product_id, dp_ids)
 
+    @attr("INT")
+    def test_ingestion_eval(self):
+        '''
+        This test verifies that ingestion does NOT try to evaluate the values coming in
+        '''
 
+        # Make a new function for failure
+        owner = 'ion.util.functions'
+        func = 'fail'
+        arg_list = ['x']
+        expr = PythonFunction('fail', owner, func, arg_list)
+        expr_id = self.dataset_management.create_parameter_function(name='fail', parameter_function=expr.dump())
+        self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
+        expr.param_map = {'x':'temp'}
+        failure_ctx = ParameterContext('failure', param_type=ParameterFunctionType(expr))
+        failure_ctx.uom = '1'
+        failure_ctxt_id = self.dataset_management.create_parameter_context(name='failure', parameter_context=failure_ctx.dump(), parameter_function_id=expr_id)
+        self.addCleanup(self.dataset_management.delete_parameter_context, failure_ctxt_id)
+
+        pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict')
+        self.resource_registry.create_association(pdict_id, PRED.hasParameterContext, failure_ctxt_id)
+
+        data_product_id = self.make_ctd_data_product()
+        verified = Event()
+        event_subscriber = EventSubscriber(event_type=OT.GranuleIngestionErrorEvent, callback=lambda *args, **kwargs : verified.set(), auto_delete=True)
+        event_subscriber.start()
+        self.addCleanup(event_subscriber.stop)
+        dataset_monitor = DatasetMonitor(data_product_id=data_product_id)
+        rdt = self.ph.rdt_for_data_product(data_product_id)
+        rdt['time'] = [0]
+        rdt['temp'] = [1]
+        self.ph.publish_rdt_to_data_product(data_product_id, rdt)
+        self.assertTrue(dataset_monitor.wait())
+
+        self.assertFalse(verified.wait(2))
 

--- a/ion/util/functions.py
+++ b/ion/util/functions.py
@@ -14,6 +14,10 @@ from pyon.public import OT
 
 
 def fail(x):
+    '''
+    The goal behind this function is to publish an event so that threads
+    can synchronize with it to verify that it was run, regardless of context
+    '''
     event_publisher = EventPublisher(OT.GranuleIngestionErrorEvent)
     try:
         event_publisher.publish_event(error_msg='failure')

--- a/ion/util/functions.py
+++ b/ion/util/functions.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+'''
+Contains generic functions
+
+The initial purpose was to play home to parameter functions that 
+can be used for testing and non-scientific purposes
+'''
+
+__author__ = "Luke"
+
+from pyon.ion.event import EventPublisher
+from pyon.public import OT
+
+
+def fail(x):
+    event_publisher = EventPublisher(OT.GranuleIngestionErrorEvent)
+    try:
+        event_publisher.publish_event(error_msg='failure')
+
+        raise StandardError('Something you tried to do failed')
+    finally:
+        event_publisher.close()
+


### PR DESCRIPTION
Ingestion used to check to see if a parameter was empty by evaluating
it, which causes the entire parameter function to evaluate against the
array. This patch prevents ingestion from evaluating parameter functions
it doesn't need to.

[OOIION-1774](https://jira.oceanobservatories.org/tasks/browse/OOIION-1774)
