### PR TITLE
Clones the Parameter Dictionary for every New Data Product

### DIFF
--- a/ion/processes/bootstrap/ion_loader.py
+++ b/ion/processes/bootstrap/ion_loader.py
@@ -3129,6 +3129,11 @@ Reason: %s
 
         for assoc in assocs_filtered:
             pdict = self._get_resource_obj(assoc.s)
+            # If the parameter dictionary was created by the service logic then it won't be cached in the loader
+            # In this case, we need to pull it from the resource registry
+            # TODO: Update the preload logic to mimic the service way
+            if pdict is None:
+                pdict = self.container.resource_registry.read(assoc.s)
             pdef = self._get_resource_obj(assoc.o, True)
             if pdef is None:
                 log.warn("Ignoring ParameterContext %s - not found", assoc.o)

--- a/ion/services/sa/product/data_product_management_service.py
+++ b/ion/services/sa/product/data_product_management_service.py
@@ -85,23 +85,6 @@ class DataProductManagementService(BaseDataProductManagementService):
       # Return the id of the new data product
         return data_product_id
 
-    def clone_pdict(self, data_product, stream_definition_id=''):
-        pdicts, assocs = self.clients.resource_registry.find_objects(stream_definition_id, PRED.hasParameterDictionary, id_only=False)
-        if not pdicts:
-            raise BadRequest("No parameter dictionary associated with the stream definition %s" % stream_definition_id)
-        pdict = pdicts[0]
-        assoc = assocs[0] # I've never had to use this before
-
-        parameter_ids, _ = self.clients.resource_registry.find_objects(pdict._id, PRED.hasParameterContext, id_only=True)
-        pdict_id = self.clients.dataset_management.create_parameter_dictionary(
-                    name="%s-%s" % (data_product.name, data_product._id),
-                    parameter_context_ids=parameter_ids,
-                    temporal_context=pdict.temporal_context, 
-                    description=pdict.description)
-        self.clients.resource_registry.delete_association(assoc)
-        self.clients.resource_registry.create_association(subject=stream_definition_id, predicate=PRED.hasParameterDictionary, object=pdict_id)
-
-
     def create_data_product_(self, data_product=None):
 
         validate_is_not_none(data_product, 'A data product (ion object) must be passed to register a data product')
@@ -176,6 +159,24 @@ class DataProductManagementService(BaseDataProductManagementService):
         Determine the relevant parameters that need QC applied and create parameters for the evaluations
         '''
         pass
+    
+    def clone_pdict(self, data_product, stream_definition_id=''):
+        pdicts, assocs = self.clients.resource_registry.find_objects(stream_definition_id, PRED.hasParameterDictionary, id_only=False)
+        if not pdicts:
+            raise BadRequest("No parameter dictionary associated with the stream definition %s" % stream_definition_id)
+        pdict = pdicts[0]
+        assoc = assocs[0] # I've never had to use this before
+
+        parameter_ids, _ = self.clients.resource_registry.find_objects(pdict._id, PRED.hasParameterContext, id_only=True)
+        pdict_id = self.clients.dataset_management.create_parameter_dictionary(
+                    name="%s-%s" % (data_product.name, data_product._id),
+                    parameter_context_ids=parameter_ids,
+                    temporal_context=pdict.temporal_context, 
+                    description=pdict.description)
+        self.clients.resource_registry.delete_association(assoc)
+        self.clients.resource_registry.create_association(subject=stream_definition_id, predicate=PRED.hasParameterDictionary, object=pdict_id)
+
+
 
     def assign_stream_definition_to_data_product(self, data_product_id='', stream_definition_id='', exchange_point=''):
 
@@ -188,6 +189,8 @@ class DataProductManagementService(BaseDataProductManagementService):
         exchange_point = exchange_point or 'science_data'
 
         data_product = self.RR2.read(data_product_id)
+
+        self.clone_pdict(data_product, stream_definition_id)
 
         #if stream_definition_id:
         #@todo: What about topics?

--- a/ion/services/sa/product/test/test_data_product_management_service.py
+++ b/ion/services/sa/product/test/test_data_product_management_service.py
@@ -49,38 +49,6 @@ class TestDataProductManagementServiceUnit(PyonTestCase):
         self.data_source.description = 'data source desc'
 
 
-    def test_createDataProduct_and_DataProducer_success(self):
-        # setup
-        self.clients.resource_registry.find_resources.return_value = ([], 'do not care')
-        self.clients.resource_registry.find_associations.return_value = []
-        self.clients.resource_registry.create.return_value = ('SOME_RR_ID1', 'Version_1')
-        self.clients.data_acquisition_management.assign_data_product.return_value = None
-        self.clients.pubsub_management.create_stream.return_value = "stream_id", "route_id"
-
-
-        # Construct temporal and spatial Coordinate Reference System objects
-        tcrs = CRS([AxisTypeEnum.TIME])
-        scrs = CRS([AxisTypeEnum.LON, AxisTypeEnum.LAT])
-
-        # Construct temporal and spatial Domain objects
-        tdom = GridDomain(GridShape('temporal', [0]), tcrs, MutabilityEnum.EXTENSIBLE) # 1d (timeline)
-        sdom = GridDomain(GridShape('spatial', [0]), scrs, MutabilityEnum.IMMUTABLE) # 1d spatial topology (station/trajectory)
-
-        sdom = sdom.dump()
-        tdom = tdom.dump()
-
-
-        dp_obj = IonObject(RT.DataProduct,
-            name='DP1',
-            description='some new dp',
-            temporal_domain = tdom,
-            spatial_domain = sdom)
-
-        # test call
-        dp_id = self.data_product_management_service.create_data_product(data_product=dp_obj,
-                stream_definition_id='a stream def id')
-
-
 
     @unittest.skip('not working')
     def test_createDataProduct_and_DataProducer_with_id_NotFound(self):


### PR DESCRIPTION
- Cloned Parameter Dictionaries have the name DataProduct.name + _ + DataProduct._id
- Preload is a bit slower because it doesn't mimic the service yet which leads to cache misses for the parameter dictionaries in the loading process
  - For now, I'd rather preload go slower than have consistency issues
- Removes DPMS Unit test. The test serves little more than a syntax check and it's now deprecated. Frankly, I'm surprised it worked because of the refactor we did a few months ago. When we split up the creation into multiple methods that the test should have broke, I think.
