### PR TITLE
CIDEVSTC-43	Implement data process management service extensions

### DIFF
--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -324,7 +324,7 @@ class DatasetManagementService(BaseDatasetManagementService):
 
     def delete_parameter_function(self, parameter_function_id=''):
         self.read_parameter_function(parameter_function_id)
-        self.clients.resource_registry.delete(parameter_function_id)
+        self.clients.resource_registry.retire(parameter_function_id)
         return True
 
     @classmethod

--- a/ion/services/sa/process/test/test_data_process_management_service.py
+++ b/ion/services/sa/process/test/test_data_process_management_service.py
@@ -122,7 +122,4 @@ utg = UnitTestGenerator(Test_DataProcessManagementService_Unit,
 
 utg.test_all_in_one(True)
 
-utg.add_resource_unittests(RT.TransformFunction, "transform_function", {})
-#utg.add_resource_unittests(RT.DataProcessDefinition, "data_process_definition", {})
-#utg.add_resource_unittests(RT.DataProcess, "data_process", {})
 


### PR DESCRIPTION
modify delete processing in DataProcessMgmtSvc to retire (vs delete) DPD, DP, TF and PF object so that provenance is maintained.

@lukecampbell please review

@mmeisinger please review
