### PR TITLE
 CIDEVSTC-43	Implement data process management service extensions

### DIFF
--- a/ion/processes/data/transforms/test/test_transform_worker.py
+++ b/ion/processes/data/transforms/test/test_transform_worker.py
@@ -120,7 +120,8 @@ class TestTransformWorker(IonIntegrationTestCase):
         self.data_process_objs = []
         self._output_stream_ids = []
         self.granule_verified = Event()
-        self.status_event_verified = Event()
+        self.worker_assigned_event_verified = Event()
+        self.dp_created_event_verified = Event()
         self.heartbeat_event_verified = Event()
 
         self.parameter_dict_id = self.dataset_management_client.read_parameter_dictionary_by_name(name='ctd_parsed_param_dict', id_only=True)
@@ -223,8 +224,11 @@ class TestTransformWorker(IonIntegrationTestCase):
         # validate that the output granule is received and the updated value is correct
         self.assertTrue(self.granule_verified.wait(self.wait_time))
 
-        # validate that the data process load is received    (L4-CI-SA-RQ-182)
-        self.assertTrue(self.status_event_verified.wait(self.wait_time))
+        # validate that the data process loaded into worker event is received    (L4-CI-SA-RQ-182)
+        self.assertTrue(self.worker_assigned_event_verified.wait(self.wait_time))
+
+        # validate that the data process create (with data product ids) event is received    (NEW SA -42)
+        self.assertTrue(self.dp_created_event_verified.wait(self.wait_time))
 
         # validate that the data process heartbeat event is received (for every hundred granules processed) (L4-CI-SA-RQ-182)
         #this takes a while so set wait limit to large value
@@ -285,6 +289,8 @@ class TestTransformWorker(IonIntegrationTestCase):
 
         # create the DPD, DataProcess and output DataProduct
         dataprocessdef_id, dataprocess_id, dataproduct_id = self.create_data_process()
+        self.addCleanup(self.dataprocessclient.delete_data_process, dataprocess_id)
+        self.addCleanup(self.dataprocessclient.delete_data_process_definition, dataprocessdef_id)
 
         # Test for provenance. Get Data product produced by the data processes
         output_data_product_id,_ = self.rrclient.find_objects(subject=dataprocess_id,
@@ -342,6 +348,8 @@ class TestTransformWorker(IonIntegrationTestCase):
 
         # create the DPD, DataProcess and output DataProduct
         dataprocessdef_id, dataprocess_id, dataproduct_id = self.create_data_process()
+        self.addCleanup(self.dataprocessclient.delete_data_process, dataprocess_id)
+        self.addCleanup(self.dataprocessclient.delete_data_process_definition, dataprocessdef_id)
 
         # Test for provenance. Get Data product produced by the data processes
         output_data_product_id,_ = self.rrclient.find_objects(subject=dataprocess_id,
@@ -620,9 +628,10 @@ class TestTransformWorker(IonIntegrationTestCase):
 
         else:
             # else check that this is the assign event
-            self.assertIn( 'data process assigned to transform worker', data_process_event.description)
-
-        self.status_event_verified.set()
+            if 'Data process assigned to transform worker' in data_process_event.description:
+                self.worker_assigned_event_verified.set()
+            elif 'Data process created for data product' in data_process_event.description:
+                self.dp_created_event_verified.set()
 
 
     def validate_output_granule(self, msg, route, stream_id):

--- a/ion/processes/data/transforms/test/test_transform_worker_subscriptions.py
+++ b/ion/processes/data/transforms/test/test_transform_worker_subscriptions.py
@@ -97,6 +97,8 @@ class TestTransformWorkerSubscriptions(IonIntegrationTestCase):
         dp1_func_output_dp_id, dp2_func_output_dp_id =  self.create_output_data_products()
         first_dp_id = self.create_data_process_one(dpd_id, dp1_func_output_dp_id)
 
+        second_dp_id = self.create_data_process_two(dpd_id, self.input_dp_two_id, dp2_func_output_dp_id)
+
         #retrieve subscription from data process
         subscription_objs, _ = self.rrclient.find_objects(subject=first_dp_id, predicate=PRED.hasSubscription, object_type=RT.Subscription, id_only=False)
         log.debug('test_transform_worker subscription_obj:  %s', subscription_objs[0])
@@ -124,7 +126,7 @@ class TestTransformWorkerSubscriptions(IonIntegrationTestCase):
 
         self.publisher_one.publish(msg=rdt.to_granule(), stream_id=self.stream_one_id)
 
-        second_dp_id = self.create_data_process_two(dpd_id, self.input_dp_two_id, dp2_func_output_dp_id)
+
 
         #retrieve subscription from data process
         subscription_objs, _ = self.rrclient.find_objects(subject=second_dp_id, predicate=PRED.hasSubscription, object_type=RT.Subscription, id_only=False)


### PR DESCRIPTION
use values attribute in DataProcessStatusEvent event to hold data product ids, etc. augment test to check that event is received when a data process is created for a data product.

@lukecampbell please review
