### PR TITLE
M088 - QC tables - download via DatasetManagementService

### DIFF
--- a/ion/processes/data/upload/upload_qc_processing.py
+++ b/ion/processes/data/upload/upload_qc_processing.py
@@ -234,7 +234,7 @@ class UploadQcProcessing(ImmediateProcess):
             try: # if reference_designator exists in object_store, read it                           
                 rd = self.object_store.read(r)
             except: # if does not yet exist in object_store, create it (can't use update_doc because need to set id)
-                rd = self.object_store.create_doc({},r) # CAUTION: this returns a tuple, not a dict like read() returns
+                rd = self.object_store.create_doc({'_type':'QC'},r) # CAUTION: this returns a tuple, not a dict like read() returns
                 rd = self.object_store.read(r) # read so we have a dict like we expect
             # merge all from updates[r] into dict destined for the object_store (rd)
             for dp in updates[r]: # loops the dataproducts under each reference_designator in updates

--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -754,5 +754,9 @@ class DatasetManagementService(BaseDatasetManagementService):
                 pdict.add_context(context)
         return pdict
 
-    def read_object(self, obj_id):
-        return self.container.object_store.read(obj_id)
+    def read_qc_table(self, obj_id):
+        obj = self.container.object_store.read(obj_id)
+        if '_type' in obj and obj['_type'] == 'QC':
+            return obj
+        else:
+            raise BadRequest('obj_id %s not QC' % obj_id)

--- a/ion/services/dm/inventory/dataset_management_service.py
+++ b/ion/services/dm/inventory/dataset_management_service.py
@@ -754,3 +754,5 @@ class DatasetManagementService(BaseDatasetManagementService):
                 pdict.add_context(context)
         return pdict
 
+    def read_object(self, obj_id):
+        return self.container.object_store.read(obj_id)

--- a/ion/services/dm/test/test_uploads.py
+++ b/ion/services/dm/test/test_uploads.py
@@ -10,6 +10,7 @@ import numpy as np
 from nose.plugins.attrib import attr
 from webtest import TestApp
 from interface.services.coi.iservice_gateway_service import ServiceGatewayServiceClient
+from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
 from ion.services.coi.service_gateway_service import service_gateway_app
 from ion.services.dm.test.dm_test_case import DMTestCase
 from ion.services.dm.test.test_dm_end_2_end import DatasetMonitor
@@ -390,6 +391,93 @@ Archive:  local_range_test.zip
               }
            ]
         })
+
+    def test_download(self):
+
+        # clients
+        dataset_management = DatasetManagementServiceClient()
+
+        # verify target object [REFDES01] do not exist in object_store
+        self.assertRaises(NotFound, dataset_management.read_object, 'REFDES01')
+
+        # NOTE: time is again monkey patched in 'test_upload_qc' but should be static for that
+        # MONKEY PATCH time.time() for volatile ts_updated values in dict (set in POST below)
+        CONSTANT_TIME = time.time() # time value we'll use in assert tests
+        def new_time():
+            return CONSTANT_TIME
+        old_time = time.time
+        time.time = new_time
+
+        #upload some data
+        self.test_upload_qc()
+
+        # restore MONKEY PATCHed time
+        time.time = old_time
+
+        REFDES01 = dataset_management.read_object('REFDES01')
+        RD01DP01 = REFDES01.get('RD01DP01', None)
+        self.assertEquals(RD01DP01, {
+           'stuck_value':[
+              {
+                 'units':'C',
+                 'consecutive_values':10,
+                 'ts_created':CONSTANT_TIME,
+                 'resolution':0.005,
+                 'author':'Otter'
+              }
+           ],
+           'gradient_test':[
+              {
+                 'toldat':0.1,
+                 'xunits':'s',
+                 'mindx':30,
+                 'author':'Boon',
+                 'startdat':None,
+                 'ddatdx':[-0.01, 0.01],
+                 'units':'C',
+                 'ts_created':CONSTANT_TIME
+              }
+           ],
+           'global_range':[
+              {
+                 'units':'m/s',
+                 'max_value':1,
+                 'min_value':-1,
+                 'ts_created':CONSTANT_TIME,
+                 'author':'Douglas C. Neidermeyer'
+              },
+              {
+                 'units':'m/s',
+                 'max_value':10,
+                 'min_value':-10,
+                 'ts_created':CONSTANT_TIME,
+                 'author':'Bluto'
+              }
+           ],
+           'trend_test':[
+              {
+                 'author':'Pinto',
+                 'standard_deviation':4.5,
+                 'polynomial_order':4,
+                 'sample_length':25,
+                 'units':'K',
+                 'ts_created':CONSTANT_TIME
+              }
+           ],
+           'spike_test':[
+              {
+                 'author':'Flounder',
+                 'range_multiplier':4,
+                 'window_length':15,
+                 'units':'degrees',
+                 'ts_created':CONSTANT_TIME,
+                 'accuracy':0.0001
+              }
+           ]
+        })
+
+
+
 
     def getUploadedParameterContexts(self, dp_id):
         '''

--- a/ion/services/dm/test/test_uploads.py
+++ b/ion/services/dm/test/test_uploads.py
@@ -398,7 +398,7 @@ Archive:  local_range_test.zip
         dataset_management = DatasetManagementServiceClient()
 
         # verify target object [REFDES01] do not exist in object_store
-        self.assertRaises(NotFound, dataset_management.read_object, 'REFDES01')
+        self.assertRaises(NotFound, dataset_management.read_qc_table, 'REFDES01')
 
         # NOTE: time is again monkey patched in 'test_upload_qc' but should be static for that
         # MONKEY PATCH time.time() for volatile ts_updated values in dict (set in POST below)
@@ -414,7 +414,7 @@ Archive:  local_range_test.zip
         # restore MONKEY PATCHed time
         time.time = old_time
 
-        REFDES01 = dataset_management.read_object('REFDES01')
+        REFDES01 = dataset_management.read_qc_table('REFDES01')
         RD01DP01 = REFDES01.get('RD01DP01', None)
         self.assertEquals(RD01DP01, {
            'stuck_value':[


### PR DESCRIPTION
@MauriceManning
@lukecampbell

requires https://github.com/ooici/ion-definitions/pull/548

adds read_object to dataset management service and test to read QC tables from object store through DMS
