### PR TITLE
CIDEVSTC-84	 Implement notification delivery by rule

### DIFF
--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -2144,9 +2144,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         dp_obj = IonObject(RT.DataProduct,
             name='DP1',
-            description='some new dp',
-            temporal_domain = tdom,
-            spatial_domain = sdom)
+            description='some new dp')
 
         data_product_id = data_product_management.create_data_product(data_product=dp_obj, stream_definition_id=streamdef_id)
 
@@ -2295,9 +2293,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         dp_obj = IonObject(RT.DataProduct,
             name='DP1',
-            description='some new dp',
-            temporal_domain = tdom,
-            spatial_domain = sdom)
+            description='some new dp')
 
         data_product_id = data_product_management.create_data_product(data_product=dp_obj, stream_definition_id=streamdef_id)
 
@@ -2515,9 +2511,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         dp_obj = IonObject(RT.DataProduct,
             name='DP1',
-            description='some new dp',
-            temporal_domain = tdom,
-            spatial_domain = sdom)
+            description='some new dp')
 
         data_product_id = data_product_management.create_data_product(data_product=dp_obj, stream_definition_id=streamdef_id)
 

--- a/ion/services/dm/presentation/test/user_notification_test.py
+++ b/ion/services/dm/presentation/test/user_notification_test.py
@@ -18,13 +18,14 @@ from sets import Set
 from pyon.util.int_test import IonIntegrationTestCase
 from pyon.util.unit_test import PyonTestCase
 from pyon.util.containers import DotDict, get_ion_ts
-from pyon.public import IonObject, RT, OT, PRED, Container
+from pyon.public import IonObject, RT, OT, PRED, LCS, Container
 from pyon.core.exception import NotFound, BadRequest
 from pyon.core.bootstrap import get_sys_name, CFG
 from pyon.util.context import LocalContextMixin
 from pyon.util.log import log
 from pyon.util.poller import poll
 from pyon.event.event import EventPublisher, EventSubscriber
+#from pyon.util.containers import get_ion_ts_millis
 
 from ion.services.dm.utility.granule_utils import time_series_domain
 from ion.services.dm.presentation.user_notification_service import UserNotificationService
@@ -38,10 +39,13 @@ from interface.services.dm.ipubsub_management_service import PubsubManagementSer
 from interface.services.dm.idataset_management_service import DatasetManagementServiceClient
 from interface.services.dm.idiscovery_service import DiscoveryServiceClient
 from interface.services.sa.idata_product_management_service import DataProductManagementServiceClient
-from interface.objects import UserInfo, DeliveryConfig, ComputedListValue, ComputedValueAvailability
+from interface.services.sa.iinstrument_management_service import InstrumentManagementServiceClient
+from interface.services.sa.iobservatory_management_service import ObservatoryManagementServiceClient
+from interface.objects import UserInfo, DeliveryConfiguration, ComputedListValue, ComputedValueAvailability
 from interface.objects import DeviceEvent, NotificationPreferences, NotificationDeliveryModeEnum
 from interface.services.cei.ischeduler_service import SchedulerServiceProcessClient
 from interface.objects import NotificationRequest, TemporalBounds, DeviceStatusType, AggregateStatusType
+from interface.objects import DeliveryModeEnum, NotificationFrequencyEnum, NotificationTypeEnum
 from ion.services.dm.utility.uns_utility_methods import setting_up_smtp_client
 
 
@@ -352,6 +356,8 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         self.rrc = ResourceRegistryServiceClient()
         self.imc = IdentityManagementServiceClient()
         self.discovery = DiscoveryServiceClient()
+        self.ims = InstrumentManagementServiceClient()
+        self.oms = ObservatoryManagementServiceClient()
 
         self.event = Event()
         self.number_event_published = 0
@@ -838,9 +844,6 @@ class UserNotificationIntTest(IonIntegrationTestCase):
     def test_process_batch(self):
         # Test that the process_batch() method works
 
-        test_start_time = get_ion_ts() # Note this time is in milliseconds
-        test_end_time = str(int(get_ion_ts()) + 10000) # Adding 10 seconds
-
         #--------------------------------------------------------------------------------------
         # Publish events corresponding to the notification requests just made
         # These events will get stored in the event repository allowing UNS to batch process
@@ -859,9 +862,10 @@ class UserNotificationIntTest(IonIntegrationTestCase):
                 event_type=OT.ResourceLifecycleEvent)
 
             event_publisher.publish_event(
-                origin="instrument_3",
-                origin_type="type_3",
-                event_type=OT.ResourceLifecycleEvent)
+                origin="instrument_2",
+                origin_type="type_2",
+                event_type=OT.DetectionEvent)
+            gevent.sleep(3)
 
         #----------------------------------------------------------------------------------------
         # Create users and get the user_ids
@@ -922,46 +926,63 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         # Make notification request objects -- Remember to put names
         #--------------------------------------------------------------------------------------
 
-        notification_request_correct = NotificationRequest(   name = "notification_1",
+
+        delivery_config1a = IonObject(OT.DeliveryConfiguration, email='user_1@gmail.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
+        delivery_config1b = IonObject(OT.DeliveryConfiguration, email='user_1@yahoo.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
+        notification_request_1 = NotificationRequest(   name = "notification_1",
             origin="instrument_1",
             origin_type="type_1",
-            event_type=OT.ResourceLifecycleEvent)
+            event_type=OT.ResourceLifecycleEvent,
+            delivery_configurations=[delivery_config1a, delivery_config1b])
 
+        delivery_config2a = IonObject(OT.DeliveryConfiguration, email='user_2@gmail.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
+        delivery_config2b = IonObject(OT.DeliveryConfiguration, email='user_2@yahoo.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
         notification_request_2 = NotificationRequest(   name = "notification_2",
             origin="instrument_2",
             origin_type="type_2",
-            event_type=OT.DetectionEvent)
+            event_type=OT.DetectionEvent,
+            delivery_configurations=[delivery_config2a, delivery_config2b])
 
-
+        delivery_config3 = IonObject(OT.DeliveryConfiguration, email='user_3@gmail.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
         notification_request_3 = NotificationRequest(   name = "notification_3",
-            origin="instrument_3",
-            origin_type="type_3",
-            event_type=OT.ResourceLifecycleEvent)
+            origin="*",
+            event_type=OT.DetectionEvent,
+            delivery_configurations=[delivery_config3])
 
+        delivery_config4 = IonObject(OT.DeliveryConfiguration, email='user_4@gmail.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
+        notification_request_4 = NotificationRequest(   name = "notification_4",
+            origin="*",
+            origin_type="type_2",
+            event_type='',
+            delivery_configurations=[delivery_config4])
+        deliver_emails = ['user_1@gmail.com', 'user_1@yahoo.com', 'user_2@gmail.com', 'user_2@yahoo.com', 'user_3@gmail.com', 'user_4@gmail.com']
 
 
         #--------------------------------------------------------------------------------------
         # Create a notification using UNS. This should cause the user_info to be updated
         #--------------------------------------------------------------------------------------
 
-        self.unsc.create_notification(notification=notification_request_correct, user_id=user_id_1)
-        self.unsc.create_notification(notification=notification_request_2, user_id=user_id_1)
-
+        self.unsc.create_notification(notification=notification_request_1, user_id=user_id_1)
         self.unsc.create_notification(notification=notification_request_2, user_id=user_id_2)
 
-        self.unsc.create_notification(notification=notification_request_2, user_id=user_id_3)
+        #self.unsc.create_notification(notification=notification_request_2, user_id=user_id_2)
+        #
+        #self.unsc.create_notification(notification=notification_request_2, user_id=user_id_3)
         self.unsc.create_notification(notification=notification_request_3, user_id=user_id_3)
-
-        self.unsc.create_notification(notification=notification_request_correct, user_id=user_id_4)
-        self.unsc.create_notification(notification=notification_request_3, user_id=user_id_4)
-
-        self.unsc.create_notification(notification=notification_request_correct, user_id=user_id_5)
-        self.unsc.create_notification(notification=notification_request_3, user_id=user_id_5)
+        #
+        #self.unsc.create_notification(notification=notification_request_correct, user_id=user_id_4)
+        self.unsc.create_notification(notification=notification_request_4, user_id=user_id_4)
+        #
+        #self.unsc.create_notification(notification=notification_request_correct, user_id=user_id_5)
+        #self.unsc.create_notification(notification=notification_request_3, user_id=user_id_5)
 
         #--------------------------------------------------------------------------------------
         # Do a process_batch() in order to start the batch notifications machinery
         #--------------------------------------------------------------------------------------
-
+        #use a 10 second range from current time
+        current_timestamp = int(time.time() * 1000)
+        test_start_time = str( current_timestamp - 5000 )
+        test_end_time = str( current_timestamp + 5000)
         self.unsc.process_batch(start_time=test_start_time, end_time= test_end_time)
 
         #--------------------------------------------------------------------------------------
@@ -975,15 +996,15 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         while not proc1.smtp_client.sent_mail.empty():
             email_tuple = proc1.smtp_client.sent_mail.get(timeout=10)
+            log.debug('test_process_batch  email_tuple: %s', email_tuple)
             email_list.append(email_tuple)
 
-        self.assertEquals(len(email_list), 1)
 
         for email_tuple in email_list:
             msg_sender, msg_recipient, msg = email_tuple
 
             self.assertEquals(msg_sender, CFG.get_safe('server.smtp.sender') )
-            self.assertTrue(msg_recipient in ['user_1@gmail.com', 'user_2@gmail.com', 'user_3@gmail.com'])
+            self.assertTrue(msg_recipient in deliver_emails)
 
             lines = msg.split("\r\n")
 
@@ -1002,9 +1023,195 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
             self.assertIsNotNone(event_time)
 
-#            # Check that the events sent in the email had times within the user specified range
-#            self.assertTrue(event_time >= test_start_time)
-#            self.assertTrue(event_time <= test_end_time)
+
+
+    def test_aggregate_notifications_batch(self):
+        # Test that the process_batch() method works
+
+        #----------------------------------------------------------------------------------------
+        # Create org, sites and devices
+        #----------------------------------------------------------------------------------------
+
+
+        org_obj = IonObject(RT.Org,
+                            name='TestOrg',
+                            description='some new mf org')
+
+        org_id =  self.oms.create_marine_facility(org_obj)
+
+
+
+        platform_site__obj = IonObject(RT.PlatformSite,
+                                        name='PlatformSite1',
+                                        description='test platform site')
+        platform_site_id = self.oms.create_platform_site(platform_site__obj)
+
+        platform_device__obj = IonObject(RT.PlatformDevice,
+                                        name='PlatformDevice1',
+                                        description='test platform device')
+        platform_device_id = self.ims.create_platform_device(platform_device__obj)
+
+
+        instrument_site_obj = IonObject(RT.InstrumentSite,
+                                        name='InstrumentSite1',
+                                        description='test instrument site',
+                                        reference_designator='GA01SUMO-FI003-01-CTDMO0999')
+        instrument_site_id = self.oms.create_instrument_site(instrument_site_obj, platform_site_id)
+
+        instrument_device_obj = IonObject(RT.InstrumentDevice,
+                                        name='InstrumentDevice1',
+                                        description='test instrument device')
+        instrument_device_id = self.ims.create_instrument_device(instrument_device_obj)
+        self.rrc.create_association(platform_device_id, PRED.hasDevice, instrument_device_id)
+
+
+        self.oms.assign_resource_to_observatory_org(resource_id=platform_site_id, org_id=org_id)
+        self.oms.assign_resource_to_observatory_org(resource_id=platform_device_id, org_id=org_id)
+        self.oms.assign_resource_to_observatory_org(resource_id=instrument_site_id, org_id=org_id)
+        self.oms.assign_resource_to_observatory_org(resource_id=instrument_device_id, org_id=org_id)
+
+
+        #--------------------------------------------------------------------------------------
+        # Publish events corresponding to the notification requests just made
+        # These events will get stored in the event repository allowing UNS to batch process
+        # them later for batch notifications
+        #--------------------------------------------------------------------------------------
+
+        event_publisher = EventPublisher()
+
+        # this part of code is in the beginning to allow enough time for the events_index creation
+
+        for i in xrange(10):
+
+            event_publisher.publish_event(
+                origin=instrument_device_id,
+                origin_type="InstrumentDevice",
+                event_type=OT.DeviceStatusEvent)
+
+            event_publisher.publish_event(
+                origin=instrument_site_id,
+                origin_type="InstrumentSite",
+                event_type=OT.ResourceLifecycleEvent)
+
+        gevent.sleep(3)
+
+        #----------------------------------------------------------------------------------------
+        # Create users and get the user_ids
+        #----------------------------------------------------------------------------------------
+
+        # user_1  -- default notification preferences  - notifications_disabled and notifications_daily_digest are False
+        user_1 = UserInfo()
+        user_1.name = 'user_1'
+        user_1.contact.email = 'user_1@hotmail.com'
+        user_1.variables.extend( [  {'name' : 'notifications_disabled', 'value' : False},
+                                 {'name' : 'notifications_daily_digest', 'value' : True}  ] )
+
+
+        # this part of code is in the beginning to allow enough time for the users_index creation
+
+        user_id_1, _ = self.rrc.create(user_1)
+
+
+        #--------------------------------------------------------------------------------------
+        # Grab the UNS process
+        #--------------------------------------------------------------------------------------
+
+        proc1 = self.container.proc_manager.procs_by_name['user_notification']
+
+        #--------------------------------------------------------------------------------------
+        # Make notification request objects -- Remember to put names
+        #--------------------------------------------------------------------------------------
+
+
+        delivery_config1a = IonObject(OT.DeliveryConfiguration, email='user_1@gmail.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
+        notification_request_1 = NotificationRequest(   name = "device_notification",
+            type=NotificationTypeEnum.PLATFORM,
+            origin=platform_device_id,
+            origin_type="PlatformDevice",
+            event_type=OT.DeviceStatusEvent,
+            delivery_configurations=[delivery_config1a])
+
+
+        delivery_config1b = IonObject(OT.DeliveryConfiguration, email='user_1@yahoo.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
+        notification_request_2 = NotificationRequest(   name = "site_notification",
+            type=NotificationTypeEnum.SITE,
+            origin=platform_site_id,
+            origin_type="PlatformSite",
+            event_type=OT.ResourceLifecycleEvent,
+            delivery_configurations=[delivery_config1b])
+
+
+        delivery_config1c = IonObject(OT.DeliveryConfiguration, email='', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
+        notification_request_3 = NotificationRequest(   name = "facility_notification",
+            type=NotificationTypeEnum.FACILITY,
+            origin=org_id,
+            origin_type="Org",
+            event_type="",
+            delivery_configurations=[delivery_config1c])
+
+        deliver_emails = ['user_1@gmail.com', 'user_1@yahoo.com', 'user_1@hotmail.com']
+
+
+        #--------------------------------------------------------------------------------------
+        # Create a notification using UNS. This should cause the user_info to be updated
+        #--------------------------------------------------------------------------------------
+
+        self.unsc.create_notification(notification=notification_request_1, user_id=user_id_1)
+        self.unsc.create_notification(notification=notification_request_2, user_id=user_id_1)
+        self.unsc.create_notification(notification=notification_request_3, user_id=user_id_1)
+
+        #--------------------------------------------------------------------------------------
+        # Do a process_batch() in order to start the batch notifications machinery
+        #--------------------------------------------------------------------------------------
+        #use a 10 second range from current time
+        current_timestamp = int(time.time() * 1000)
+        test_start_time = str( current_timestamp - 10000 )
+        test_end_time = str( current_timestamp + 10000)
+        self.unsc.process_batch(start_time=test_start_time, end_time= test_end_time)
+
+        #--------------------------------------------------------------------------------------
+        # Check that the emails were sent to the users. This is done using the fake smtp client
+        # Make assertions....
+        #--------------------------------------------------------------------------------------
+
+        self.assertFalse(proc1.smtp_client.sent_mail.empty())
+
+        email_list = []
+
+        while not proc1.smtp_client.sent_mail.empty():
+            email_tuple = proc1.smtp_client.sent_mail.get(timeout=10)
+            log.debug('test_process_batch  email_tuple: %s', email_tuple)
+            email_list.append(email_tuple)
+
+
+        for email_tuple in email_list:
+            msg_sender, msg_recipient, msg = email_tuple
+
+            self.assertEquals(msg_sender, CFG.get_safe('server.smtp.sender') )
+            self.assertTrue(msg_recipient in deliver_emails)
+
+            lines = msg.split("\r\n")
+
+            maps = []
+
+            for line in lines:
+
+                maps.extend(line.split(','))
+
+            log.debug('test_aggregate_notifications_batch  maps: %s', maps)
+            event_time = ''
+            for map in maps:
+                fields = map.split(":")
+                if fields[0].find("Date & Time:") > -1:
+                    event_time = fields[1].strip(" ")
+                    log.debug('test_aggregate_notifications_batch  event_time: %s', event_time)
+                    break
+
+            self.assertIsNotNone(event_time)
+
+
+
+
 
 
     def test_worker_send_email(self):
@@ -1362,6 +1569,7 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         notific_2 = self.rrc.read(notification_id2)
         # This checks that the notifications have been retired.
         self.assertNotEquals(notific_2.temporal_bounds.end_datetime, '')
+        self.assertEquals(notific_2.lcstate, LCS.RETIRED)
 
         # Now check the user info object has the notifications
         user = self.rrc.read(user_id)
@@ -1384,7 +1592,10 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------------
         self.unsc.delete_notification(notification_id1)
         notific_1 = self.rrc.read(notification_id1)
+        log.debug('test_delete_user_notifications notific_1:  %s ', notific_1)
         self.assertNotEquals(notific_1.temporal_bounds.end_datetime, '')
+        self.assertEquals(notific_1.lcstate, LCS.RETIRED)
+
 
         # Now check the user info object has the notifications
         user = self.rrc.read(user_id)
@@ -1629,27 +1840,22 @@ class UserNotificationIntTest(IonIntegrationTestCase):
 
         def publish_events():
             for i in xrange(3):
-                t = get_ion_ts()
 
-                event_publisher.publish_event( ts_created= t ,
+                event_publisher.publish_event(
                     origin="instrument_1",
                     origin_type="type_1",
                     event_type=OT.ResourceLifecycleEvent)
 
-                event_publisher.publish_event( ts_created= t ,
+                event_publisher.publish_event(
                     origin="instrument_2",
                     origin_type="type_2",
                     event_type=OT.ResourceLifecycleEvent)
 
-                times_of_events_published.add(t)
                 self.number_event_published += 2
                 self.event.set()
-                #            time.sleep(1)
-                log.debug("Published events of origins = instrument_1, instrument_2 with ts_created: %s" % t)
 
         publish_events()
 
-        self.assertTrue(self.event.wait(10))
         #----------------------------------------------------------------------------------------
         # Create users and get the user_ids
         #----------------------------------------------------------------------------------------
@@ -1668,16 +1874,24 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------------
         # Make notification request objects -- Remember to put names
         #--------------------------------------------------------------------------------------
-
+        delivery_config1a = IonObject(OT.DeliveryConfiguration, email='user_1@gmail.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
         notification_request_correct = NotificationRequest(   name = "notification_1",
+            type=NotificationTypeEnum.SIMPLE,
             origin="instrument_1",
             origin_type="type_1",
-            event_type=OT.ResourceLifecycleEvent)
+            event_type=OT.ResourceLifecycleEvent,
+            delivery_configurations=[delivery_config1a])
 
+        delivery_config1b = IonObject(OT.DeliveryConfiguration, email='user_1@yahoo.com', mode=DeliveryModeEnum.UNFILTERED, frequency=NotificationFrequencyEnum.BATCH)
         notification_request_2 = NotificationRequest(   name = "notification_2",
+            type=NotificationTypeEnum.SIMPLE,
             origin="instrument_2",
             origin_type="type_2",
-            event_type=OT.ResourceLifecycleEvent)
+            event_type=OT.ResourceLifecycleEvent,
+            delivery_configurations=[delivery_config1b])
+
+        deliver_emails = ["user_1@gmail.com", "user_1@yahoo.com"]
+
 
         #--------------------------------------------------------------------------------------
         # Create a notification using UNS. This should cause the user_info to be updated
@@ -1692,8 +1906,8 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------
 
         # Set up a time for the scheduler to trigger timer events
-        # Trigger the timer event 15 seconds later from now
-        time_now = datetime.utcnow() + timedelta(seconds=15)
+        # Trigger the timer event 3 seconds later from now
+        time_now = datetime.utcnow() + timedelta(seconds=3)
         times_of_day =[{'hour': str(time_now.hour),'minute' : str(time_now.minute), 'second':str(time_now.second) }]
 
         sid = self.ssclient.create_time_of_day_timer(   times_of_day=times_of_day,
@@ -1718,38 +1932,48 @@ class UserNotificationIntTest(IonIntegrationTestCase):
         #--------------------------------------------------------------------------------
         # Assert that emails were sent
         #--------------------------------------------------------------------------------
+        # wait for the timer to go off.
+        gevent.sleep(6)
+        proc1 = self.container.proc_manager.procs_by_name['user_notification']
 
-        proc = self.container.proc_manager.procs_by_name['user_notification']
 
-        ar_1 = gevent.event.AsyncResult()
-        ar_2 = gevent.event.AsyncResult()
 
-        def send_email(events_for_message, user_id, *args, **kwargs):
-            log.warning("(in asyncresult) events_for_message: %s" % events_for_message)
-            ar_1.set(events_for_message)
-            ar_2.set(user_id)
+        email_list = []
+        while not proc1.smtp_client.sent_mail.empty():
+            email_tuple = proc1.smtp_client.sent_mail.get(timeout=10)
+            log.debug('test_process_batch  email_tuple: %s', email_tuple)
+            email_list.append(email_tuple)
 
-        proc.format_and_send_email = send_email
 
-        events_for_message = ar_1.get(timeout=20)
-        user_id = ar_2.get(timeout=20)
+        for email_tuple in email_list:
+            msg_sender, msg_recipient, msg = email_tuple
 
-        log.warning("user_id: %s" % user_id)
+            self.assertEquals(msg_sender, CFG.get_safe('server.smtp.sender') )
+            self.assertTrue(msg_recipient in deliver_emails)
 
-        origins_of_events = Set()
-        times = Set()
+            lines = msg.split("\r\n")
 
-        for event in events_for_message:
-            origins_of_events.add(event.origin)
-            times.add(event.ts_created)
+            maps = []
+
+            for line in lines:
+                maps.extend(line.split(','))
+
+            event_time = ''
+            for map in maps:
+                fields = map.split(":")
+                log.debug('test_aggregate_notifications_batch  fields: %s', fields)
+                if fields[0].find("Date & Time") > -1:
+                    event_time = fields[1].strip(" ")
+                    self.assertIsNotNone(event_time)
+                    log.debug('test_aggregate_notifications_batch  event_time: %s', event_time)
+
 
         #--------------------------------------------------------------------------------
         # Make assertions on the events mentioned in the formatted email
         #--------------------------------------------------------------------------------
 
-        self.assertEquals(len(events_for_message), self.number_event_published)
-        self.assertEquals(times, times_of_events_published)
-        self.assertEquals(origins_of_events, Set(['instrument_1', 'instrument_2']))
+        self.assertEquals(len(email_list), len(deliver_emails))
+        #self.assertEquals(origins_of_events, Set(['instrument_1', 'instrument_2']))
 
     def test_get_user_notifications(self):
         # Test that the get_user_notifications() method returns the notifications for a user

--- a/ion/services/dm/utility/uns_utility_methods.py
+++ b/ion/services/dm/utility/uns_utility_methods.py
@@ -195,6 +195,10 @@ def _collect_resources_from_event_origins(events=None, rr_client=None):
 
 def _get_notification_name(event_id='', notifications_map=None):
     notification_names = ''
+
+    if not notifications_map:
+        return notification_names
+
     names_list = set()
     if event_id in notifications_map:
         for notification_obj in notifications_map[event_id]:
@@ -226,7 +230,7 @@ def send_email(event, msg_recipient, smtp_client, rr_client):
     ION_NOTIFICATION_EMAIL_ADDRESS = 'data_alerts@oceanobservatories.org'
     smtp_sender = CFG.get_safe('server.smtp.sender', ION_NOTIFICATION_EMAIL_ADDRESS)
 
-    msg = convert_events_to_email_message([event], rr_client)
+    msg = convert_events_to_email_message(events=[event], notifications_map=None, rr_client=rr_client)
     msg['From'] = smtp_sender
     msg['To'] = msg_recipient
     log.debug("UNS sending email from %s to %s for event type: %s", smtp_sender,msg_recipient, event.type_)


### PR DESCRIPTION
Implement batch processing for UNS to meet R3 scope. Aligns with updated notifications.yml.
- supports multiple delivery configurations per NR
- adds NR name to event summary in email
- supports notification types: simple, platform, site and facility using outil
- batch processing does not support digest DeliveryMode 

this PR will NOT pass buildbot until the new notifications.yml is merged:
https://github.com/ooici/ion-definitions/pull/564

@mmeisinger please review
@brianmckenna please review
@seman  please review
