### PR TITLE
More flexible platform command dispatch involving child instruments

### DIFF
--- a/ion/agents/platform/mission_manager.py
+++ b/ion/agents/platform/mission_manager.py
@@ -31,7 +31,9 @@ class MissionManager(object):
         self._agent = pa
         self._platform_id = pa._platform_id
 
-        self._agent.aparam_mission = []
+        self._agent.aparam_mission = None
+        self._mission_entries = None
+        self._mission_scheduler = None
 
         self._agent.aparam_set_mission = self.aparam_set_mission
 
@@ -39,13 +41,20 @@ class MissionManager(object):
     def aparam_set_mission(self, yaml_filename):
         """
         Specifies mission to be executed.
-        @param yaml_filename  Mission definition
+        @param yaml_filename  Mission definition filename; can be None.
         """
         log.debug('[mm] aparam_set_mission: yaml_filename=%s', yaml_filename)
 
+        self._agent.aparam_mission = yaml_filename
+
+        if self._agent.aparam_mission is None:
+            self._mission_entries = None
+            self._mission_scheduler = None
+            return
+
         mission_loader = MissionLoader()
         mission_loader.load_mission_file(yaml_filename)
-        self._agent.aparam_mission = mission_loader.mission_entries
+        self._mission_entries = mission_loader.mission_entries
 
         log.debug('[mm] aparam_set_mission: _ia_clients=\n%s',
                   self._agent._pp.pformat(self._agent._ia_clients))
@@ -61,35 +70,44 @@ class MissionManager(object):
 
                 instruments[obj.resource_id] = obj.ia_client
 
-        self.mission_scheduler = MissionScheduler(self._agent,
-                                                  instruments,
-                                                  self._agent.aparam_mission)
+        self._mission_scheduler = MissionScheduler(self._agent,
+                                                   instruments,
+                                                   self._mission_entries)
         log.debug('[mm] aparam_set_mission: MissionScheduler created. entries=%s',
-                  self._agent.aparam_mission)
+                  self._mission_entries)
 
     # TODO appropriate way to handle potential errors/exceptions in
     # methods below.  Very ad hoc for the moment.
 
     def run_mission(self):
-        try:
-            self.mission_scheduler.run_mission()
-            return None
-        except Exception as ex:
-            log.exception('[mm] run_mission')
-            return ex
+        if self._mission_scheduler is not None:
+            try:
+                self._mission_scheduler.run_mission()
+                return None
+            except Exception as ex:
+                log.exception('[mm] run_mission')
+                return ex
+        else:
+            log.error('[mm] run_mission: no mission given')
 
     def abort_mission(self):
-        try:
-            self.mission_scheduler.abort_mission()
-            return None
-        except Exception as ex:
-            log.exception('[mm] abort_mission')
-            return ex
+        if self._mission_scheduler is not None:
+            try:
+                self._mission_scheduler.abort_mission()
+                return None
+            except Exception as ex:
+                log.exception('[mm] abort_mission')
+                return ex
+        else:
+            log.error('[mm] abort_mission: no mission given')
 
     def kill_mission(self):
-        try:
-            self.mission_scheduler.kill_mission()
-            return None
-        except Exception as ex:
-            log.exception('[mm] kill_mission')
-            return ex
+        if self._mission_scheduler is not None:
+            try:
+                self._mission_scheduler.kill_mission()
+                return None
+            except Exception as ex:
+                log.exception('[mm] kill_mission')
+                return ex
+        else:
+            log.error('[mm] kill_mission: no mission given')

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -2095,15 +2095,12 @@ class PlatformAgent(ResourceAgent):
 
         return children_with_errors
 
-    def _instruments_execute_agent(self, command=None, create_command=None,
+    def _instruments_execute_agent(self, command,
                                    expected_state=None):
         """
         Supporting routine for various commands sent to instruments.
 
         Note that invalidated children are ignored.
-
-        @param create_command invoked as create_command(instrument_id) for each
-                              instrument to create the command to be executed.
 
         @param expected_state  If given, it is checked that the child gets to
                                this state.
@@ -2111,9 +2108,6 @@ class PlatformAgent(ResourceAgent):
         @return dict with children having caused some error. Empty if all
                 children were processed OK.
         """
-
-        # OOIION-1290: only rely on self._ia_clients, which is the more dynamic
-        # variable reflecting the current situation with child instruments.
 
         # act only on the children that are not invalidated:
         valid_clients = dict((k, v) for k, v in self._ia_clients.iteritems()
@@ -2129,8 +2123,8 @@ class PlatformAgent(ResourceAgent):
         if not len(valid_clients):
             log.warn("%r: OOIION-1077 all instrument children (%s) are "
                      "invalidated or could not be re-validated. Not executing"
-                     " command. command=%r, create_command=%r",
-                     self._platform_id, instrument_ids, command, create_command)
+                     " command. command=%r",
+                     self._platform_id, instrument_ids, command)
             return children_with_errors   # that is, none.
 
         def execute_cmd(instrument_id, cmd):
@@ -2168,12 +2162,8 @@ class PlatformAgent(ResourceAgent):
 
             return None
 
-        if command:
-            log.debug("%r: executing command %r on my instruments: %s",
-                      self._platform_id, command, valid_clients.keys())
-        else:
-            log.debug("%r: executing command on my instruments: %s",
-                      self._platform_id, valid_clients.keys())
+        log.debug("%r: executing command %r on my instruments: %s",
+                  self._platform_id, command, valid_clients.keys())
 
         for instrument_id in valid_clients:
             if expected_state:
@@ -2187,7 +2177,7 @@ class PlatformAgent(ResourceAgent):
                               self._platform_id, instrument_id, expected_state)
                     continue
 
-            cmd = AgentCommand(command=command) if command else create_command(instrument_id)
+            cmd = AgentCommand(command=command)
             err_msg = execute_cmd(instrument_id, cmd)
 
             if err_msg is not None:
@@ -2386,9 +2376,6 @@ class PlatformAgent(ResourceAgent):
                 children were processed OK.
         """
         instruments_with_errors = {}
-
-        # OOIION-1290: only rely on self._ia_clients, which is the more dynamic
-        # variable reflecting the current situation with child instruments.
 
         # Act only on the children that are not invalidated:
         valid_clients = dict((k, v) for k, v in self._ia_clients.iteritems()

--- a/ion/agents/platform/schema.py
+++ b/ion/agents/platform/schema.py
@@ -294,7 +294,14 @@ AGENT_SCHEMA_V1 = {
                         "value_map" : DeviceStatusType._value_map
                         }                    
                     }]
-                }
+                },
+        "mission":
+            {
+                "display_name" : "Mission.",
+                "description" : "Mission filename.",
+                "visibility" : "READ_WRITE",
+                "type" : "string"
+            }
         },
     "states" : {
         PlatformAgentState.UNINITIALIZED : {

--- a/ion/agents/platform/test/mission_RSN_simulator0C.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator0C.yml
@@ -1,0 +1,43 @@
+#
+# Based on mission_RSN_simulator1.yml but here even simpler (1 instrument) to
+# facilitate some core testing of the platform-agent/mission-execution integration
+# and platform-instrument coordination in terms of state transitions.
+#
+# In this case, mission to be started by platform in COMMAND state.
+#
+
+name: OMS Simulator Mission
+version: 0.4
+description: Sample OMS Simulator Mission
+
+platform:
+  platformID: LJ01D
+
+mission:
+  - instrument:
+    instrumentID: [SBE37_SIM_02]
+    errorHandling:
+      default: retry
+      maxRetries: 3
+    schedule:
+      startTime: 05/01/2014 00:00:00
+      loop:
+        quantity: 1
+        value: 3
+        units: mins
+      event:
+        parentID: 
+        eventID: 
+    preMissionSequence:
+      - command: SBE37_SIM_02, set_resource(INTERVAL{3})
+        onError: retry
+    missionSequence:
+      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
+        onError: retry
+      - command: wait(1)
+        onError:
+      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+        onError: retry
+    postMissionSequence:
+      - command: SBE37_SIM_02, execute_agent(RESET)
+        onError: retry

--- a/ion/agents/platform/test/mission_RSN_simulator0S.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator0S.yml
@@ -1,0 +1,39 @@
+#
+# Based on mission_RSN_simulator1.yml but here even simpler (1 instrument) to
+# facilitate some core testing of the platform-agent/mission-execution integration
+# and platform-instrument coordination in terms of state transitions.
+#
+# In this case, mission to be started by platform in STREAMING (MONITORING) state.
+#
+
+name: OMS Simulator Mission
+version: 0.4
+description: Sample OMS Simulator Mission
+
+platform:
+  platformID: LJ01D
+
+mission:
+  - instrument:
+    instrumentID: [SBE37_SIM_02]
+    errorHandling:
+      default: retry
+      maxRetries: 3
+    schedule:
+      startTime: 05/01/2014 00:00:00
+      loop:
+        quantity: 1
+        value: 3
+        units: mins
+      event:
+        parentID: 
+        eventID: 
+    preMissionSequence:
+    missionSequence:
+      - command: wait(1)
+        onError:
+    postMissionSequence:
+      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+        onError: retry
+      - command: SBE37_SIM_02, execute_agent(RESET)
+        onError: retry

--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -108,7 +108,13 @@ class TestPlatformAgent(BaseIntTestPlatform):
                     else:
                         # default "done" sequence for most tests
                         try:
-                            self._go_inactive()
+                            state = self._get_state()
+                            if state != PlatformAgentState.UNINITIALIZED:
+                                if state in [PlatformAgentState.IDLE,
+                                             PlatformAgentState.STOPPED,
+                                             PlatformAgentState.COMMAND,
+                                             PlatformAgentState.LOST_CONNECTION]:
+                                    self._go_inactive()
                             self._reset()
                         finally:  # attempt shutdown anyway
                             self._shutdown()
@@ -390,6 +396,7 @@ class TestPlatformAgent(BaseIntTestPlatform):
             'alerts',
             'aggstatus',
             'rollup_status',
+            'mission',
         ]
         res_pars_all = []
         res_cmds_all = [


### PR DESCRIPTION
See https://confluence.oceanobservatories.org/display/CIDev/Platform+Agent+adjustments+for+Mission+Execution

All relevant unit and integration tests completing OK locally (including Bob's TestSimpleMission.test_simple_simulator_mission)

Also, includes a fix to a broken test_capabilities test (due to missing 'mission' param in platform agent schema).

@edwardhunter please review/merge
@Bobfrat  please review
