### PR TITLE
CIDEVSTC-49 - Refactors Parameter-based DM service methods to respect IonObjects

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -1901,7 +1901,7 @@ Reason: %s
 
         if pfid and ptype!='function':
             log.warn('Parameter %s (%s) has type %s, did not expect function %s', row['ID'], name, ptype, pfid)
-            #validate parameter type
+        #validate parameter type
         try:
             tm = TypesManager(dataset_management, self.resource_ids, self.resource_objs)
             param_type = tm.get_parameter_type(ptype, encoding,code_set,pfid, pmap)

--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -213,7 +213,6 @@ class DatasetManagementService(BaseDatasetManagementService):
         return parameter_context_id
 
     @classmethod
-    @debug_wrapper
     def get_coverage_parameter(cls, parameter_context):
         '''
         Creates a Coverage Model based Parameter Context given the 

--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -278,7 +278,9 @@ class DatasetManagementService(BaseDatasetManagementService):
                                   owner=parameter_function.owner,
                                   func_name=parameter_function.function,
                                   arg_list=parameter_function.args,
-                                  kwarg_map=None)
+                                  kwarg_map=None,
+                                  param_map=None,
+                                  egg_uri=parameter_function.egg_uri)
         elif parameter_function.function_type == PFT.NUMEXPR:
             func = NumexprFunction(name=parameter_function.name, 
                                    expression=parameter_function.function, 

--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -25,7 +25,7 @@ from coverage_model import AbstractCoverage, ViewCoverage, ComplexCoverage, Comp
 from coverage_model.parameter_functions import AbstractFunction
 from interface.services.sa.idata_process_management_service import DataProcessManagementServiceProcessClient
 from coverage_model import NumexprFunction, PythonFunction, QuantityType, ParameterFunctionType
-from interface.objects import DataProcessDefinition, DataProcessTypeEnum
+from interface.objects import DataProcessDefinition, DataProcessTypeEnum, ParameterFunctionType as PFT
 
 from uuid import uuid4
 
@@ -250,24 +250,38 @@ class DatasetManagementService(BaseDatasetManagementService):
 
 #--------
 
-    def create_parameter_function(self, name='', parameter_function=None, description=''):
-        validate_true(name, 'Name field may not be empty')
-        validate_is_instance(parameter_function, dict, 'parameter_function field is not dictable.')
-        parameter_function = self.numpy_walk(parameter_function)
-        pf_res = ParameterFunctionResource(name=name, parameter_function=parameter_function, description=description)
-        pf_id, ver = self.clients.resource_registry.create(pf_res)
+    def create_parameter_function(self, parameter_function=None):
+        validate_is_instance(parameter_function, ParameterFunctionResource)
+        pf_id, ver = self.clients.resource_registry.create(parameter_function)
         return pf_id
 
     def read_parameter_function(self, parameter_function_id=''):
         res = self.clients.resource_registry.read(parameter_function_id)
         validate_is_instance(res, ParameterFunctionResource)
-        res.parameter_function = self.numpy_walk(res.parameter_function)
         return res
 
     def delete_parameter_function(self, parameter_function_id=''):
         self.read_parameter_function(parameter_function_id)
         self.clients.resource_registry.delete(parameter_function_id)
         return True
+
+    @classmethod
+    def get_coverage_function(self, parameter_function=None):
+        func = None
+        if parameter_function.function_type == PFT.PYTHON:
+            func = PythonFunction(name=parameter_function.name,
+                                  owner=parameter_function.owner,
+                                  func_name=parameter_function.function,
+                                  arg_list=parameter_function.args,
+                                  kwarg_map=None)
+        elif parameter_function.function_type == PFT.NUMEXPR:
+            func = NumexprFunction(name=parameter_function.name, 
+                                   expression=parameter_function.function, 
+                                   arg_list=parameter_function.args)
+        if not isinstance(func, AbstractFunction):
+            raise Conflict("Incompatible parameter function loaded: %s" % parameter_function._id)
+        return func
+
 
 #--------
 
@@ -281,25 +295,26 @@ class DatasetManagementService(BaseDatasetManagementService):
         descr     = row['Description']
 
         data_process_management = DataProcessManagementServiceProcessClient(self)
-        func = None
-        if ftype == 'NumexprFunction':
-            func = NumexprFunction(row['Name'], func_expr, args)
-        elif ftype == 'PythonFunction':
-            func = PythonFunction(name, owner, func_expr, args, None)
+
+        function_type=None
+        if ftype == 'PythonFunction':
+            function_type = PFT.PYTHON
+        elif ftype == 'NumexprFunction':
+            function_type = PFT.NUMEXPR
         else:
             raise Conflict('Unsupported Function Type: %s' % ftype)
-            return
-
         
-        #--- create_function ---
-        parameter_function = func.dump()
-        validate_true(name, 'Name field may not be empty')
-        validate_is_instance(parameter_function, dict, 'parameter_function field is not dictable.')
-        parameter_function = self.numpy_walk(parameter_function)
-        pf_res = ParameterFunctionResource(name=name, parameter_function=parameter_function, description=descr)
-        pf_res.alt_ids = ['PRE:' + row['ID']]
-        pf_id, ver = self.clients.resource_registry.create(pf_res)
-        #-----------------------
+        parameter_function = ParameterFunctionResource(
+                    name=name, 
+                    function=func_expr,
+                    function_type=function_type,
+                    owner=owner,
+                    args=args,
+                    description=descr)
+        parameter_function.alt_ids = ['PRE:' + row['ID']]
+
+        parameter_function_id = self.create_parameter_function(parameter_function)
+        
 
         dpd = DataProcessDefinition()
         dpd.name = name
@@ -307,9 +322,168 @@ class DatasetManagementService(BaseDatasetManagementService):
         dpd.data_process_type = DataProcessTypeEnum.PARAMETER_FUNCTION
         dpd.parameters = args
 
-        data_process_management.create_data_process_definition(dpd, pf_id)
+        data_process_management.create_data_process_definition(dpd, parameter_function_id)
 
-        return pf_id
+        return parameter_function_id
+
+    def _parse_lookup_value(self, context, lookup_value, name):
+        if lookup_value:
+            if lookup_value.lower() == 'true':
+                context.lookup_value = name
+                context.document_key = ''
+            else:
+                if '||' in lookup_value:
+                    context.lookup_value,context.document_key = lookup_value.split('||')
+                else:
+                    context.lookup_value = name
+                    context.document_key = lookup_value
+
+    def load_parameter_context(self, row):
+        from ion.services.dm.utility.types import TypesManager
+
+        def sanitize_uni(s):
+            b = []
+            for a in s:
+                if ord(a) <= 128:
+                    b.append(a)
+            return ''.join(b)
+
+
+        self.row_count += 1
+        name         = sanitize_uni(row['Name'])
+        ptype        = sanitize_uni(row['Parameter Type'])
+        encoding     = sanitize_uni(row['Value Encoding'])
+        uom          = sanitize_uni(row['Unit of Measure'] or 'undefined')
+        code_set     = sanitize_uni(row['Code Set'])
+        fill_value   = sanitize_uni(row['Fill Value'])
+        display_name = sanitize_uni(row['Display Name'])
+        std_name     = sanitize_uni(row['Standard Name'])
+        long_name    = sanitize_uni(row['Long Name'])
+        references   = sanitize_uni(row['confluence'])
+        description  = sanitize_uni(row['Description'])
+        pfid         = sanitize_uni(row['Parameter Function ID'])
+        pmap         = sanitize_uni(row['Parameter Function Map'])
+        sname        = sanitize_uni(row['Data Product Identifier'])
+        precision    = sanitize_uni(row['Precision'])
+        param_id     = sanitize_uni(row['ID'])
+        lookup_value = sanitize_uni(row['Lookup Value'])
+        qc           = sanitize_uni(row['QC Functions'])
+        visible      = get_typed_value(row['visible'], targettype="bool") if row['visible'] else True
+
+        dataset_management = self
+
+        #validate unit of measure
+        # allow google doc to include more maintainable "key: value, key: value" instead of python "{ 'key': 'value', 'key': 'value' }"
+        pmap = pmap if pmap.startswith('{') else repr(parse_dict(pmap))
+
+        if pfid and ptype!='function':
+            log.warn('Parameter %s (%s) has type %s, did not expect function %s', row['ID'], name, ptype, pfid)
+            #validate parameter type
+        try:
+            tm = TypesManager(dataset_management, self.resource_ids, self.resource_objs)
+            param_type = tm.get_parameter_type(ptype, encoding,code_set,pfid, pmap)
+            context = ParameterContext(name=name, param_type=param_type)
+            context.uom = uom
+            try:
+                tm.get_unit(uom)
+            except UdunitsError as e:
+                log.warning('Parameter %s (%s) has invalid units: %s', name,param_id, uom)
+            context.fill_value = tm.get_fill_value(fill_value, encoding, param_type)
+            context.reference_urls = references
+            context.internal_name = name
+            context.display_name = display_name
+            context.standard_name = std_name
+            context.ooi_short_name = sname
+            context.description = description
+            context.precision = precision
+            context.visible = visible
+            self._parse_lookup_value(context, lookup_value, name)
+            
+            qc_map = {
+                    'Global Range Test (GLBLRNG) QC'                         : 'glblrng_qc',
+                    'Stuck Value Test (STUCKVL) QC'                          : 'stuckvl_qc',
+                    'Spike Test (SPKETST) QC'                                : 'spketst_qc',
+                    'Trend Test (TRNDTST) QC'                                : 'trndtst_qc',
+                    'Gradient Test (GRADTST) QC'                             : 'gradtst_qc',
+                    'Local Range Test (LOCLRNG) QC'                          : 'loclrng_qc',
+                    'Modulus (MODULUS) QC'                                   : 'modulus_qc',
+                    'Evaluate Polynomial (POLYVAL) QC'                       : 'polyval_qc',
+                    'Solar Elevation (SOLAREL) QC'                           : 'solarel_qc',
+                    'Conductivity Compressibility Compensation (CONDCMP) QC' : 'condcmp_qc',
+                    '1-D Interpolation (INTERP1) QC'                         : 'interp1_qc',
+                    'Combine QC Flags (CMBNFLG) QC'                          : 'cmbnflg_qc',
+                    }
+            
+            qc_fields = None
+            if self.ooi_loader._extracted:
+                # Yes, OOI Assets were parsed
+                dps = self.ooi_loader.get_type_assets('data_product')
+                if context.ooi_short_name in dps:
+                    dp = dps[context.ooi_short_name]
+                    qc_fields = [v for k,v in qc_map.iteritems() if dp[k] == 'applicable']
+                    if qc_fields and not qc: # If the column wasn't filled out but SAF says it should be there, just use the OOI Short Name
+                        log.warning("Enabling QC for %s (%s) based on SAF requirement but QC-identifier wasn't specified.", name, row[COL_ID])
+                        qc = sname
+                    
+
+
+            if qc:
+                try:
+                    if isinstance(context.param_type, (QuantityType, ParameterFunctionType)):
+                        context.qc_contexts = tm.make_qc_functions(name,qc,self._register_id, qc_fields)
+                except KeyError:
+                    pass
+
+        except TypeError as e:
+            log.exception(e.message)
+            self._conflict_report(row['ID'], row['Name'], e.message)
+            return
+        except Exception:
+            log.exception('Could not load the following parameter definition: %s', row)
+            return
+
+        context_dump = context.dump()
+
+        try:
+            json.dumps(context_dump)
+        except Exception as e:
+            self._conflict_report(row['ID'], row['Name'], e.message)
+            return
+        try:
+            creation_args = dict(
+                name=name, parameter_context=context_dump,
+                description=description,
+                reference_urls=[references],
+                parameter_type=ptype,
+                internal_name=name,
+                value_encoding=encoding,
+                code_report=code_set,
+                units=uom,
+                fill_value=fill_value,
+                display_name=display_name,
+                parameter_function_map=pmap,
+                standard_name=std_name,
+                ooi_short_name=sname,
+                precision=precision,
+                visible=visible,
+                headers=self._get_system_actor_headers())
+            if pfid:
+                try:
+                    creation_args['parameter_function_id'] = self.resource_ids[pfid]
+                except KeyError:
+                    pass
+            context_id = dataset_management.create_parameter_context(**creation_args)
+            context_obj = self.container.resource_registry.read(context_id)
+            context_obj.alt_ids = ['PRE:'+row[COL_ID]]
+            self.container.resource_registry.update(context_obj)
+        except AttributeError as e:
+            if e.message == "'dict' object has no attribute 'read'":
+                self._conflict_report(row['ID'], row['Name'], 'Something is not JSON compatible.')
+                return
+            else:
+                self._conflict_report(row['ID'], row['Name'], e.message)
+                return
+        self._register_id(row[COL_ID], context_id, context_obj)
 
 #--------
 

--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -266,7 +266,7 @@ class DatasetManagementService(BaseDatasetManagementService):
         return True
 
     @classmethod
-    def get_coverage_function(self, parameter_function=None):
+    def get_coverage_function(self, parameter_function):
         func = None
         if parameter_function.function_type == PFT.PYTHON:
             func = PythonFunction(name=parameter_function.name,

--- a/ion/services/dm/test/test_dm_end_2_end.py
+++ b/ion/services/dm/test/test_dm_end_2_end.py
@@ -757,7 +757,6 @@ class TestDMEnd2End(IonIntegrationTestCase):
 
 
 
-
 class DatasetMonitor(object):
     def __init__(self, dataset_id=None, data_product_id=None):
         if data_product_id and not dataset_id:

--- a/ion/services/dm/test/test_dm_extended.py
+++ b/ion/services/dm/test/test_dm_extended.py
@@ -20,7 +20,7 @@ from ion.services.dm.utility.provenance import graph
 from ion.processes.data.registration.registration_process import RegistrationProcess
 from coverage_model import ParameterFunctionType, ParameterDictionary, PythonFunction, ParameterContext
 from ion.processes.data.transforms.transform_worker import TransformWorker
-from interface.objects import DataProcessDefinition, InstrumentDevice
+from interface.objects import DataProcessDefinition, InstrumentDevice, ParameterFunction, ParameterFunctionType as PFT 
 from nose.plugins.attrib import attr
 from pyon.util.breakpoint import breakpoint
 from pyon.event.event import EventSubscriber
@@ -1419,9 +1419,10 @@ def rotate_v(u,v,theta):
         owner = 'ion.util.functions'
         func = 'fail'
         arg_list = ['x']
-        expr = PythonFunction('fail', owner, func, arg_list)
-        expr_id = self.dataset_management.create_parameter_function(name='fail', parameter_function=expr.dump())
+        pf = ParameterFunction(name='fail', function_type=PFT.PYTHON, owner=owner, function=func, args=arg_list)
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = {'x':'temp'}
         failure_ctx = ParameterContext('failure', param_type=ParameterFunctionType(expr))
         failure_ctx.uom = '1'

--- a/ion/services/dm/utility/test/parameter_helper.py
+++ b/ion/services/dm/utility/test/parameter_helper.py
@@ -5,6 +5,7 @@
 @brief Helpers for Parameters
 '''
 from coverage_model import ParameterContext, QuantityType, AxisTypeEnum, ArrayType, CategoryType, ConstantType, NumexprFunction, ParameterFunctionType, VariabilityEnum, PythonFunction, SparseConstantType
+from interface.objects import ParameterFunction, ParameterFunctionType as PFT
 from ion.services.dm.utility.types import TypesManager
 from ion.services.dm.utility.granule import RecordDictionaryTool
 from pyon.container.cc import Container
@@ -202,12 +203,13 @@ class ParameterHelper(object):
 
         # TEMPWAT_L1 = (TEMPWAT_L0 / 10000) - 10
         tl1_func = '(temperature / 10000.0) - 10'
-        expr = NumexprFunction('temp_L1', tl1_func, ['temperature'])
-        expr_id = self.dataset_management.create_parameter_function(name='temp_L1', parameter_function=expr.dump())
+        pf = ParameterFunction(name='temp_L1', function_type=PFT.NUMEXPR, function=tl1_func, args=['temperature'])
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['temp_L1'] = expr, expr_id
+        funcs['temp_L1'] = pf, expr_id
 
         tl1_pmap = {'temperature':'temp'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = tl1_pmap
         tempL1_ctxt = ParameterContext('temp_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         tempL1_ctxt.uom = 'deg_C'
@@ -217,12 +219,13 @@ class ParameterHelper(object):
 
         # CONDWAT_L1 = (CONDWAT_L0 / 100000) - 0.5
         cl1_func = '(conductivity / 100000.0) - 0.5'
-        expr = NumexprFunction('conductivity_L1', cl1_func, ['conductivity'])
-        expr_id = self.dataset_management.create_parameter_function(name='conductivity_L1', parameter_function=expr.dump())
+        pf = ParameterFunction(name='conductivity_L1', function_type=PFT.NUMEXPR, function=cl1_func, args=['conductivity'])
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['conductivity_L1'] = expr, expr_id
+        funcs['conductivity_L1'] = pf, expr_id
 
         cl1_pmap = {'conductivity':'conductivity'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = cl1_pmap
         condL1_ctxt = ParameterContext('conductivity_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         condL1_ctxt.uom = 'S m-1'
@@ -233,12 +236,13 @@ class ParameterHelper(object):
         # Equation uses p_range, which is a calibration coefficient - Fixing to 679.34040721
         #   PRESWAT_L1 = (PRESWAT_L0 * p_range / (0.85 * 65536)) - (0.05 * p_range)
         pl1_func = '(pressure / 100.0) + 0.5'
-        expr = NumexprFunction('pressure_L1', pl1_func, ['pressure'])
-        expr_id = self.dataset_management.create_parameter_function(name='pressure_L1', parameter_function=expr.dump())
+        pf = ParameterFunction(name='pressure_L1', function_type=PFT.NUMEXPR, function=pl1_func, args=['pressure'])
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['pressure_L1'] = expr, expr_id
+        funcs['pressure_L1'] = pf, expr_id
         
         pl1_pmap = {'pressure':'pressure'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = pl1_pmap
         presL1_ctxt = ParameterContext('pressure_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         presL1_ctxt.uom = 'S m-1'
@@ -253,13 +257,14 @@ class ParameterHelper(object):
         owner = 'ion_functions.workflow_tests.fake_data'
         sal_func = 'data_l2_salinity'
         sal_arglist = ['conductivity', 'temp', 'pressure']
-        expr = PythonFunction('salinity_L2', owner, sal_func, sal_arglist)
-        expr_id = self.dataset_management.create_parameter_function(name='salinity_L2', parameter_function=expr.dump())
+        pf = ParameterFunction(name='salinity_L2', function_type=PFT.PYTHON, owner=owner, function=sal_func, args=sal_arglist)
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['salinity_L2'] = expr, expr_id
+        funcs['salinity_L2'] = pf, expr_id
         
         # A magic function that may or may not exist actually forms the line below at runtime.
         sal_pmap = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = sal_pmap
         sal_ctxt = ParameterContext('salinity', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
         sal_ctxt.uom = 'g kg-1'
@@ -273,13 +278,14 @@ class ParameterHelper(object):
         owner = 'ion_functions.workflow_tests.fake_data'
         dens_func = 'data_l2_density'
         dens_arglist =['conductivity', 'temp', 'pressure', 'lat', 'lon'] 
-        expr = PythonFunction('density_L2', owner, dens_func, dens_arglist)
-        expr_id = self.dataset_management.create_parameter_function(name='density_L2', parameter_function=expr.dump())
+        pf = ParameterFunction(name='density_L2', function_type=PFT.PYTHON, owner=owner, function=dens_func, args=dens_arglist)
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['density_L2'] = expr, expr_id
+        funcs['density_L2'] = pf, expr_id
 
 
         dens_pmap = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1', 'lat':'lat', 'lon':'lon'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = dens_pmap
         dens_ctxt = ParameterContext('density', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
         dens_ctxt.uom = 'kg m-3'
@@ -370,12 +376,13 @@ class ParameterHelper(object):
 
         # TEMPWAT_L1 = (TEMPWAT_L0 / 10000) - 10
         tl1_func = '(temperature / 10000.0) - 10'
-        expr = NumexprFunction('temp_L1', tl1_func, ['temperature'])
-        expr_id = self.dataset_management.create_parameter_function(name='temp_L1', parameter_function=expr.dump())
+        pf = ParameterFunction(name='temp_L1', function_type=PFT.NUMEXPR, function=tl1_func, args=['temperature'])
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['temp_L1'] = expr, expr_id
+        funcs['temp_L1'] = pf, expr_id
 
         tl1_pmap = {'temperature':'temp'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = tl1_pmap
         tempL1_ctxt = ParameterContext('temp_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         tempL1_ctxt.uom = 'deg_C'
@@ -385,12 +392,13 @@ class ParameterHelper(object):
 
         # CONDWAT_L1 = (CONDWAT_L0 / 100000) - 0.5
         cl1_func = '(conductivity / 100000.0) - 0.5'
-        expr = NumexprFunction('conductivity_L1', cl1_func, ['conductivity'])
-        expr_id = self.dataset_management.create_parameter_function(name='conductivity_L1', parameter_function=expr.dump())
+        pf = ParameterFunction(name='conductivity_L1', function_type=PFT.NUMEXPR, function=cl1_func, args=['conductivity'])
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['conductivity_L1'] = expr, expr_id
+        funcs['conductivity_L1'] = pf, expr_id
 
         cl1_pmap = {'conductivity':'conductivity'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = cl1_pmap
         condL1_ctxt = ParameterContext('conductivity_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         condL1_ctxt.uom = 'S m-1'
@@ -401,12 +409,13 @@ class ParameterHelper(object):
         # Equation uses p_range, which is a calibration coefficient - Fixing to 679.34040721
         #   PRESWAT_L1 = (PRESWAT_L0 * p_range / (0.85 * 65536)) - (0.05 * p_range)
         pl1_func = '(pressure / 100.0) + 0.5'
-        expr = NumexprFunction('pressure_L1', pl1_func, ['pressure'])
-        expr_id = self.dataset_management.create_parameter_function(name='pressure_L1', parameter_function=expr.dump())
+        pf = ParameterFunction(name='pressure_L1', function_type=PFT.NUMEXPR, function=pl1_func, args=['pressure'])
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['pressure_L1'] = expr, expr_id
+        funcs['pressure_L1'] = pf, expr_id
         
         pl1_pmap = {'pressure':'pressure'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = pl1_pmap
         presL1_ctxt = ParameterContext('pressure_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         presL1_ctxt.uom = 'S m-1'
@@ -421,13 +430,14 @@ class ParameterHelper(object):
         owner = 'ion_functions.workflow_tests.fake_data'
         sal_func = 'data_l2_salinity'
         sal_arglist = ['conductivity', 'temp', 'pressure']
-        expr = PythonFunction('salinity_L2', owner, sal_func, sal_arglist)
-        expr_id = self.dataset_management.create_parameter_function(name='salinity_L2', parameter_function=expr.dump())
+        pf = ParameterFunction(name='salinity_L2', function_type=PFT.PYTHON, owner=owner, function=sal_func, args=sal_arglist)
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['salinity_L2'] = expr, expr_id
+        funcs['salinity_L2'] = pf, expr_id
         
         # A magic function that may or may not exist actually forms the line below at runtime.
         sal_pmap = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = sal_pmap
         sal_ctxt = ParameterContext('salinity', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
         sal_ctxt.uom = 'g kg-1'
@@ -441,13 +451,14 @@ class ParameterHelper(object):
         owner = 'ion_functions.workflow_tests.fake_data'
         dens_func = 'data_l2_density'
         dens_arglist =['conductivity', 'temp', 'pressure', 'lat', 'lon'] 
-        expr = PythonFunction('density_L2', owner, dens_func, dens_arglist)
-        expr_id = self.dataset_management.create_parameter_function(name='density_L2', parameter_function=expr.dump())
+        pf = ParameterFunction(name='density_L2', function_type=PFT.PYTHON, owner=owner, function=dens_func, args=dens_arglist)
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
-        funcs['density_L2'] = expr, expr_id
+        funcs['density_L2'] = pf, expr_id
 
 
         dens_pmap = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1', 'lat':'lat', 'lon':'lon'}
+        expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = dens_pmap
         dens_ctxt = ParameterContext('density', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
         dens_ctxt.uom = 'kg m-3'
@@ -505,11 +516,12 @@ class ParameterHelper(object):
         contexts['qc_whatever'] = qc_whatever_ctxt, qc_whatever_ctxt_id
 
 
-        nexpr = NumexprFunction('range_qc', 'min < var > max', ['min','max','var'])
-        expr_id = self.dataset_management.create_parameter_function(name='range_qc', parameter_function=nexpr.dump())
+        pf = ParameterFunction(name='range_qc', function_type=PFT.NUMEXPR, function='min < var > max', args=['min','max','var'])
+        expr_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
 
         pmap = {'min':0, 'max':20, 'var':'temp'}
+        nexpr = DatasetManagementService.get_coverage_function(pf)
         nexpr.param_map = pmap
         temp_qc_ctxt = ParameterContext('temp_qc', param_type=ParameterFunctionType(function=nexpr), variability=VariabilityEnum.TEMPORAL)
         temp_qc_ctxt.uom = '1'
@@ -565,28 +577,44 @@ class ParameterHelper(object):
         return lookup_pdict_id
 
     def create_global_range_function(self):
-        func = PythonFunction('global_range_test','ion_functions.qc.qc_functions','dataqc_globalrangetest_minmax',['dat','dat_min','dat_max'])
-        func_id = self.dataset_management.create_parameter_function(name='global_range_test', parameter_function=func.dump())
+        pf = ParameterFunction(name='global_range_test', 
+                               function_type=PFT.PYTHON, 
+                               owner='ion_functions.qc.qc_functions',
+                               function='dataqc_globalrangetest_minmax',
+                               args=['dat','dat_min','dat_max'])
+        func_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, func_id)
-        return func
+        return DatasetManagementService.get_coverage_function(pf)
 
     def create_spike_test_function(self):
-        func = PythonFunction('dataqc_spiketest','ion_functions.qc.qc_functions','dataqc_spiketest',['dat','acc','N','L'])
-        func_id = self.dataset_management.create_parameter_function(name='dataqc_spiketest', parameter_function=func.dump())
+        pf = ParameterFunction(name='dataqc_spiketest',
+                               function_type=PFT.PYTHON,
+                               owner='ion_functions.qc.qc_functions',
+                               function='dataqc_spiketest',
+                               args=['dat','acc','N','L'])
+        func_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, func_id)
-        return func
+        return DatasetManagementService.get_coverage_function(pf)
 
     def create_stuck_value_test_function(self):
-        func = PythonFunction('dataqc_stuckvaluetest','ion_functions.qc.qc_functions','dataqc_stuckvaluetest',["x","reso","num"])
-        func_id = self.dataset_management.create_parameter_function(name='dataqc_stuckvaluetest', parameter_function=func.dump())
+        pf = ParameterFunction(name='dataqc_stuckvaluetest',
+                               function_type=PFT.PYTHON,
+                               owner='ion_functions.qc.qc_functions',
+                               function='dataqc_stuckvaluetest',
+                               args=["x","reso","num"])
+        func_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, func_id)
-        return func
+        return DatasetManagementService.get_coverage_function(pf)
 
     def create_matrix_offset_function(self):
-        func = PythonFunction('matrix_offset', 'ion.services.dm.utility.test.parameter_helper','matrix_offset', ['x','y'])
-        func_id = self.dataset_management.create_parameter_function(name='matrix_offset', parameter_function=func.dump())
+        pf = ParameterFunction(name='matrix_offset',
+                               function_type=PFT.PYTHON,
+                               owner='ion.services.dm.utility.test.parameter_helper',
+                               function='matrix_offset',
+                               args=['x','y'])
+        func_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, func_id)
-        return func
+        return DatasetManagementService.get_coverage_function(pf)
 
     def create_simple_cc(self):
         contexts = {}
@@ -604,11 +632,14 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_context, temp_ctxt_id)
         contexts['temp'] = temp_ctxt, temp_ctxt_id
 
-        func = NumexprFunction('offset', 'temp + offset', ['temp','offset'])
-        types_manager.get_pfunc = lambda pfid : func
+        pf = ParameterFunction(name='offset', 
+                function_type=PFT.NUMEXPR,
+                function='temp + offset', 
+                args=['temp','offset'])
+        types_manager.get_pfunc = lambda pfid : DatasetManagementService.get_coverage_function(pf)
         func = types_manager.evaluate_pmap('pfid', {'temp':'temp', 'offset':'CC_coefficient'})
 
-        func_id = self.dataset_management.create_parameter_function('offset', func.dump())
+        func_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, func_id)
 
         offset_ctxt = ParameterContext('offset', param_type=ParameterFunctionType(func), fill_value=fill_value)

--- a/ion/services/dm/utility/test/parameter_helper.py
+++ b/ion/services/dm/utility/test/parameter_helper.py
@@ -367,65 +367,101 @@ class ParameterHelper(object):
         funcs = {}
         
 
-        t_ctxt = CovParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
-        t_ctxt.uom = 'seconds since 1900-01-01'
-        t_ctxt_id = self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump())
-        contexts['time'] = (t_ctxt, t_ctxt_id)
+        t_ctxt = ParameterContext(name='time', 
+                                  parameter_type='quantity',
+                                  value_encoding='float64',
+                                  units='seconds since 1900-01-01')
+        t_ctxt_id = self.dataset_management.create_parameter(t_ctxt)
+        t = DatasetManagementService.get_coverage_parameter(t_ctxt)
+        contexts['time'] = t, t_ctxt_id
 
-        lat_ctxt = CovParameterContext('lat', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
-        lat_ctxt.uom = 'degree_north'
-        lat_ctxt_id = self.dataset_management.create_parameter_context(name='lat', parameter_context=lat_ctxt.dump())
-        contexts['lat'] = lat_ctxt, lat_ctxt_id
+        lat_ctxt = ParameterContext(name='lat', 
+                                    parameter_type='quantity',
+                                    value_encoding='float32',
+                                    units='degrees_north')
+        lat_ctxt_id = self.dataset_management.create_parameter(lat_ctxt)
+        lat = DatasetManagementService.get_coverage_parameter(lat_ctxt)
+        contexts['lat'] = lat, lat_ctxt_id
 
-        lon_ctxt = CovParameterContext('lon', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
-        lon_ctxt.uom = 'degree_east'
-        lon_ctxt_id = self.dataset_management.create_parameter_context(name='lon', parameter_context=lon_ctxt.dump())
-        contexts['lon'] = lon_ctxt, lon_ctxt_id
+        lon_ctxt = ParameterContext(name='lon', 
+                                    parameter_type='quantity',
+                                    value_encoding='float32',
+                                    units='degrees_east')
+        lon_ctxt_id = self.dataset_management.create_parameter(lon_ctxt)
+        lon = DatasetManagementService.get_coverage_parameter(lon_ctxt)
+        contexts['lon'] = lon, lon_ctxt_id
 
         # Independent Parameters
 
         # Temperature - values expected to be the decimal results of conversion from hex
-        temp_ctxt = CovParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
-        temp_ctxt.uom = 'deg_C'
-        temp_ctxt_id = self.dataset_management.create_parameter_context(name='temp', parameter_context=temp_ctxt.dump())
-        contexts['temp'] = temp_ctxt, temp_ctxt_id
+        temp_ctxt = ParameterContext(name='temp', 
+                                     parameter_type='quantity',
+                                     value_encoding='float32',
+                                     units='deg_C')
+                    
+        temp_ctxt_id = self.dataset_management.create_parameter(temp_ctxt)
+        temp = DatasetManagementService.get_coverage_parameter(temp_ctxt)
+        contexts['temp'] = temp, temp_ctxt_id
 
         # Conductivity - values expected to be the decimal results of conversion from hex
-        cond_ctxt = CovParameterContext('conductivity', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
-        cond_ctxt.uom = 'S m-1'
-        cond_ctxt_id = self.dataset_management.create_parameter_context(name='conductivity', parameter_context=cond_ctxt.dump())
-        contexts['conductivity'] = cond_ctxt, cond_ctxt_id
+        cond_ctxt = ParameterContext(name='conductivity', 
+                                     parameter_type='quantity',
+                                     value_encoding='float32',
+                                     units='S m-1')
+        cond_ctxt_id = self.dataset_management.create_parameter(cond_ctxt)
+        cond = DatasetManagementService.get_coverage_parameter(cond_ctxt)
+        contexts['conductivity'] = cond, cond_ctxt_id
 
         # Pressure - values expected to be the decimal results of conversion from hex
-        press_ctxt = CovParameterContext('pressure', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
-        press_ctxt.uom = 'dbar'
-        press_ctxt_id = self.dataset_management.create_parameter_context(name='pressure', parameter_context=press_ctxt.dump())
-        contexts['pressure'] = press_ctxt, press_ctxt_id
+        press_ctxt = ParameterContext(name='pressure', 
+                                      parameter_type='quantity',
+                                      value_encoding='float32',
+                                      units='dbar')
+        press_ctxt_id = self.dataset_management.create_parameter(press_ctxt)
+        press = DatasetManagementService.get_coverage_parameter(press_ctxt)
+        contexts['pressure'] = press, press_ctxt_id
 
-        preffered_ctxt = CovParameterContext('preferred_timestamp', param_type=CategoryType(categories={0:'port_timestamp', 1:'driver_timestamp', 2:'internal_timestamp', 3:'time', -99:'empty'}), fill_value=-99)
-        preffered_ctxt.uom = ''
-        preffered_ctxt_id = self.dataset_management.create_parameter_context(name='preferred_timestamp', parameter_context=preffered_ctxt.dump())
-        contexts['preferred_timestamp'] = preffered_ctxt, preffered_ctxt_id
+        preferred_ctxt = ParameterContext(name='preferred_timestamp', 
+                                          parameter_type='category<int8:str>',
+                                          value_encoding='int8',
+                                          code_report={0:'port_timestamp', 1:'driver_timestamp', 2:'internal_timestamp', 3:'time', -99:'empty'},
+                                          units='1',
+                                          fill_value=-99)
+        preferred_ctxt_id = self.dataset_management.create_parameter(preferred_ctxt)
+        preferred = DatasetManagementService.get_coverage_parameter(preferred_ctxt)
+        contexts['preferred_timestamp'] = preferred, preferred_ctxt_id
         
-        port_ctxt = CovParameterContext('port_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
-        port_ctxt.uom = 'seconds since 1900-01-01'
-        port_ctxt_id = self.dataset_management.create_parameter_context(name='port_timestamp', parameter_context=port_ctxt.dump())
-        contexts['port_timestamp'] = port_ctxt, port_ctxt_id
+        port_ctxt = ParameterContext(name='port_timestamp', 
+                                     parameter_type='quantity',
+                                     value_encoding='float64',
+                                     units='seconds since 1900-01-01')
+        port_ctxt_id = self.dataset_management.create_parameter(port_ctxt)
+        port = DatasetManagementService.get_coverage_parameter(port_ctxt)
+        contexts['port_timestamp'] = port, port_ctxt_id
         
-        driver_ctxt = CovParameterContext('driver_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
-        driver_ctxt.uom = 'seconds since 1900-01-01'
-        driver_ctxt_id = self.dataset_management.create_parameter_context(name='driver_timestamp', parameter_context=driver_ctxt.dump())
-        contexts['driver_timestamp'] = driver_ctxt, driver_ctxt_id
+        driver_ctxt = ParameterContext(name='driver_timestamp', 
+                                       parameter_type='quantity',
+                                       value_encoding='float64',
+                                       units='seconds since 1900-01-01')
+        driver_ctxt_id = self.dataset_management.create_parameter(driver_ctxt)
+        driver = DatasetManagementService.get_coverage_parameter(driver_ctxt)
+        contexts['driver_timestamp'] = driver, driver_ctxt_id
         
-        internal_ctxt = CovParameterContext('internal_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
-        internal_ctxt.uom = 'seconds since 1900-01-01'
-        internal_ctxt_id = self.dataset_management.create_parameter_context(name='internal_timestamp', parameter_context=internal_ctxt.dump())
-        contexts['internal_timestamp'] = internal_ctxt, internal_ctxt_id
+        internal_ctxt = ParameterContext(name='internal_timestamp', 
+                                         parameter_type='quantity',
+                                         value_encoding='float64',
+                                         units='seconds since 1900-01-01')
+        internal_ctxt_id = self.dataset_management.create_parameter(internal_ctxt)
+        internal = DatasetManagementService.get_coverage_parameter(internal_ctxt)
+        contexts['internal_timestamp'] = internal, internal_ctxt_id
         
-        quality_ctxt = CovParameterContext('quality_flag', param_type=ArrayType())
-        quality_ctxt.uom = ''
-        quality_ctxt_id = self.dataset_management.create_parameter_context(name='quality_flag', parameter_context=quality_ctxt.dump())
-        contexts['quality_flag'] = quality_ctxt, quality_ctxt_id
+        quality_ctxt = ParameterContext(name='quality_flag', 
+                                        parameter_type='array<>',
+                                        value_encoding='int8',
+                                        units='1')
+        quality_ctxt_id = self.dataset_management.create_parameter(quality_ctxt)
+        quality = DatasetManagementService.get_coverage_parameter(quality_ctxt)
+        contexts['quality_flag'] = quality, quality_ctxt_id
 
         # Dependent Parameters
 
@@ -436,14 +472,18 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
         funcs['temp_L1'] = pf, expr_id
 
+
         tl1_pmap = {'temperature':'temp'}
-        expr = DatasetManagementService.get_coverage_function(pf)
-        expr.param_map = tl1_pmap
-        tempL1_ctxt = CovParameterContext('temp_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
-        tempL1_ctxt.uom = 'deg_C'
-        tempL1_ctxt_id = self.dataset_management.create_parameter_context(name='temp_L1', parameter_context=tempL1_ctxt.dump(), parameter_function_id=expr_id)
+        tempL1_ctxt = ParameterContext(name='temp_L1', 
+                                       parameter_type='function',
+                                       parameter_function_id=expr_id,
+                                       parameter_function_map=tl1_pmap,
+                                       value_encoding='float32',
+                                       units='deg_C')
+        tempL1_ctxt_id = self.dataset_management.create_parameter(tempL1_ctxt)
         self.addCleanup(self.dataset_management.delete_parameter_context, tempL1_ctxt_id)
-        contexts['temp_L1'] = tempL1_ctxt, tempL1_ctxt_id
+        tempL1 = DatasetManagementService.get_coverage_parameter(tempL1_ctxt)
+        contexts['temp_L1'] = tempL1, tempL1_ctxt_id
 
         # CONDWAT_L1 = (CONDWAT_L0 / 100000) - 0.5
         cl1_func = '(conductivity / 100000.0) - 0.5'
@@ -453,13 +493,16 @@ class ParameterHelper(object):
         funcs['conductivity_L1'] = pf, expr_id
 
         cl1_pmap = {'conductivity':'conductivity'}
-        expr = DatasetManagementService.get_coverage_function(pf)
-        expr.param_map = cl1_pmap
-        condL1_ctxt = CovParameterContext('conductivity_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
-        condL1_ctxt.uom = 'S m-1'
-        condL1_ctxt_id = self.dataset_management.create_parameter_context(name='conductivity_L1', parameter_context=condL1_ctxt.dump(), parameter_function_id=expr_id)
+        condL1_ctxt = ParameterContext(name='conductivity_L1', 
+                                       parameter_type='function',
+                                       parameter_function_id=expr_id,
+                                       parameter_function_map=cl1_pmap,
+                                       value_encoding='float32',
+                                       units='S m-1')
+        condL1_ctxt_id = self.dataset_management.create_parameter(condL1_ctxt)
         self.addCleanup(self.dataset_management.delete_parameter_context, condL1_ctxt_id)
-        contexts['conductivity_L1'] = condL1_ctxt, condL1_ctxt_id
+        condL1 = DatasetManagementService.get_coverage_parameter(condL1_ctxt)
+        contexts['conductivity_L1'] = condL1, condL1_ctxt_id
 
         # Equation uses p_range, which is a calibration coefficient - Fixing to 679.34040721
         #   PRESWAT_L1 = (PRESWAT_L0 * p_range / (0.85 * 65536)) - (0.05 * p_range)
@@ -470,13 +513,17 @@ class ParameterHelper(object):
         funcs['pressure_L1'] = pf, expr_id
         
         pl1_pmap = {'pressure':'pressure'}
-        expr = DatasetManagementService.get_coverage_function(pf)
-        expr.param_map = pl1_pmap
-        presL1_ctxt = CovParameterContext('pressure_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
-        presL1_ctxt.uom = 'S m-1'
-        presL1_ctxt_id = self.dataset_management.create_parameter_context(name='pressure_L1', parameter_context=presL1_ctxt.dump(), parameter_function_id=expr_id)
+        pressureL1_ctxt = ParameterContext(name='pressure_L1', 
+                                       parameter_type='function',
+                                       parameter_function_id=expr_id,
+                                       parameter_function_map=pl1_pmap,
+                                       value_encoding='float32',
+                                       units='dbar')
+
+        presL1_ctxt_id = self.dataset_management.create_parameter(pressureL1_ctxt)
         self.addCleanup(self.dataset_management.delete_parameter_context, presL1_ctxt_id)
-        contexts['pressure_L1'] = presL1_ctxt, presL1_ctxt_id
+        pressureL1 = DatasetManagementService.get_coverage_parameter(pressureL1_ctxt)
+        contexts['pressure_L1'] = pressureL1, presL1_ctxt_id
 
         # Density & practical salinity calucluated using the Gibbs Seawater library - available via python-gsw project:
         #       https://code.google.com/p/python-gsw/ & http://pypi.python.org/pypi/gsw/3.0.1

--- a/ion/services/dm/utility/test/parameter_helper.py
+++ b/ion/services/dm/utility/test/parameter_helper.py
@@ -4,13 +4,14 @@
 @file ion/services/dm/utility/test/parameter_helper.py
 @brief Helpers for Parameters
 '''
-from coverage_model import ParameterContext, QuantityType, AxisTypeEnum, ArrayType, CategoryType, ConstantType, NumexprFunction, ParameterFunctionType, VariabilityEnum, PythonFunction, SparseConstantType
+from coverage_model import ParameterContext as CovParameterContext, QuantityType, AxisTypeEnum, ArrayType, CategoryType, ConstantType, NumexprFunction, ParameterFunctionType, VariabilityEnum, PythonFunction, SparseConstantType
 from interface.objects import ParameterFunction, ParameterFunctionType as PFT
 from ion.services.dm.utility.types import TypesManager
 from ion.services.dm.utility.granule import RecordDictionaryTool
 from pyon.container.cc import Container
 from pyon.ion.stream import StandaloneStreamPublisher
 from interface.services.dm.ipubsub_management_service import PubsubManagementServiceClient
+from interface.objects import ParameterContext
 from ion.services.dm.inventory.dataset_management_service import DatasetManagementService
 import time
 import numpy as np
@@ -137,67 +138,112 @@ class ParameterHelper(object):
     def create_sparse_params(self):
         contexts = {}
         funcs = {}
-        
+        t_ctxt = ParameterContext(name='time',
+                                  parameter_type='quantity',
+                                  value_encoding='float64',
+                                  units='seconds since 1900-01-01')
 
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
-        t_ctxt.uom = 'seconds since 1900-01-01'
-        t_ctxt_id = self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump())
-        contexts['time'] = (t_ctxt, t_ctxt_id)
+        t_ctxt_id = self.dataset_management.create_parameter(t_ctxt)
+        self.addCleanup(self.dataset_management.delete_parameter_context, t_ctxt_id)
+        # Get the coverage instance of the context
+        t = DatasetManagementService.get_coverage_parameter(t_ctxt)
+        contexts['time'] = t, t_ctxt_id
 
-        lat_ctxt = ParameterContext('lat', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value), fill_value=fill_value)
-        lat_ctxt.uom = 'degree_north'
-        lat_ctxt_id = self.dataset_management.create_parameter_context(name='lat', parameter_context=lat_ctxt.dump())
-        contexts['lat'] = lat_ctxt, lat_ctxt_id
+        lat_ctxt = ParameterContext(name='lat',
+                                    parameter_type='sparse',
+                                    value_encoding='float64',
+                                    fill_value=fill_value,
+                                    units='degrees_north')
+        lat_ctxt_id = self.dataset_management.create_parameter(lat_ctxt)
+        self.addCleanup(self.dataset_management.delete_parameter_context, lat_ctxt_id)
+        lat = DatasetManagementService.get_coverage_parameter(lat_ctxt)
+        contexts['lat'] = lat, lat_ctxt_id
 
-        lon_ctxt = ParameterContext('lon', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value), fill_value=fill_value)
-        lon_ctxt.uom = 'degree_east'
-        lon_ctxt_id = self.dataset_management.create_parameter_context(name='lon', parameter_context=lon_ctxt.dump())
-        contexts['lon'] = lon_ctxt, lon_ctxt_id
+        lon_ctxt = ParameterContext(name='lon',
+                                    parameter_type='sparse',
+                                    value_encoding='float64',
+                                    fill_value=fill_value,
+                                    units='degrees_north')
+        lon_ctxt_id = self.dataset_management.create_parameter(lon_ctxt)
+        lon = DatasetManagementService.get_coverage_parameter(lon_ctxt)
+        contexts['lon'] = lon, lon_ctxt_id
 
         # Independent Parameters
 
         # Temperature - values expected to be the decimal results of conversion from hex
-        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
-        temp_ctxt.uom = 'deg_C'
-        temp_ctxt_id = self.dataset_management.create_parameter_context(name='temp', parameter_context=temp_ctxt.dump())
-        contexts['temp'] = temp_ctxt, temp_ctxt_id
+        temp_ctxt = ParameterContext(name='temp', 
+                                     parameter_type='quantity',
+                                     value_encoding='float32', 
+                                     units='deg_C',
+                                     fill_value=fill_value)
+        temp_ctxt_id = self.dataset_management.create_parameter(temp_ctxt)
+        temp = DatasetManagementService.get_coverage_parameter(temp_ctxt)
+        contexts['temp'] = temp, temp_ctxt_id
 
         # Conductivity - values expected to be the decimal results of conversion from hex
-        cond_ctxt = ParameterContext('conductivity', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
-        cond_ctxt.uom = 'S m-1'
-        cond_ctxt_id = self.dataset_management.create_parameter_context(name='conductivity', parameter_context=cond_ctxt.dump())
-        contexts['conductivity'] = cond_ctxt, cond_ctxt_id
+        cond_ctxt = ParameterContext(name='conductivity', 
+                                     parameter_type='quantity',
+                                     value_encoding='float32', 
+                                     units='S m-1',
+                                     fill_value=fill_value)
+        cond_ctxt_id = self.dataset_management.create_parameter(cond_ctxt)
+        cond = DatasetManagementService.get_coverage_parameter(cond_ctxt)
+        contexts['conductivity'] = cond, cond_ctxt_id
 
         # Pressure - values expected to be the decimal results of conversion from hex
-        press_ctxt = ParameterContext('pressure', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
-        press_ctxt.uom = 'dbar'
-        press_ctxt_id = self.dataset_management.create_parameter_context(name='pressure', parameter_context=press_ctxt.dump())
-        contexts['pressure'] = press_ctxt, press_ctxt_id
+        press_ctxt = ParameterContext(name='pressure', 
+                                      parameter_type='quantity',
+                                      value_encoding='float32', 
+                                      units='dbar',
+                                      fill_value=fill_value)
+        press_ctxt_id = self.dataset_management.create_parameter(press_ctxt)
+        press = DatasetManagementService.get_coverage_parameter(press_ctxt)
+        contexts['pressure'] = press, press_ctxt_id
 
-        preffered_ctxt = ParameterContext('preferred_timestamp', param_type=CategoryType(categories={0:'port_timestamp', 1:'driver_timestamp', 2:'internal_timestamp', 3:'time', -99:'empty'}), fill_value=-99)
-        preffered_ctxt.uom = ''
-        preffered_ctxt_id = self.dataset_management.create_parameter_context(name='preferred_timestamp', parameter_context=preffered_ctxt.dump())
-        contexts['preferred_timestamp'] = preffered_ctxt, preffered_ctxt_id
+        preferred_ctxt = ParameterContext(name='preferred_timestamp', 
+                                          parameter_type='category<int8:str>',
+                                          value_encoding='int8',
+                                          code_report={0:'port_timestamp', 1:'driver_timestamp', 2:'internal_timestamp', 3:'time', -99:'empty'}, 
+                                          units='1',
+                                          fill_value=-99)
+        preferred_ctxt_id = self.dataset_management.create_parameter(preferred_ctxt)
+        preferred = DatasetManagementService.get_coverage_parameter(preferred_ctxt)
+        contexts['preferred_timestamp'] = preferred, preferred_ctxt_id
         
-        port_ctxt = ParameterContext('port_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
-        port_ctxt.uom = 'seconds since 1900-01-01'
-        port_ctxt_id = self.dataset_management.create_parameter_context(name='port_timestamp', parameter_context=port_ctxt.dump())
-        contexts['port_timestamp'] = port_ctxt, port_ctxt_id
+        port_ctxt = ParameterContext(name='port_timestamp', 
+                                     parameter_type='quantity',
+                                     value_encoding='float64', 
+                                     units='seconds since 1900-01-01',
+                                     fill_value=fill_value)
+        port_ctxt_id = self.dataset_management.create_parameter(port_ctxt)
+        port = DatasetManagementService.get_coverage_parameter(port_ctxt)
+        contexts['port_timestamp'] = port, port_ctxt_id
         
-        driver_ctxt = ParameterContext('driver_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
-        driver_ctxt.uom = 'seconds since 1900-01-01'
-        driver_ctxt_id = self.dataset_management.create_parameter_context(name='driver_timestamp', parameter_context=driver_ctxt.dump())
-        contexts['driver_timestamp'] = driver_ctxt, driver_ctxt_id
+        driver_ctxt = ParameterContext(name='driver_timestamp', 
+                                       parameter_type='quantity',
+                                       value_encoding='float64',
+                                       units='seconds since 1900-01-01',
+                                       fill_value=fill_value)
+        driver_ctxt_id = self.dataset_management.create_parameter(driver_ctxt)
+        driver = DatasetManagementService.get_coverage_parameter(driver_ctxt)
+        contexts['driver_timestamp'] = driver, driver_ctxt_id
         
-        internal_ctxt = ParameterContext('internal_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
-        internal_ctxt.uom = 'seconds since 1900-01-01'
-        internal_ctxt_id = self.dataset_management.create_parameter_context(name='internal_timestamp', parameter_context=internal_ctxt.dump())
-        contexts['internal_timestamp'] = internal_ctxt, internal_ctxt_id
+        internal_ctxt = ParameterContext(name='internal_timestamp', 
+                                         parameter_type='quantity',
+                                         value_encoding='float64',
+                                         units='seconds since 1900-01-01',
+                                         fill_value=fill_value)
+        internal_ctxt_id = self.dataset_management.create_parameter(internal_ctxt)
+        internal = DatasetManagementService.get_coverage_parameter(internal_ctxt)
+        contexts['internal_timestamp'] = internal, internal_ctxt_id
         
-        quality_ctxt = ParameterContext('quality_flag', param_type=ArrayType())
-        quality_ctxt.uom = ''
-        quality_ctxt_id = self.dataset_management.create_parameter_context(name='quality_flag', parameter_context=quality_ctxt.dump())
-        contexts['quality_flag'] = quality_ctxt, quality_ctxt_id
+        quality_ctxt = ParameterContext(name='quality_flag', 
+                                        parameter_type='array<quantity>',
+                                        value_encoding='float32',
+                                        units='1')
+        quality_ctxt_id = self.dataset_management.create_parameter(quality_ctxt)
+        quality = DatasetManagementService.get_coverage_parameter(quality_ctxt)
+        contexts['quality_flag'] = quality, quality_ctxt_id
 
         # Dependent Parameters
 
@@ -208,14 +254,15 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
         funcs['temp_L1'] = pf, expr_id
 
-        tl1_pmap = {'temperature':'temp'}
-        expr = DatasetManagementService.get_coverage_function(pf)
-        expr.param_map = tl1_pmap
-        tempL1_ctxt = ParameterContext('temp_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
-        tempL1_ctxt.uom = 'deg_C'
-        tempL1_ctxt_id = self.dataset_management.create_parameter_context(name='temp_L1', parameter_context=tempL1_ctxt.dump(), parameter_function_id=expr_id)
-        self.addCleanup(self.dataset_management.delete_parameter_context, tempL1_ctxt_id)
-        contexts['temp_L1'] = tempL1_ctxt, tempL1_ctxt_id
+        tempL1_ctxt = ParameterContext(name='temp_L1', 
+                                       parameter_type='function',
+                                       parameter_function_id=expr_id,
+                                       units='deg_C',
+                                       value_encoding='float32',
+                                       parameter_function_map={'temperature':'temp'})
+        tempL1_ctxt_id = self.dataset_management.create_parameter(tempL1_ctxt)
+        tempL1 = DatasetManagementService.get_coverage_parameter(tempL1_ctxt)
+        contexts['temp_L1'] = tempL1, tempL1_ctxt_id
 
         # CONDWAT_L1 = (CONDWAT_L0 / 100000) - 0.5
         cl1_func = '(conductivity / 100000.0) - 0.5'
@@ -224,14 +271,17 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
         funcs['conductivity_L1'] = pf, expr_id
 
-        cl1_pmap = {'conductivity':'conductivity'}
-        expr = DatasetManagementService.get_coverage_function(pf)
-        expr.param_map = cl1_pmap
-        condL1_ctxt = ParameterContext('conductivity_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
-        condL1_ctxt.uom = 'S m-1'
-        condL1_ctxt_id = self.dataset_management.create_parameter_context(name='conductivity_L1', parameter_context=condL1_ctxt.dump(), parameter_function_id=expr_id)
+        condL1_ctxt = ParameterContext(name='conductivity_L1', 
+                                       parameter_type='function',
+                                       parameter_function_id=expr_id,
+                                       parameter_function_map={'conductivity':'conductivity'},
+                                       value_encoding='float32',
+                                       units='S m-1')
+
+        condL1_ctxt_id = self.dataset_management.create_parameter(condL1_ctxt)
         self.addCleanup(self.dataset_management.delete_parameter_context, condL1_ctxt_id)
-        contexts['conductivity_L1'] = condL1_ctxt, condL1_ctxt_id
+        condL1 = DatasetManagementService.get_coverage_parameter(condL1_ctxt)
+        contexts['conductivity_L1'] = condL1, condL1_ctxt_id
 
         # Equation uses p_range, which is a calibration coefficient - Fixing to 679.34040721
         #   PRESWAT_L1 = (PRESWAT_L0 * p_range / (0.85 * 65536)) - (0.05 * p_range)
@@ -241,14 +291,16 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
         funcs['pressure_L1'] = pf, expr_id
         
-        pl1_pmap = {'pressure':'pressure'}
-        expr = DatasetManagementService.get_coverage_function(pf)
-        expr.param_map = pl1_pmap
-        presL1_ctxt = ParameterContext('pressure_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
-        presL1_ctxt.uom = 'S m-1'
-        presL1_ctxt_id = self.dataset_management.create_parameter_context(name='pressure_L1', parameter_context=presL1_ctxt.dump(), parameter_function_id=expr_id)
+        presL1_ctxt = ParameterContext(name='pressure_L1',
+                                       parameter_type='function',
+                                       parameter_function_id=expr_id,
+                                       parameter_function_map={'pressure':'pressure'},
+                                       value_encoding='float32',
+                                       units='S m-1')
+        presL1_ctxt_id = self.dataset_management.create_parameter(presL1_ctxt)
         self.addCleanup(self.dataset_management.delete_parameter_context, presL1_ctxt_id)
-        contexts['pressure_L1'] = presL1_ctxt, presL1_ctxt_id
+        presL1 = DatasetManagementService.get_coverage_parameter(presL1_ctxt)
+        contexts['pressure_L1'] = presL1, presL1_ctxt_id
 
         # Density & practical salinity calucluated using the Gibbs Seawater library - available via python-gsw project:
         #       https://code.google.com/p/python-gsw/ & http://pypi.python.org/pypi/gsw/3.0.1
@@ -262,15 +314,16 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_function, expr_id)
         funcs['salinity_L2'] = pf, expr_id
         
-        # A magic function that may or may not exist actually forms the line below at runtime.
-        sal_pmap = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1'}
-        expr = DatasetManagementService.get_coverage_function(pf)
-        expr.param_map = sal_pmap
-        sal_ctxt = ParameterContext('salinity', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
-        sal_ctxt.uom = 'g kg-1'
-        sal_ctxt_id = self.dataset_management.create_parameter_context(name='salinity', parameter_context=sal_ctxt.dump(), parameter_function_id=expr_id)
+        sal_ctxt = ParameterContext(name='salinity',
+                                    parameter_type='function',
+                                    parameter_function_id=expr_id,
+                                    parameter_function_map={'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1'},
+                                    value_encoding='float32',
+                                    units='1')
+        sal_ctxt_id = self.dataset_management.create_parameter(sal_ctxt)
         self.addCleanup(self.dataset_management.delete_parameter_context, sal_ctxt_id)
-        contexts['salinity'] = sal_ctxt, sal_ctxt_id
+        sal = DatasetManagementService.get_coverage_parameter(sal_ctxt)
+        contexts['salinity'] = sal, sal_ctxt_id
 
         # absolute_salinity = gsw.SA_from_SP(PRACSAL, PRESWAT_L1, longitude, latitude)
         # conservative_temperature = gsw.CT_from_t(absolute_salinity, TEMPWAT_L1, PRESWAT_L1)
@@ -284,14 +337,16 @@ class ParameterHelper(object):
         funcs['density_L2'] = pf, expr_id
 
 
-        dens_pmap = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1', 'lat':'lat', 'lon':'lon'}
-        expr = DatasetManagementService.get_coverage_function(pf)
-        expr.param_map = dens_pmap
-        dens_ctxt = ParameterContext('density', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
-        dens_ctxt.uom = 'kg m-3'
-        dens_ctxt_id = self.dataset_management.create_parameter_context(name='density', parameter_context=dens_ctxt.dump(), parameter_function_id=expr_id)
+        dens_ctxt = ParameterContext(name='density',
+                                     parameter_type='function',
+                                     parameter_function_id=expr_id,
+                                     parameter_function_map={'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1', 'lat':'lat', 'lon':'lon'},
+                                     value_encoding='float32',
+                                     units='kg m-3')
+        dens_ctxt_id = self.dataset_management.create_parameter(dens_ctxt)
         self.addCleanup(self.dataset_management.delete_parameter_context, dens_ctxt_id)
-        contexts['density'] = dens_ctxt, dens_ctxt_id
+        dens = DatasetManagementService.get_coverage_parameter(dens_ctxt)
+        contexts['density'] = dens, dens_ctxt_id
 
         return contexts, funcs
 
@@ -312,17 +367,17 @@ class ParameterHelper(object):
         funcs = {}
         
 
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
+        t_ctxt = CovParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
         t_ctxt.uom = 'seconds since 1900-01-01'
         t_ctxt_id = self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump())
         contexts['time'] = (t_ctxt, t_ctxt_id)
 
-        lat_ctxt = ParameterContext('lat', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        lat_ctxt = CovParameterContext('lat', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         lat_ctxt.uom = 'degree_north'
         lat_ctxt_id = self.dataset_management.create_parameter_context(name='lat', parameter_context=lat_ctxt.dump())
         contexts['lat'] = lat_ctxt, lat_ctxt_id
 
-        lon_ctxt = ParameterContext('lon', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        lon_ctxt = CovParameterContext('lon', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         lon_ctxt.uom = 'degree_east'
         lon_ctxt_id = self.dataset_management.create_parameter_context(name='lon', parameter_context=lon_ctxt.dump())
         contexts['lon'] = lon_ctxt, lon_ctxt_id
@@ -330,44 +385,44 @@ class ParameterHelper(object):
         # Independent Parameters
 
         # Temperature - values expected to be the decimal results of conversion from hex
-        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        temp_ctxt = CovParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         temp_ctxt.uom = 'deg_C'
         temp_ctxt_id = self.dataset_management.create_parameter_context(name='temp', parameter_context=temp_ctxt.dump())
         contexts['temp'] = temp_ctxt, temp_ctxt_id
 
         # Conductivity - values expected to be the decimal results of conversion from hex
-        cond_ctxt = ParameterContext('conductivity', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        cond_ctxt = CovParameterContext('conductivity', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         cond_ctxt.uom = 'S m-1'
         cond_ctxt_id = self.dataset_management.create_parameter_context(name='conductivity', parameter_context=cond_ctxt.dump())
         contexts['conductivity'] = cond_ctxt, cond_ctxt_id
 
         # Pressure - values expected to be the decimal results of conversion from hex
-        press_ctxt = ParameterContext('pressure', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        press_ctxt = CovParameterContext('pressure', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         press_ctxt.uom = 'dbar'
         press_ctxt_id = self.dataset_management.create_parameter_context(name='pressure', parameter_context=press_ctxt.dump())
         contexts['pressure'] = press_ctxt, press_ctxt_id
 
-        preffered_ctxt = ParameterContext('preferred_timestamp', param_type=CategoryType(categories={0:'port_timestamp', 1:'driver_timestamp', 2:'internal_timestamp', 3:'time', -99:'empty'}), fill_value=-99)
+        preffered_ctxt = CovParameterContext('preferred_timestamp', param_type=CategoryType(categories={0:'port_timestamp', 1:'driver_timestamp', 2:'internal_timestamp', 3:'time', -99:'empty'}), fill_value=-99)
         preffered_ctxt.uom = ''
         preffered_ctxt_id = self.dataset_management.create_parameter_context(name='preferred_timestamp', parameter_context=preffered_ctxt.dump())
         contexts['preferred_timestamp'] = preffered_ctxt, preffered_ctxt_id
         
-        port_ctxt = ParameterContext('port_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
+        port_ctxt = CovParameterContext('port_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
         port_ctxt.uom = 'seconds since 1900-01-01'
         port_ctxt_id = self.dataset_management.create_parameter_context(name='port_timestamp', parameter_context=port_ctxt.dump())
         contexts['port_timestamp'] = port_ctxt, port_ctxt_id
         
-        driver_ctxt = ParameterContext('driver_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
+        driver_ctxt = CovParameterContext('driver_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
         driver_ctxt.uom = 'seconds since 1900-01-01'
         driver_ctxt_id = self.dataset_management.create_parameter_context(name='driver_timestamp', parameter_context=driver_ctxt.dump())
         contexts['driver_timestamp'] = driver_ctxt, driver_ctxt_id
         
-        internal_ctxt = ParameterContext('internal_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
+        internal_ctxt = CovParameterContext('internal_timestamp', param_type=QuantityType(value_encoding=np.dtype('float64')), fill_value=fill_value)
         internal_ctxt.uom = 'seconds since 1900-01-01'
         internal_ctxt_id = self.dataset_management.create_parameter_context(name='internal_timestamp', parameter_context=internal_ctxt.dump())
         contexts['internal_timestamp'] = internal_ctxt, internal_ctxt_id
         
-        quality_ctxt = ParameterContext('quality_flag', param_type=ArrayType())
+        quality_ctxt = CovParameterContext('quality_flag', param_type=ArrayType())
         quality_ctxt.uom = ''
         quality_ctxt_id = self.dataset_management.create_parameter_context(name='quality_flag', parameter_context=quality_ctxt.dump())
         contexts['quality_flag'] = quality_ctxt, quality_ctxt_id
@@ -384,7 +439,7 @@ class ParameterHelper(object):
         tl1_pmap = {'temperature':'temp'}
         expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = tl1_pmap
-        tempL1_ctxt = ParameterContext('temp_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
+        tempL1_ctxt = CovParameterContext('temp_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         tempL1_ctxt.uom = 'deg_C'
         tempL1_ctxt_id = self.dataset_management.create_parameter_context(name='temp_L1', parameter_context=tempL1_ctxt.dump(), parameter_function_id=expr_id)
         self.addCleanup(self.dataset_management.delete_parameter_context, tempL1_ctxt_id)
@@ -400,7 +455,7 @@ class ParameterHelper(object):
         cl1_pmap = {'conductivity':'conductivity'}
         expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = cl1_pmap
-        condL1_ctxt = ParameterContext('conductivity_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
+        condL1_ctxt = CovParameterContext('conductivity_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         condL1_ctxt.uom = 'S m-1'
         condL1_ctxt_id = self.dataset_management.create_parameter_context(name='conductivity_L1', parameter_context=condL1_ctxt.dump(), parameter_function_id=expr_id)
         self.addCleanup(self.dataset_management.delete_parameter_context, condL1_ctxt_id)
@@ -417,7 +472,7 @@ class ParameterHelper(object):
         pl1_pmap = {'pressure':'pressure'}
         expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = pl1_pmap
-        presL1_ctxt = ParameterContext('pressure_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
+        presL1_ctxt = CovParameterContext('pressure_L1', param_type=ParameterFunctionType(function=expr), variability=VariabilityEnum.TEMPORAL)
         presL1_ctxt.uom = 'S m-1'
         presL1_ctxt_id = self.dataset_management.create_parameter_context(name='pressure_L1', parameter_context=presL1_ctxt.dump(), parameter_function_id=expr_id)
         self.addCleanup(self.dataset_management.delete_parameter_context, presL1_ctxt_id)
@@ -439,7 +494,7 @@ class ParameterHelper(object):
         sal_pmap = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1'}
         expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = sal_pmap
-        sal_ctxt = ParameterContext('salinity', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
+        sal_ctxt = CovParameterContext('salinity', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
         sal_ctxt.uom = 'g kg-1'
         sal_ctxt_id = self.dataset_management.create_parameter_context(name='salinity', parameter_context=sal_ctxt.dump(), parameter_function_id=expr_id)
         self.addCleanup(self.dataset_management.delete_parameter_context, sal_ctxt_id)
@@ -460,7 +515,7 @@ class ParameterHelper(object):
         dens_pmap = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1', 'lat':'lat', 'lon':'lon'}
         expr = DatasetManagementService.get_coverage_function(pf)
         expr.param_map = dens_pmap
-        dens_ctxt = ParameterContext('density', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
+        dens_ctxt = CovParameterContext('density', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
         dens_ctxt.uom = 'kg m-3'
         dens_ctxt_id = self.dataset_management.create_parameter_context(name='density', parameter_context=dens_ctxt.dump(), parameter_function_id=expr_id)
         self.addCleanup(self.dataset_management.delete_parameter_context, dens_ctxt_id)
@@ -474,14 +529,14 @@ class ParameterHelper(object):
         
         density_lookup_map = {'conductivity':'conductivity_L1', 'temp':'temp_L1', 'pressure':'pressure_L1', 'lat':'lat_lookup', 'lon':'lon_lookup'}
         expr.param_map = density_lookup_map
-        density_lookup_ctxt = ParameterContext('density_lookup', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
+        density_lookup_ctxt = CovParameterContext('density_lookup', param_type=ParameterFunctionType(expr), variability=VariabilityEnum.TEMPORAL)
         density_lookup_ctxt.uom = 'kg m-3'
         density_lookup_ctxt_id = self.dataset_management.create_parameter_context(name='density_lookup', parameter_context=density_lookup_ctxt.dump(), parameter_function_id=expr_id)
         self.addCleanup(self.dataset_management.delete_parameter_context, density_lookup_ctxt_id)
         contexts['density_lookup'] = density_lookup_ctxt, density_lookup_ctxt_id
 
 
-        lat_lookup_ctxt = ParameterContext('lat_lookup', param_type=ConstantType(QuantityType(value_encoding=np.dtype('float32'))), fill_value=fill_value)
+        lat_lookup_ctxt = CovParameterContext('lat_lookup', param_type=ConstantType(QuantityType(value_encoding=np.dtype('float32'))), fill_value=fill_value)
         lat_lookup_ctxt.uom = 'degree_north'
         lat_lookup_ctxt.lookup_value = 'lat'
         lat_lookup_ctxt.document_key = ''
@@ -490,7 +545,7 @@ class ParameterHelper(object):
         contexts['lat_lookup'] = lat_lookup_ctxt, lat_lookup_ctxt_id
         
 
-        lon_lookup_ctxt = ParameterContext('lon_lookup', param_type=ConstantType(QuantityType(value_encoding=np.dtype('float32'))), fill_value=fill_value)
+        lon_lookup_ctxt = CovParameterContext('lon_lookup', param_type=ConstantType(QuantityType(value_encoding=np.dtype('float32'))), fill_value=fill_value)
         lon_lookup_ctxt.uom = 'degree_east'
         lon_lookup_ctxt.lookup_value = 'lon'
         lon_lookup_ctxt.document_key = ''
@@ -499,7 +554,7 @@ class ParameterHelper(object):
         contexts['lon_lookup'] = lon_lookup_ctxt, lon_lookup_ctxt_id
 
 
-        beam_samples = ParameterContext('beam_samples', param_type=ArrayType(inner_encoding='float64'))
+        beam_samples = CovParameterContext('beam_samples', param_type=ArrayType(inner_encoding='float64'))
         beam_samples.uom = 'db'
         beam_samples_id = self.dataset_management.create_parameter_context(name='beam_samples', parameter_context=beam_samples.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, beam_samples_id)
@@ -509,7 +564,7 @@ class ParameterHelper(object):
 
     def create_qc_contexts(self):
         contexts = {}
-        qc_whatever_ctxt = ParameterContext('qc_whatever', param_type=ArrayType())
+        qc_whatever_ctxt = CovParameterContext('qc_whatever', param_type=ArrayType())
         qc_whatever_ctxt.uom = '1'
         qc_whatever_ctxt_id = self.dataset_management.create_parameter_context(name='qc_whatever', parameter_context=qc_whatever_ctxt.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, qc_whatever_ctxt_id)
@@ -523,7 +578,7 @@ class ParameterHelper(object):
         pmap = {'min':0, 'max':20, 'var':'temp'}
         nexpr = DatasetManagementService.get_coverage_function(pf)
         nexpr.param_map = pmap
-        temp_qc_ctxt = ParameterContext('temp_qc', param_type=ParameterFunctionType(function=nexpr), variability=VariabilityEnum.TEMPORAL)
+        temp_qc_ctxt = CovParameterContext('temp_qc', param_type=ParameterFunctionType(function=nexpr), variability=VariabilityEnum.TEMPORAL)
         temp_qc_ctxt.uom = '1'
         temp_qc_ctxt_id = self.dataset_management.create_parameter_context(name='temp_qc', parameter_context=temp_qc_ctxt.dump(), parameter_function_id=expr_id)
         self.addCleanup(self.dataset_management.delete_parameter_context, temp_qc_ctxt_id)
@@ -619,13 +674,13 @@ class ParameterHelper(object):
     def create_simple_cc(self):
         contexts = {}
         types_manager = TypesManager(self.dataset_management, None, None)
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
+        t_ctxt = CovParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
         t_ctxt.uom = 'seconds since 1900-01-01'
         t_ctxt_id = self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, t_ctxt_id)
         contexts['time'] = t_ctxt, t_ctxt_id
 
-        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        temp_ctxt = CovParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         temp_ctxt.uom = 'deg_C'
         temp_ctxt.ooi_short_name = 'TEMPWAT'
         temp_ctxt_id = self.dataset_management.create_parameter_context(name='temp', parameter_context=temp_ctxt.dump(), ooi_short_name='TEMPWAT')
@@ -642,7 +697,7 @@ class ParameterHelper(object):
         func_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, func_id)
 
-        offset_ctxt = ParameterContext('offset', param_type=ParameterFunctionType(func), fill_value=fill_value)
+        offset_ctxt = CovParameterContext('offset', param_type=ParameterFunctionType(func), fill_value=fill_value)
         offset_ctxt.uom = '1'
         offset_ctxt_id = self.dataset_management.create_parameter_context('offset', offset_ctxt.dump(), parameter_function_id=func_id)
         self.addCleanup(self.dataset_management.delete_parameter_context, offset_ctxt_id)
@@ -666,13 +721,13 @@ class ParameterHelper(object):
     def create_simple_array(self):
         contexts = {}
         types_manager = TypesManager(self.dataset_management,None,None)
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
+        t_ctxt = CovParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
         t_ctxt.uom = 'seconds since 1900-01-01'
         t_ctxt_id = self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, t_ctxt_id)
         contexts['time'] = (t_ctxt, t_ctxt_id)
 
-        temp_ctxt = ParameterContext('temp_sample', param_type=ArrayType(inner_encoding='float32'))
+        temp_ctxt = CovParameterContext('temp_sample', param_type=ArrayType(inner_encoding='float32'))
         temp_ctxt.uom = 'deg_C'
         temp_ctxt.ooi_short_name = 'TEMPWAT'
         temp_ctxt.display_name = 'Temperature'
@@ -680,7 +735,7 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_context, temp_ctxt_id)
         contexts['temp_sample'] = temp_ctxt, temp_ctxt_id
         
-        cond_ctxt = ParameterContext('cond_sample', param_type=ArrayType(inner_encoding='float64'))
+        cond_ctxt = CovParameterContext('cond_sample', param_type=ArrayType(inner_encoding='float64'))
         cond_ctxt.uom = 'deg_C'
         cond_ctxt.ooi_short_name = 'CONDWAT'
         cond_ctxt.display_anme = 'Conductivity'
@@ -690,7 +745,7 @@ class ParameterHelper(object):
 
         func = self.create_matrix_offset_function()
         func.param_map = {'x':'temp_sample', 'y':'cond_sample'}
-        temp_offset = ParameterContext('temp_offset', param_type=ParameterFunctionType(func))
+        temp_offset = CovParameterContext('temp_offset', param_type=ParameterFunctionType(func))
         temp_offset.uom = '1'
         temp_offset_id = self.dataset_management.create_parameter_context(name='temp_offset', parameter_context=temp_offset.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, temp_offset_id)
@@ -710,13 +765,13 @@ class ParameterHelper(object):
     
     def create_illegal_char(self):
         contexts = {}
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
+        t_ctxt = CovParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
         t_ctxt.uom = 'seconds since 1900-01-01'
         t_ctxt_id = self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, t_ctxt_id)
         contexts['time'] = (t_ctxt, t_ctxt_id)
 
-        i_ctxt = ParameterContext('ice-cream', param_type=QuantityType(value_encoding=np.dtype('float32')))
+        i_ctxt = CovParameterContext('ice-cream', param_type=QuantityType(value_encoding=np.dtype('float32')))
         i_ctxt.uom = '1'
         i_ctxt_id = self.dataset_management.create_parameter_context(name='ice-cream', parameter_context=i_ctxt.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, i_ctxt_id)
@@ -736,13 +791,13 @@ class ParameterHelper(object):
     def create_simple_qc(self):
         contexts = {}
         types_manager = TypesManager(self.dataset_management,None,None)
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
+        t_ctxt = CovParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
         t_ctxt.uom = 'seconds since 1900-01-01'
         t_ctxt_id = self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, t_ctxt_id)
         contexts['time'] = (t_ctxt, t_ctxt_id)
         
-        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        temp_ctxt = CovParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         temp_ctxt.uom = 'deg_C'
         temp_ctxt.ooi_short_name = 'TEMPWAT'
         temp_ctxt.qc_contexts = types_manager.make_qc_functions('temp','TEMPWAT',lambda *args, **kwargs : None)
@@ -750,7 +805,7 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_context, temp_ctxt_id)
         contexts['temp'] = temp_ctxt, temp_ctxt_id
 
-        press_ctxt = ParameterContext('pressure', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        press_ctxt = CovParameterContext('pressure', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         press_ctxt.uom = 'dbar'
         press_ctxt.ooi_short_name = 'PRESWAT'
         press_ctxt.qc_contexts = types_manager.make_qc_functions('pressure', 'PRESWAT', lambda *args, **kwargs : None)
@@ -758,12 +813,12 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_context, press_ctxt_id)
         contexts['pressure'] = press_ctxt, press_ctxt_id
         
-        lat_ctxt = ParameterContext('lat', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value), fill_value=fill_value)
+        lat_ctxt = CovParameterContext('lat', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value), fill_value=fill_value)
         lat_ctxt.uom = 'degree_north'
         lat_ctxt_id = self.dataset_management.create_parameter_context(name='lat', parameter_context=lat_ctxt.dump())
         contexts['lat'] = lat_ctxt, lat_ctxt_id
 
-        lon_ctxt = ParameterContext('lon', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value), fill_value=fill_value)
+        lon_ctxt = CovParameterContext('lon', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value), fill_value=fill_value)
         lon_ctxt.uom = 'degree_east'
         lon_ctxt_id = self.dataset_management.create_parameter_context(name='lon', parameter_context=lon_ctxt.dump())
         contexts['lon'] = lon_ctxt, lon_ctxt_id
@@ -793,17 +848,17 @@ class ParameterHelper(object):
 
     def create_lookup_contexts(self):
         contexts = {}
-        t_ctxt = ParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
+        t_ctxt = CovParameterContext('time', param_type=QuantityType(value_encoding=np.dtype('float64')))
         t_ctxt.uom = 'seconds since 1900-01-01'
         t_ctxt_id = self.dataset_management.create_parameter_context(name='time', parameter_context=t_ctxt.dump())
         contexts['time'] = (t_ctxt, t_ctxt_id)
         
-        temp_ctxt = ParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
+        temp_ctxt = CovParameterContext('temp', param_type=QuantityType(value_encoding=np.dtype('float32')), fill_value=fill_value)
         temp_ctxt.uom = 'deg_C'
         temp_ctxt_id = self.dataset_management.create_parameter_context(name='temp', parameter_context=temp_ctxt.dump())
         contexts['temp'] = temp_ctxt, temp_ctxt_id
 
-        offset_ctxt = ParameterContext(name='offset_a', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value))
+        offset_ctxt = CovParameterContext(name='offset_a', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value))
         offset_ctxt.uom = ''
         offset_ctxt.lookup_value = 'offset_a'
         offset_ctxt.document_key = ''
@@ -811,7 +866,7 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_context, offset_ctxt_id)
         contexts['offset_a'] = offset_ctxt, offset_ctxt_id
 
-        offsetb_ctxt = ParameterContext('offset_b', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value))
+        offsetb_ctxt = CovParameterContext('offset_b', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value))
         offsetb_ctxt.uom = ''
         offsetb_ctxt.lookup_value = 'offset_b'
         offsetb_ctxt.document_key = 'coefficient_document'
@@ -819,7 +874,7 @@ class ParameterHelper(object):
         self.addCleanup(self.dataset_management.delete_parameter_context, offsetb_ctxt_id)
         contexts['offset_b'] = offsetb_ctxt, offsetb_ctxt_id
         
-        offsetc_ctxt = ParameterContext('offset_c', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value))
+        offsetc_ctxt = CovParameterContext('offset_c', param_type=SparseConstantType(base_type=ConstantType(value_encoding='float64'), fill_value=fill_value))
         offsetc_ctxt.uom = ''
         offsetc_ctxt.lookup_value = 'offset_c'
         offsetc_ctxt.document_key = '$designator_OFFSETC'
@@ -829,7 +884,7 @@ class ParameterHelper(object):
 
         func = NumexprFunction('calibrated', 'temp + offset', ['temp','offset'], param_map={'temp':'temp', 'offset':'offset_a'})
         func.lookup_values = ['LV_offset']
-        calibrated = ParameterContext('calibrated', param_type=ParameterFunctionType(func, value_encoding='float32'), fill_value=fill_value)
+        calibrated = CovParameterContext('calibrated', param_type=ParameterFunctionType(func, value_encoding='float32'), fill_value=fill_value)
         calibrated.uom = 'deg_C'
         calibrated_id = self.dataset_management.create_parameter_context(name='calibrated', parameter_context=calibrated.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, calibrated_id)
@@ -837,7 +892,7 @@ class ParameterHelper(object):
 
         func = NumexprFunction('calibrated_b', 'temp + offset_a + offset_b', ['temp','offset_a', 'offset_b'], param_map={'temp':'temp', 'offset_a':'offset_a', 'offset_b':'offset_b'})
         func.lookup_values = ['LV_offset_a', 'LV_offset_b']
-        calibrated_b = ParameterContext('calibrated_b', param_type=ParameterFunctionType(func, value_encoding='float32'), fill_value=fill_value)
+        calibrated_b = CovParameterContext('calibrated_b', param_type=ParameterFunctionType(func, value_encoding='float32'), fill_value=fill_value)
         calibrated_b.uom = 'deg_C'
         calibrated_b_id = self.dataset_management.create_parameter_context(name='calibrated_b', parameter_context=calibrated_b.dump())
         self.addCleanup(self.dataset_management.delete_parameter_context, calibrated_b_id)

--- a/ion/services/dm/utility/types.py
+++ b/ion/services/dm/utility/types.py
@@ -48,12 +48,13 @@ class TypesManager(object):
         groups = re.match(r'(category)(<)(.*)(:)(.*)(>)', parameter_type).groups()
         dtype = np.dtype(groups[2])
         try:
-            codestr = code_set.replace('\\', '')
-            code_set = ast.literal_eval(codestr)
-            for k in code_set.keys():
-                v = code_set[k]
-                del code_set[k]
-                code_set[dtype.type(k)] = v
+            if isinstance(code_set, basestring):
+                codestr = code_set.replace('\\', '')
+                code_set = ast.literal_eval(codestr)
+                for k in code_set.keys():
+                    v = code_set[k]
+                    del code_set[k]
+                    code_set[dtype.type(k)] = v
         except:
             raise TypeError('Invalid Code Set: %s' % code_set)
         return CategoryType(categories=code_set)
@@ -87,22 +88,24 @@ class TypesManager(object):
 
         if val == '':
             return None
-        if val.lower() == 'none':
+        if isinstance(val, basestring) and val.lower() == 'none':
             return None
-        if val.lower() == 'empty':
+        if isinstance(val, basestring) and val.lower() == 'empty':
             return ''
-        if val.lower() == 'false':
+        if isinstance(val, basestring) and val.lower() == 'false':
             return 0
-        if val.lower() == 'true':
+        if isinstance(val, basestring) and val.lower() == 'true':
             return 1
         if 'float' in encoding:
             return float(val)
         if 'int' in encoding:
             return int(val)
-        if encoding.lower()[0] == 's':
+        if isinstance(val, basestring) and encoding.lower()[0] == 's':
             return val
-        if encoding.lower() == 'opaque':
+        if isinstance(val, basestring) and encoding.lower() == 'opaque':
             raise TypeError('Fill value for opaque must be None, not: %s' % val)
+        if 'category' in encoding.lower() and isinstance(val, (int, float)):
+            return val
         else:
             raise TypeError('Invalid Fill Value: %s' % val) # May never be called
 
@@ -140,6 +143,8 @@ class TypesManager(object):
 
     def get_pfunc(self,pfid):
         # Preload Case
+        if not pfid:
+            raise TypeError('No parameter function id specified')
         if pfid.startswith('PFID'):
             if pfid not in self.resource_objs: 
                 raise KeyError('Function %s was not loaded' % pfid)

--- a/ion/services/dm/utility/types.py
+++ b/ion/services/dm/utility/types.py
@@ -234,8 +234,9 @@ class TypesManager(object):
     @memoize_lru(maxsize=100)
     def find_function(self,name):
         res_obj, _ = Container.instance.resource_registry.find_resources(name=name, restype=RT.ParameterFunction, id_only=False)
+
         if res_obj:
-            return res_obj[0]._id, AbstractFunction.load(res_obj[0].parameter_function)
+            return res_obj[0]._id, DatasetManagementService.get_coverage_function(res_obj[0])
         else:
             raise KeyError('%s was never loaded' % name)
 

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -27,6 +27,7 @@ from interface.services.dm.ipubsub_management_service import PubsubManagementSer
 from coverage_model.parameter_functions import AbstractFunction, PythonFunction, NumexprFunction
 from coverage_model import ParameterContext, ParameterFunctionType, ParameterDictionary
 from ion.processes.data.replay.replay_client import ReplayClient
+from ion.services.dm.inventory.dataset_management_service import DatasetManagementService
 
 from pyon.util.arg_check import validate_is_instance
 from ion.util.module_uploader import RegisterModulePreparerPy
@@ -652,8 +653,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         pfuncs, _ = self.clients.resource_registry.find_objects(data_process_definition_id, PRED.hasParameterFunction, id_only=False)
         if not pfuncs:
             raise BadRequest('Data Process Definition %s has no parameter functions' % data_process_definition_id)
-        pfunc_res = pfuncs[0]
-        func = AbstractFunction.load(pfunc_res.parameter_function)
+        func = DatasetManagementService.get_coverage_function(pfuncs[0])
         if isinstance(func, PythonFunction):
             func._import_func()
             # Gets a list of lines of the source code
@@ -741,10 +741,9 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         parameter_functions, _ = self.clients.resource_registry.find_objects(data_process_definition_id, PRED.hasParameterFunction, id_only=False)
         if not parameter_functions:
             raise BadRequest("No associated parameter functions with data process definition %s" % data_process_definition_id)
-        parameter_function = parameter_functions[0]
-
         # Make a context specific to this data process
-        pf = AbstractFunction.load(parameter_function.parameter_function)
+        pf = DatasetManagementService.get_coverage_function(parameter_functions[0])
+
         # Assign the parameter map
         if not param_map:
             raise BadRequest('A parameter map must be specified for ParameterFunctions')
@@ -1142,7 +1141,7 @@ class DataProcessManagementService(BaseDataProcessManagementService):
             tfunc_objs, _ = self.clients.resource_registry.find_objects(subject=data_process_def_obj, predicate=PRED.hasTransformFunction, id_only=False)
 
             if len(tfunc_objs) != 1:
-                log.exception('The data process definition for a data process is not correctly associated with a ParameterFunction resource.')
+                log.exception('The data process definition for a data process is not correctly associated with a TransformFunction resource.')
             else:
                 transform_function_obj = tfunc_objs[0]
 

--- a/ion/services/sa/test/test_data_process_functions.py
+++ b/ion/services/sa/test/test_data_process_functions.py
@@ -5,8 +5,7 @@ from ion.processes.data.replay.replay_process import RetrieveProcess
 from ion.services.dm.inventory.dataset_management_service import DatasetManagementService
 from ion.services.dm.utility.granule import RecordDictionaryTool
 from ion.services.dm.test.test_dm_end_2_end import DatasetMonitor
-from ion.services.dm.utility.provenance import graph
-from coverage_model import ParameterFunctionType, ParameterDictionary, PythonFunction, ParameterContext
+from coverage_model import ParameterFunctionType 
 from ion.processes.data.transforms.transform_worker import TransformWorker
 from interface.objects import DataProcessDefinition
 from nose.plugins.attrib import attr
@@ -15,7 +14,8 @@ from datetime import datetime, timedelta
 from pyon.util.containers import DotDict
 from pyon.util.log import log
 from pyon.public import RT, PRED, IonObject
-from interface.objects import TransformFunctionType, DataProcessTypeEnum, ParameterFunction, ParameterFunctionType as PFT
+from interface.objects import TransformFunctionType, DataProcessTypeEnum
+from interface.objects import ParameterFunction, ParameterFunctionType as PFT, ParameterContext
 import os
 import unittest
 import numpy as np
@@ -85,11 +85,20 @@ class TestDataProcessFunctions(DMTestCase):
         self.addCleanup(self.dataset_management.delete_parameter_function, pfunc_id)
 
         # Make a context (instance of the function)
-        pfunc = DatasetManagementService.get_coverage_function(pf)
-        pfunc.param_map = {'a':'temp', 'b':'pressure'}
-        ctxt = ParameterContext('array_sum', param_type=ParameterFunctionType(pfunc))
-        ctxt_dump = ctxt.dump()
-        ctxt_id = self.dataset_management.create_parameter_context('array_sum', ctxt_dump)
+        context = ParameterContext(name='array_sum',
+                                   units="1",
+                                   fill_value="-9999",
+                                   parameter_function_id=pfunc_id,
+                                   parameter_type="function",
+                                   value_encoding="float32",
+                                   display_name="Array Summation",
+                                   parameter_function_map={'a':'temp','b':'pressure'})
+        #pfunc = DatasetManagementService.get_coverage_function(pf)
+        #pfunc.param_map = {'a':'temp', 'b':'pressure'}
+        #ctxt = ParameterContext('array_sum', param_type=ParameterFunctionType(pfunc))
+        #ctxt_dump = ctxt.dump()
+        #ctxt_id = self.dataset_management.create_parameter_context('array_sum', ctxt_dump)
+        ctxt_id = self.dataset_management.create_parameter(context)
         self.dataset_management.add_parameter_to_dataset(ctxt_id, dataset_id)
 
         granule = self.data_retriever.retrieve(dataset_id)

--- a/ion/services/sa/test/test_data_process_functions.py
+++ b/ion/services/sa/test/test_data_process_functions.py
@@ -2,6 +2,7 @@
 __author__ = 'Luke'
 from ion.services.dm.test.dm_test_case import DMTestCase
 from ion.processes.data.replay.replay_process import RetrieveProcess
+from ion.services.dm.inventory.dataset_management_service import DatasetManagementService
 from ion.services.dm.utility.granule import RecordDictionaryTool
 from ion.services.dm.test.test_dm_end_2_end import DatasetMonitor
 from ion.services.dm.utility.provenance import graph
@@ -14,7 +15,7 @@ from datetime import datetime, timedelta
 from pyon.util.containers import DotDict
 from pyon.util.log import log
 from pyon.public import RT, PRED, IonObject
-from interface.objects import TransformFunctionType, DataProcessTypeEnum
+from interface.objects import TransformFunctionType, DataProcessTypeEnum, ParameterFunction, ParameterFunctionType as PFT
 import os
 import unittest
 import numpy as np
@@ -79,13 +80,12 @@ class TestDataProcessFunctions(DMTestCase):
         owner = 'ion_example.add_arrays'
         func = 'add_arrays'
         arglist = ['a', 'b']
-        pfunc = PythonFunction('add_arrays', owner, func, arglist, None, None)
-
-        pfunc_dump = pfunc.dump()
-        pfunc_id = self.dataset_management.create_parameter_function('add_arrays', pfunc_dump, 'Adds two arrays')
+        pf = ParameterFunction(name='add_arrays', function_type=PFT.PYTHON, owner=owner, function=func, args=arglist)
+        pfunc_id = self.dataset_management.create_parameter_function(pf)
         self.addCleanup(self.dataset_management.delete_parameter_function, pfunc_id)
 
         # Make a context (instance of the function)
+        pfunc = DatasetManagementService.get_coverage_function(pf)
         pfunc.param_map = {'a':'temp', 'b':'pressure'}
         ctxt = ParameterContext('array_sum', param_type=ParameterFunctionType(pfunc))
         ctxt_dump = ctxt.dump()
@@ -125,10 +125,8 @@ class TestDataProcessFunctions(DMTestCase):
         owner = 'ion_example.add_arrays'
         func = 'add_arrays'
         arglist = ['a', 'b']
-        pfunc = PythonFunction('add_arrays', owner, func, arglist, None, None, egg_url)
-
-        pfunc_dump = pfunc.dump()
-        pfunc_id = self.dataset_management.create_parameter_function('add_arrays', pfunc_dump, 'Adds two arrays')
+        pf = ParameterFunction(name='add_arrays', function_type=PFT.PYTHON, owner=owner, function=func, args=arglist, egg_uri=egg_url)
+        pfunc_id = self.dataset_management.create_parameter_function(pf)
         #--------------------------------------------------------------------------------
         self.addCleanup(self.dataset_management.delete_parameter_function, pfunc_id)
 


### PR DESCRIPTION
- Refactors preload for ParameterFunction resources to use a service method instead of independent behavior.
- Adds new service method `create_parameter` which accepts a ParameterContext resource and mimics most of the behavior used in preload.
- Adds new class method `get_coverage_parameter`, creates a coverage-model based ParameterContext object using the ParameterContext IonObject
- Adds new class method `get_coverage_function`, creates a coverage-model based ParameterFunction object using the ParameterFunction IonObject
- Adds new service method `load_parameter_function` which behaves like the preload for parameter functions, this allows service clients to have the same functionality as loading a preloaded resource.
  - Parses information from a row like dictionary
  - Creates an appropriate data process definition
- Changes DM tests to use the new service methods
- Updates types.py to be more robust and not geared only towards preload but for general cases as well.
