### PR TITLE
M114 Coverage Model Integration

### DIFF
--- a/ion/util/test/test_coverage_recovery.py
+++ b/ion/util/test/test_coverage_recovery.py
@@ -188,6 +188,7 @@ class TestCoverageModelRecoveryInt(IonIntegrationTestCase):
         gevent.sleep(1)
 
     @attr('LOCOINT')
+    @unittest.skip('Coverage metadata is now stored in Postgres.  Recovery may no longer make sense.')
     @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Host requires file-system access to coverage files, CEI mode does not support.')
     @unittest.skipIf(not_have_h5stat, 'h5stat is not accessible in current PATH')
     @unittest.skipIf(not not_have_h5stat and not h5stat_correct_version, 'HDF is the incorrect version: %s' % version_str)

--- a/ion/util/test/test_direct_coverage_utils.py
+++ b/ion/util/test/test_direct_coverage_utils.py
@@ -258,6 +258,7 @@ class TestDirectCoverageAccess(DMTestCase):
                     np.testing.assert_equal(cov.get_parameter_values(p, slice(None, 10)), want_vals[p])
 
     @attr('LOCOINT')
+    @unittest.skip('Coverage metadata is now stored in Postgres.  Recovery may no longer make sense.')
     @unittest.skipIf(os.getenv('CEI_LAUNCH_TEST', False), 'Host requires file-system access to coverage files, CEI mode does not support.')
     @unittest.skipIf(not_have_h5stat, 'h5stat is not accessible in current PATH')
     @unittest.skipIf(not not_have_h5stat and not h5stat_correct_version, 'HDF is the incorrect version: %s' % version_str)


### PR DESCRIPTION
Skip tests that corrupt hdf metadata files.  HDF is no longer used the backing store for metadata.
