### PR TITLE
fix OOIION-1863

### DIFF
--- a/ion/services/dm/test/test_instrument_integration.py
+++ b/ion/services/dm/test/test_instrument_integration.py
@@ -29,6 +29,8 @@ from ion.agents.instrument.test.load_test_driver_egg import load_egg
 load_egg()
 
 
+from mock import patch
+@patch.dict(CFG, {'endpoint': {'receive': {'timeout': 120}}})
 @attr('INT', group='dm')
 class TestInstrumentIntegration(DMTestCase):
 


### PR DESCRIPTION
increase timeout in TestInstrumentIntegration to try to avoid the corresponding failure at the of the test in stop_instrument_agent_instance (which happens sometimes)

@edwardhunter please review
