### PR TITLE
CIDEVSTC-49 - New service method for adding a parameter to a data product

### DIFF
--- a/ion/processes/bootstrap/registration_bootstrap.py
+++ b/ion/processes/bootstrap/registration_bootstrap.py
@@ -38,5 +38,8 @@ class RegistrationBootstrap(ImmediateProcess):
         real_path = FileSystem.get_extended_url(base)
         datasets_xml_path = os.path.join(real_path, filename)
 
-        os.remove(datasets_xml_path)
+        try:
+            os.remove(datasets_xml_path)
+        except OSError:
+            pass # File doesn't exist
 

--- a/ion/services/dm/test/test_dm_extended.py
+++ b/ion/services/dm/test/test_dm_extended.py
@@ -227,24 +227,10 @@ class TestDMExtended(DMTestCase):
         self.container.spawn_process('import_dataset', 'ion.processes.data.import_dataset', 'ImportDataset', {'op':'stop', 'instrument':'CTDGV'})
 
 
-    def preload_ui(self):
-        config = DotDict()
-        config.op='loadui'
-        config.loadui=True
-        config.attachments='res/preload/r2_ioc/attachments'
-        config.ui_path = "http://userexperience.oceanobservatories.org/database-exports/Candidates"
-        
-        self.container.spawn_process('preloader', 'ion.processes.bootstrap.ion_loader', 'IONLoader', config)
 
     def preload_indexes(self):
         pass
 
-    def launch_ui_facepage(self, data_product_id):
-        '''
-        Opens the UI face page on localhost for a particular data product
-        '''
-        from subprocess import call
-        call(['open', 'http://localhost:3000/DataProduct/face/%s/' % data_product_id])
 
     def launch_device_facepage(self, instrument_device_id):
         '''
@@ -253,22 +239,6 @@ class TestDMExtended(DMTestCase):
         from subprocess import call
         call(['open', 'http://localhost:3000/InstrumentDevice/face/%s/' % instrument_device_id])
 
-
-    def strap_erddap(self, data_product_id=None):
-        '''
-        Copies the datasets.xml to /tmp
-        '''
-        datasets_xml_path = RegistrationProcess.get_datasets_xml_path(CFG)
-        if os.path.lexists('/tmp/datasets.xml'):
-            os.unlink('/tmp/datasets.xml')
-        os.symlink(datasets_xml_path, '/tmp/datasets.xml')
-        if data_product_id:
-            with open('/tmp/erddap/flag/data%s' % data_product_id, 'a'):
-                pass
-
-        gevent.sleep(5)
-        from subprocess import call
-        call(['open', 'http://localhost:9000/erddap/tabledap/data%s.html' % data_product_id])
 
     def create_google_dt_workflow_def(self):
         # Check to see if the workflow defnition already exist

--- a/ion/services/sa/process/data_process_management_service.py
+++ b/ion/services/sa/process/data_process_management_service.py
@@ -825,12 +825,8 @@ class DataProcessManagementService(BaseDataProcessManagementService):
         '''
         Adds the parameter context to the data product
         '''
-        # Get the dataset id
-        dataset_ids, _ = self.clients.resource_registry.find_objects(data_product_id, PRED.hasDataset, id_only=True)
-        dataset_id = dataset_ids[0]
-
         # Add the parameter
-        self.clients.dataset_management.add_parameter_to_dataset(parameter_context_id, dataset_id)
+        self.clients.data_product_management.add_parameter_to_data_product(parameter_context_id, data_product_id)
 
     def _create_data_process_for_parameter_function(self, data_process_definition, data_product_id, param_map):
         '''

--- a/ion/services/sa/product/data_product_management_service.py
+++ b/ion/services/sa/product/data_product_management_service.py
@@ -472,14 +472,14 @@ class DataProductManagementService(BaseDataProductManagementService):
 
         stream_def_ids, _ = self.clients.resource_registry.find_objects(data_product_id, PRED.hasStreamDefinition, id_only=False)
         stream_def = stream_def_ids[0]
-        pdict_ids, _ = self.clients.resource_registry.find_objects(data_product_id, PRED.hasParameterDictionary,id_only=True)
+        pdict_ids, _ = self.clients.resource_registry.find_objects(stream_def._id, PRED.hasParameterDictionary,id_only=True)
         pdict_id = pdict_ids[0]
-        self.clients.resource_registry.create_association(subject=pdict_id, predicate=PRED.hasParameterContext, object=pdict_id)
+        self.clients.resource_registry.create_association(subject=pdict_id, predicate=PRED.hasParameterContext, object=parameter_context_id)
         if stream_def.available_fields:
-            stream_def.append(pc.name)
+            stream_def.available_fields.append(pc.name)
             self.clients.resource_registry.update(stream_def)
 
-        datasets = self.clients.resource_registry.find_objects(data_product_id, PRED.hasDataset, id_only=True)
+        datasets, _ = self.clients.resource_registry.find_objects(data_product_id, PRED.hasDataset, id_only=True)
         if not datasets:
             raise BadRequest("No associated dataset, please ensure that this data product is activated")
         

--- a/ion/services/sa/test/test_data_process_functions.py
+++ b/ion/services/sa/test/test_data_process_functions.py
@@ -7,7 +7,7 @@ from ion.services.dm.utility.granule import RecordDictionaryTool
 from ion.services.dm.test.test_dm_end_2_end import DatasetMonitor
 from coverage_model import ParameterFunctionType 
 from ion.processes.data.transforms.transform_worker import TransformWorker
-from interface.objects import DataProcessDefinition
+from interface.objects import DataProcessDefinition, DataProduct
 from nose.plugins.attrib import attr
 from pyon.util.breakpoint import breakpoint
 from datetime import datetime, timedelta
@@ -16,6 +16,8 @@ from pyon.util.log import log
 from pyon.public import RT, PRED, IonObject
 from interface.objects import TransformFunctionType, DataProcessTypeEnum
 from interface.objects import ParameterFunction, ParameterFunctionType as PFT, ParameterContext
+from pyon.util.poller import poll_wrapper
+from pyon.public import CFG
 import os
 import unittest
 import numpy as np
@@ -202,6 +204,56 @@ class TestDataProcessFunctions(DMTestCase):
 
         params = dpms.parameters_for_data_product(data_product_id, True)
         self.assertEquals(len(params), 2)
+
+    @attr('INT')
+    def test_add_parameter_to_data_product(self):
+        self.test_add_parameter_function()
+        data_product_id = self.data_product_id
+        stream_def_id = self.resource_registry.find_objects(data_product_id, PRED.hasStreamDefinition, id_only=True)[0][0]
+        pdict_id = self.resource_registry.find_objects(stream_def_id, PRED.hasParameterDictionary, id_only=True)[0][0]
+        # Create a new data product htat represents the L1 temp from the ctd simulator
+        dp = DataProduct(name='CTD Simulator TEMPWAT L1')
+        stream_def_id = self.pubsub_management.create_stream_definition(name='tempwat_l1', parameter_dictionary_id=pdict_id, available_fields=['time','temp'])
+        dp_id = self.data_product_management.create_data_product(dp, stream_definition_id=stream_def_id, parent_data_product_id=data_product_id)
+
+        parameter_function = ParameterFunction(name='linear_corr',
+                                               function_type=PFT.NUMEXPR,
+                                               function='a * x + b',
+                                               args=['x','a','b'])
+        pf_id = self.dataset_management.create_parameter_function(parameter_function)
+
+        dpd = DataProcessDefinition(name='linear_corr', description='Linear Correction')
+        self.data_process_management.create_data_process_definition(dpd, pf_id)
+
+        parameter = ParameterContext(name='temperature_corrected',
+                                     parameter_type='function',
+                                     parameter_function_id=pf_id,
+                                     parameter_function_map={'x':'temp', 'a':1.03, 'b':0.25},
+                                     value_encoding='float32',
+                                     units='deg_C',
+                                     display_name='Temperature Corrected')
+        p_id = self.dataset_management.create_parameter(parameter)
+        self.data_product_management.add_parameter_to_data_product(p_id,dp_id)
+
+        dataset_id = self.RR2.find_dataset_id_of_data_product_using_has_dataset(data_product_id)
+
+        @poll_wrapper(CFG.get_safe('endpoint.receive.timeout', 10))
+        def poller():
+            granule = self.data_retriever.retrieve(dataset_id)
+            rdt = RecordDictionaryTool.load_from_granule(granule)
+            if 'temperature_corrected' in rdt:
+                return rdt
+            return None
+        rdt = poller()
+        np.testing.assert_array_almost_equal(rdt['temperature_corrected'], np.arange(30,dtype=np.float32) * 1.03 + 0.25, decimal=5)
+
+
+        #self.preload_ui()
+        #self.launch_ui_facepage(dp_id)
+        #self.strap_erddap(dp_id)
+        #breakpoint(locals(), globals())
+        
+
 
     @attr('UTIL')
     def test_logger(self):

--- a/ion/services/sa/test/test_data_process_functions.py
+++ b/ion/services/sa/test/test_data_process_functions.py
@@ -22,6 +22,7 @@ import os
 import unittest
 import numpy as np
 import calendar
+import gevent
 
 class TestDataProcessFunctions(DMTestCase):
 
@@ -236,8 +237,9 @@ class TestDataProcessFunctions(DMTestCase):
         self.data_product_management.add_parameter_to_data_product(p_id,dp_id)
 
         dataset_id = self.RR2.find_dataset_id_of_data_product_using_has_dataset(data_product_id)
+        gevent.sleep(2) # Yield to close
 
-        @poll_wrapper(CFG.get_safe('endpoint.receive.timeout', 10))
+        @poll_wrapper(30)
         def poller():
             granule = self.data_retriever.retrieve(dataset_id)
             rdt = RecordDictionaryTool.load_from_granule(granule)

--- a/ion/services/sa/test/test_data_process_functions.py
+++ b/ion/services/sa/test/test_data_process_functions.py
@@ -208,6 +208,7 @@ class TestDataProcessFunctions(DMTestCase):
 
     @attr('INT')
     def test_add_parameter_to_data_product(self):
+        #self.preload_ui()
         self.test_add_parameter_function()
         data_product_id = self.data_product_id
         stream_def_id = self.resource_registry.find_objects(data_product_id, PRED.hasStreamDefinition, id_only=True)[0][0]
@@ -237,7 +238,7 @@ class TestDataProcessFunctions(DMTestCase):
         self.data_product_management.add_parameter_to_data_product(p_id,dp_id)
 
         dataset_id = self.RR2.find_dataset_id_of_data_product_using_has_dataset(data_product_id)
-        gevent.sleep(2) # Yield to close
+        gevent.sleep(5) # Yield to close
 
         @poll_wrapper(30)
         def poller():
@@ -250,7 +251,6 @@ class TestDataProcessFunctions(DMTestCase):
         np.testing.assert_array_almost_equal(rdt['temperature_corrected'], np.arange(30,dtype=np.float32) * 1.03 + 0.25, decimal=5)
 
 
-        #self.preload_ui()
         #self.launch_ui_facepage(dp_id)
         #self.strap_erddap(dp_id)
         #breakpoint(locals(), globals())


### PR DESCRIPTION
Only adding it to a dataset doesn't update the stream definition or the datasets catalog, this method provides clients to add a parameter to a data product and have it propagate through the system correctly
