### PR TITLE
fix mission test and other adjustments

### DIFF
--- a/ion/agents/mission_executive.py
+++ b/ion/agents/mission_executive.py
@@ -25,6 +25,8 @@ from ion.agents.platform.platform_agent_enums import PlatformAgentEvent
 from ion.agents.platform.platform_agent_enums import PlatformAgentState
 from ion.agents.platform.rsn.rsn_platform_driver import RSNPlatformDriverEvent
 
+from ion.core.includes.mi import DriverEvent
+
 from interface.objects import AgentCommand
 from interface.objects import AgentCapability
 from interface.objects import CapabilityType
@@ -539,7 +541,6 @@ class MissionScheduler(object):
         @param agent_client         Instrument/platform agent client
         @param cmd                  Mission command to be parsed
         """
-        from mi.core.instrument.instrument_driver import DriverEvent
 
         method = cmd['method']
         command = cmd['command']
@@ -717,7 +718,6 @@ class MissionScheduler(object):
         Run an event driven mission
         @param mission      Mission dictionary
         """
-        from mi.core.instrument.instrument_driver import DriverEvent
 
         self.max_attempts = mission['error_handling']['maxRetries']
         self.default_error = mission['error_handling']['default']
@@ -967,7 +967,6 @@ class MissionScheduler(object):
         """
         Check state, stop streaming if necessary and get into command state
         """
-        from mi.core.instrument.instrument_driver import DriverEvent
 
         state = agent_client.get_agent_state()
         while state != ResourceAgentState.COMMAND:

--- a/ion/agents/platform/test/mission_RSN_simulator0C.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator0C.yml
@@ -14,7 +14,7 @@ platform:
   platformID: LJ01D
 
 mission:
-  - instrument:
+  - missionThread:
     instrumentID: [SBE37_SIM_02]
     errorHandling:
       default: retry
@@ -29,11 +29,11 @@ mission:
         parentID: 
         eventID: 
     preMissionSequence:
+      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
+        onError: retry
       - command: SBE37_SIM_02, set_resource(INTERVAL{3})
         onError: retry
     missionSequence:
-      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
-        onError: retry
       - command: wait(1)
         onError:
       - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)

--- a/ion/agents/platform/test/mission_RSN_simulator0S.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator0S.yml
@@ -14,7 +14,7 @@ platform:
   platformID: LJ01D
 
 mission:
-  - instrument:
+  - missionThread:
     instrumentID: [SBE37_SIM_02]
     errorHandling:
       default: retry

--- a/ion/agents/platform/test/test_mission_manager.py
+++ b/ion/agents/platform/test/test_mission_manager.py
@@ -146,10 +146,15 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
         self._set_mission(generated_filename)
         self._run_mission()
 
-        self._assert_state(mission_state)
-
-        # not restricting with max_wait for the moment
-        self._await_mission_completion(mission_state)
+        state = self._get_state()
+        if state == mission_state:
+            # ok, this is the general expected behaviour here as typical
+            # mission plans should at least take several seconds to complete;
+            # now wait until mission is completed:
+            # (note: not restricting with max_wait for the moment)
+            self._await_mission_completion(mission_state)
+        # else: mission completed/failed very quickly; we should be
+        # back in the base state, as verified below in general.
 
         # verify we are back to the base_state:
         self._assert_state(base_state)


### PR DESCRIPTION
Some adjustments including a fix for test_simple_mission_command_state.

@edwardhunter please review/merge
@bobfrat please review.

Note: it includes a change in mission_executive to import DriverEvent from ion.core.includes.mi (which seems to be the module to use according to its occurrence in several other source files in coi-services).
