### PR TITLE
CIDEVSTC-98 Updates Devices with Site and Deployment attributes upon deployment

### DIFF
--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -715,6 +715,8 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
                 if d in device_ids:
                     a = self.RR.get_association(s, PRED.hasDevice, d)
                     self.RR.delete_association(a)
+                    log.info("Removing geo and updating temporal attrs for device '%s'", d)
+                    self.update_device_remove_geo_update_temporal(d)
                     self.RR.execute_lifecycle_transition(d, LCE.INTEGRATE)
 
         # This should set the deployment resource to retired.

--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -463,7 +463,7 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
 
         self.RR2.unassign_device_from_site_with_has_device(device_id, site_id)
 
-    def update_device_add_geo_add_temporal(self, device_id='', site_id='', deployment_obj=''):
+    def _update_device_add_geo_add_temporal(self, device_id='', site_id='', deployment_obj=''):
         """Assigns to device:
                temporal extent from deployment
                geo location from site
@@ -483,7 +483,7 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
                 device_obj.temporal_bounds = constraint
         self.RR.update(device_obj)
 
-    def update_device_remove_geo_update_temporal(self, device_id='', deployment_obj=''):
+    def _update_device_remove_geo_update_temporal(self, device_id='', deployment_obj=''):
         """Remove the geo location and update temporal extent (end) from the device
 
         @param device_id    str
@@ -667,14 +667,14 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
             log.info("Unassigning hasDevice; device '%s' from site '%s'", device_id, site_id)
             self.unassign_device_from_site(device_id, site_id)
             log.info("Removing geo and updating temporal attrs for device '%s'", device_id)
-            self.update_device_remove_geo_update_temporal(device_id, depl_obj)
+            self._update_device_remove_geo_update_temporal(device_id, depl_obj)
 
         # process the additions
         for site_id, device_id in deployment_activator.hasdevice_associations_to_create():
             log.info("Setting primary device '%s' for site '%s'", device_id, site_id)
             self.assign_device_to_site(device_id, site_id)
             log.info("Adding geo and updating temporal attrs for device '%s'", device_id)
-            self.update_device_add_geo_add_temporal(device_id, site_id, depl_obj)
+            self._update_device_add_geo_add_temporal(device_id, site_id, depl_obj)
 
 
         #        self.RR.execute_lifecycle_transition(deployment_id, LCE.DEPLOY)
@@ -725,7 +725,7 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
                     a = self.RR.get_association(s, PRED.hasDevice, d)
                     self.RR.delete_association(a)
                     log.info("Removing geo and updating temporal attrs for device '%s'", d)
-                    self.update_device_remove_geo_update_temporal(d, deployment_obj)
+                    self._update_device_remove_geo_update_temporal(d, deployment_obj)
                     self.RR.execute_lifecycle_transition(d, LCE.INTEGRATE)
 
         # This should set the deployment resource to retired.

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -15,7 +15,7 @@ from interface.services.sa.idata_product_management_service import DataProductMa
 from interface.services.sa.idata_acquisition_management_service import DataAcquisitionManagementServiceClient
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
 from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
-from interface.objects import PortTypeEnum
+from interface.objects import PortTypeEnum, GeospatialBounds
 
 from pyon.util.context import LocalContextMixin
 from pyon.core.exception import NotFound, BadRequest
@@ -192,9 +192,17 @@ class TestDeployment(IonIntegrationTestCase):
         # Create platform site, platform device, platform model
         #-------------------------------------------------------------------------------------
 
+        bounds = GeospatialBounds(geospatial_latitude_limit_north=float(5),
+                                  geospatial_latitude_limit_south=float(5),
+                                  geospatial_longitude_limit_west=float(15),
+                                  geospatial_longitude_limit_east=float(15),
+                                  geospatial_vertical_min=float(0),
+                                  geospatial_vertical_max=float(1000))
+
         platform_site__obj = IonObject(RT.PlatformSite,
                                         name='PlatformSite1',
-                                        description='test platform site')
+                                        description='test platform site',
+                                        constraint_list=[bounds])
         platform_site_id = self.omsclient.create_platform_site(platform_site__obj)
 
         platform_device_obj = IonObject(RT.PlatformDevice,
@@ -213,9 +221,17 @@ class TestDeployment(IonIntegrationTestCase):
         # Create instrument site
         #-------------------------------------------------------------------------------------
 
+        bounds = GeospatialBounds(geospatial_latitude_limit_north=float(45),
+                                  geospatial_latitude_limit_south=float(40),
+                                  geospatial_longitude_limit_west=float(-75),
+                                  geospatial_longitude_limit_east=float(-70),
+                                  geospatial_vertical_min=float(0),
+                                  geospatial_vertical_max=float(500))
+
         instrument_site_obj = IonObject(RT.InstrumentSite,
                                         name='InstrumentSite1',
-                                        description='test instrument site')
+                                        description='test instrument site',
+                                        constraint_list=[bounds])
         instrument_site_id = self.omsclient.create_instrument_site(instrument_site_obj, platform_site_id)
 
         pdict_id = self.dataset_management.read_parameter_dictionary_by_name('ctd_parsed_param_dict', id_only=True)
@@ -248,9 +264,9 @@ class TestDeployment(IonIntegrationTestCase):
         # Create a deployment object
         #----------------------------------------------------------------------------------------------------
 
-        start = IonTime(datetime.datetime(2013,1,1))
-        end = IonTime(datetime.datetime(2014,1,1))
-        temporal_bounds = IonObject(OT.TemporalBounds, name='planned', start_datetime=start.to_string(), end_datetime=end.to_string())
+        start = (datetime.datetime(2013,1,1) - datetime.datetime.utcfromtimestamp(0)).total_seconds()
+        end = (datetime.datetime(2014,1,1) - datetime.datetime.utcfromtimestamp(0)).total_seconds()
+        temporal_bounds = IonObject(OT.TemporalBounds, name='planned', start_datetime=str(start), end_datetime=str(end))
         deployment_obj = IonObject(RT.Deployment,
                                    name='TestDeployment',
                                    description='some new deployment',

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -307,11 +307,33 @@ class TestDeployment(IonIntegrationTestCase):
         self.omsclient.deploy_platform_site(res.platform_site_id, res.deployment_id)
         self.imsclient.deploy_platform_device(res.platform_device_id, res.deployment_id)
 
+        before_activate_instrument_device_obj = self.rrclient.read(res.instrument_device_id)
+
         log.debug("activating deployment, expecting success")
         self.omsclient.activate_deployment(res.deployment_id)
 
+        def assertGeospatialBoundsEquals(a, b):
+            self.assertEquals(a['geospatial_latitude_limit_north'],b['geospatial_latitude_limit_north'])
+            self.assertEquals(a['geospatial_latitude_limit_south'],b['geospatial_latitude_limit_south'])
+            self.assertEquals(a['geospatial_longitude_limit_west'],b['geospatial_longitude_limit_west'])
+            self.assertEquals(a['geospatial_longitude_limit_east'],b['geospatial_longitude_limit_east'])
+
+        def assertGeospatialBoundsNotEquals(a, b):
+            self.assertNotEquals(a['geospatial_latitude_limit_north'],b['geospatial_latitude_limit_north'])
+            self.assertNotEquals(a['geospatial_latitude_limit_south'],b['geospatial_latitude_limit_south'])
+            self.assertNotEquals(a['geospatial_longitude_limit_west'],b['geospatial_longitude_limit_west'])
+            self.assertNotEquals(a['geospatial_longitude_limit_east'],b['geospatial_longitude_limit_east'])
+
+        after_activate_instrument_device_obj = self.rrclient.read(res.instrument_device_id)
+        assertGeospatialBoundsNotEquals(before_activate_instrument_device_obj.geospatial_bounds,after_activate_instrument_device_obj.geospatial_bounds)
+
         log.debug("deactivatin deployment, expecting success")
         self.omsclient.deactivate_deployment(res.deployment_id)
+
+        after_deactivate_instrument_device_obj = self.rrclient.read(res.instrument_device_id)
+
+        assertGeospatialBoundsNotEquals(after_activate_instrument_device_obj.geospatial_bounds, after_deactivate_instrument_device_obj.geospatial_bounds)
+
 
     #@unittest.skip("targeting")
     def test_activate_deployment_nomodels(self):


### PR DESCRIPTION
Updates Devices with Site and Deployment attributes upon deployment and removes when deployment is deactivated.

Device uses Site for geospatial bounds and Deployment for temporal bounds

Upon deactivation, geospatial is returned to the default 0's and temporal bounds is once again copied from the Deployment object
