### PR TITLE
TEST - Removes deprecated part of retrieve test

### DIFF
--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -612,19 +612,6 @@ class TestDMEnd2End(IonIntegrationTestCase):
         
         self.assertTrue(dataset_id in DataRetrieverService._retrieve_cache)
 
-        DataRetrieverService._refresh_interval = 100
-        self.publish_hifi(stream_id,route,1)
-        self.wait_until_we_have_enough_granules(dataset_id, data_size=20)
-            
- 
-        event = gevent.event.Event()
-        with gevent.Timeout(20):
-            while not event.wait(0.1):
-                if dataset_id not in DataRetrieverService._retrieve_cache:
-                    event.set()
-
-
-        self.assertTrue(event.is_set())
 
         
     def publish_and_wait(self, dataset_id, granule):


### PR DESCRIPTION
- The test used to rely on the retrieve_last function actually hitting
  the cache. Cache support for this was removed at some point and it was
  by coincidence that the test didn't cause any issues.
