### PR TITLE
M101: pass mission plan arguments directly to PA mission commands

### DIFF
--- a/ion/agents/platform/mission_manager.py
+++ b/ion/agents/platform/mission_manager.py
@@ -16,6 +16,7 @@ from pyon.public import log
 
 from ion.agents.mission_executive import MissionLoader
 from ion.agents.mission_executive import MissionScheduler
+from pyon.core.exception import BadRequest
 
 
 class MissionManager(object):
@@ -31,32 +32,83 @@ class MissionManager(object):
         self._agent = pa
         self._platform_id = pa._platform_id
 
-        self._agent.aparam_mission = None
-        self._mission_entries = None
-        self._mission_scheduler = None
+        # mission_id -> MissionScheduler mapping:
+        self._running_missions = {}
 
-        self._agent.aparam_set_mission = self.aparam_set_mission
+    def get_number_of_running_missions(self):
+        return len(self._running_missions)
 
-    # TODO confirm appropriate mechanism to indicate mission to the agent
-    def aparam_set_mission(self, yaml_filename):
+    # TODO perhaps we need some additional error handling below besides the
+    # relevant event notifications done by mission executive.
+
+    def run_mission(self, mission_id, mission_yml):
         """
-        Specifies mission to be executed.
-        @param yaml_filename  Mission definition filename; can be None.
+        Runs a mission returning to caller when the execution is completed.
+
+        @param mission_id
+        @param mission_yml
         """
-        log.debug('[mm] aparam_set_mission: yaml_filename=%s', yaml_filename)
 
-        self._agent.aparam_mission = yaml_filename
+        if mission_id in self._running_missions:
+            raise BadRequest('run_mission: mission_id=%r is already running', mission_id)
 
-        if self._agent.aparam_mission is None:
-            self._mission_entries = None
-            self._mission_scheduler = None
-            return
+        mission_scheduler = self._create_mission_scheduler(mission_id, mission_yml)
+        self._running_missions[mission_id] = mission_scheduler
+        try:
+            mission_scheduler.run_mission()
+        except Exception as ex:
+            log.exception('[mm] run_mission mission_id=%r', mission_id)
+        finally:
+            del self._running_missions[mission_id]
+
+    def abort_mission(self, mission_id):
+        if mission_id not in self._running_missions:
+            raise BadRequest('abort_mission: invalid mission_id=%r', mission_id)
+
+        mission_scheduler = self._running_missions[mission_id]
+        try:
+            mission_scheduler.abort_mission()
+            return None
+        except Exception as ex:
+            log.exception('[mm] abort_mission')
+            return ex
+        finally:
+            del self._running_missions[mission_id]
+
+    def kill_mission(self, mission_id):
+        if mission_id not in self._running_missions:
+            raise BadRequest('kill_mission: invalid mission_id=%r', mission_id)
+
+        mission_scheduler = self._running_missions[mission_id]
+        try:
+            mission_scheduler.kill_mission()
+            return None
+        except Exception as ex:
+            log.exception('[mm] kill_mission')
+            return ex
+        finally:
+            del self._running_missions[mission_id]
+
+    ############
+    # private
+    ############
+
+    def _create_mission_scheduler(self, mission_id, mission_yml):
+        """
+        @param mission_id
+        @param mission_yml
+        """
+        log.debug('[mm] _create_mission_scheduler: mission_id=%r', mission_id)
 
         mission_loader = MissionLoader(self._agent)
-        mission_loader.load_mission_file(yaml_filename)
+
+        # TODO: for the moment passing the filename still while load_mission is implemented
+        mission_loader.load_mission_file(mission_yml)
+        # mission_loader.load_mission(mission_id, mission_yml)
+
         self._mission_entries = mission_loader.mission_entries
 
-        log.debug('[mm] aparam_set_mission: _ia_clients=\n%s',
+        log.debug('[mm] _create_mission_scheduler: _ia_clients=\n%s',
                   self._agent._pp.pformat(self._agent._ia_clients))
 
         # get instrument IDs and clients for the valid running instruments:
@@ -65,49 +117,14 @@ class MissionManager(object):
             if isinstance(obj, dict):
                 # it's valid instrument.
                 if instrument_id != obj.resource_id:
-                    log.error('[mm] aparam_set_mission: instrument_id=%s, '
+                    log.error('[mm] _create_mission_scheduler: instrument_id=%s, '
                               'resource_id=%s', instrument_id, obj.resource_id)
 
                 instruments[obj.resource_id] = obj.ia_client
 
-        self._mission_scheduler = MissionScheduler(self._agent,
-                                                   instruments,
-                                                   self._mission_entries)
-        log.debug('[mm] aparam_set_mission: MissionScheduler created. entries=%s',
+        mission_scheduler = MissionScheduler(self._agent,
+                                             instruments,
+                                             self._mission_entries)
+        log.debug('[mm] _create_mission_scheduler: MissionScheduler created. entries=%s',
                   self._mission_entries)
-
-    # TODO appropriate way to handle potential errors/exceptions in
-    # methods below.  Very ad hoc for the moment.
-
-    def run_mission(self):
-        if self._mission_scheduler is not None:
-            try:
-                self._mission_scheduler.run_mission()
-                return None
-            except Exception as ex:
-                log.exception('[mm] run_mission')
-                return ex
-        else:
-            log.error('[mm] run_mission: no mission given')
-
-    def abort_mission(self):
-        if self._mission_scheduler is not None:
-            try:
-                self._mission_scheduler.abort_mission()
-                return None
-            except Exception as ex:
-                log.exception('[mm] abort_mission')
-                return ex
-        else:
-            log.error('[mm] abort_mission: no mission given')
-
-    def kill_mission(self):
-        if self._mission_scheduler is not None:
-            try:
-                self._mission_scheduler.kill_mission()
-                return None
-            except Exception as ex:
-                log.exception('[mm] kill_mission')
-                return ex
-        else:
-            log.error('[mm] kill_mission: no mission given')
+        return mission_scheduler

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -45,8 +45,8 @@ from ion.core.includes.mi import DriverEvent
 
 from pyon.util.containers import DotDict
 
-from pyon.agent.common import BaseEnum
 from pyon.agent.instrument_fsm import FSMStateError
+from pyon.agent.instrument_fsm import FSMError
 
 from ion.agents.platform.launcher import Launcher
 
@@ -192,12 +192,6 @@ class PlatformAgent(ResourceAgent):
 
         # MissionManager created on_start:
         self._mission_manager = None
-
-        # currently loaded mission
-        self.aparam_mission = None
-
-        # method set by MissionManager
-        self.aparam_set_mission = None
 
         # state to return to after mission termination
         self._pre_mission_state = None
@@ -3531,46 +3525,65 @@ class PlatformAgent(ResourceAgent):
     # mission related handlers
     ##############################################################
 
-    def _run_mission(self):
+    def _run_mission(self, mission_id, mission_yml):
         """
-        Method launched in a separate greenlet to run the mission, at the end
-        of which EXIT_MISSION is triggered to return to saved state.
+        Method launched in a separate greenlet to run a mission, at the end
+        of which, if no remaining missions are executing, EXIT_MISSION is
+        triggered to return to saved state.
         """
         time_start = time.time()
-        log.debug('_run_mission: running...')
-        self._mission_manager.run_mission()
+        log.debug('[mm] _run_mission: running mission_id=%r ...', mission_id)
+        self._mission_manager.run_mission(mission_id, mission_yml)
 
         elapsed_time = time.time() - time_start
-        log.debug('_run_mission: completed. elapsed_time=%s', elapsed_time)
+        log.debug('[mm] _run_mission: completed mission_id=%s. elapsed_time=%s',
+                  mission_id, elapsed_time)
 
-        # check state before attempting the EXIT_MISSION.
-        # (but we could still have a "check-then-act" race condition here)
-        curr_state = self.get_agent_state()
-        if curr_state in [PlatformAgentState.MISSION_COMMAND,
-                          PlatformAgentState.MISSION_STREAMING]:
-            log.debug('_run_mission: triggering EXIT_MISSION')
-            self._fsm.on_event(PlatformAgentEvent.EXIT_MISSION)
-        else:
-            log.warn('_run_mission: not triggering EXIT_MISSION: FSM not in '
-                     'mission substate (%s)', curr_state)
+        remaining = self._mission_manager.get_number_of_running_missions()
+        if remaining == 0:
+            # check state before attempting the EXIT_MISSION.
+            # (but we could still have a "check-then-act" race condition here)
+            curr_state = self.get_agent_state()
+            if curr_state in [PlatformAgentState.MISSION_COMMAND,
+                              PlatformAgentState.MISSION_STREAMING]:
+                log.debug('[mm] _run_mission: triggering EXIT_MISSION')
+                self._fsm.on_event(PlatformAgentEvent.EXIT_MISSION)
+            else:
+                log.warn('[mm] _run_mission: not triggering EXIT_MISSION: FSM not in '
+                         'mission substate (%s)', curr_state)
 
     def _handler_mission_run(self, *args, **kwargs):
         """
-        Saves current state to return to upon mission termination.
-        Starts the mission execution in a separate thread.
-        Transitions to the appropriate mission substate.
+        In a separate thread, starts the execution of the mission indicated
+        with the kwargs 'mission_id' and 'mission_yml'.
+        If not already in a mission state, it saves current state to return to
+        upon all mission executions are completed, and transitions to the
+        appropriate mission substate.
         """
         if log.isEnabledFor(logging.TRACE):  # pragma: no cover
             log.trace("%r/%s args=%s kwargs=%s",
                       self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        curr_state = self.get_agent_state()
-        next_state = PlatformAgentState.MISSION_COMMAND if curr_state == \
-            PlatformAgentState.COMMAND else PlatformAgentState.MISSION_STREAMING
+        mission_id = kwargs.get('mission_id', None)
+        if mission_id is None:
+            raise FSMError('mission_run: missing mission_id argument')
+        mission_yml = kwargs.get('mission_yml', None)
+        if mission_yml is None:
+            raise FSMError('mission_run: missing mission_yml argument')
 
-        self._pre_mission_state = curr_state
-        self._mission_greenlet = spawn(self._run_mission)
-        log.info("%r: started mission execution", self._platform_id)
+        curr_state = self.get_agent_state()
+        if curr_state in [PlatformAgentState.COMMAND, PlatformAgentState.MISSION_STREAMING]:
+            # save state to return to when all mission executions are completed
+            self._pre_mission_state = curr_state
+
+            next_state = PlatformAgentState.MISSION_COMMAND if curr_state == \
+                PlatformAgentState.COMMAND else PlatformAgentState.MISSION_STREAMING
+        else:
+            # just stay in the current state:
+            next_state = None
+
+        self._mission_greenlet = spawn(self._run_mission, mission_id, mission_yml)
+        log.info("%r: started mission execution, mission_id=%r", self._platform_id, mission_id)
 
         result = None
         return next_state, result
@@ -3591,39 +3604,49 @@ class PlatformAgent(ResourceAgent):
 
     def _handler_mission_abort(self, *args, **kwargs):
         """
-        Aborts the ongoing mission execution. Transitions to saved state prior
-        to the execution.
+        Aborts the execution of the mission indicated with the kwarg 'mission_id'.
+        Transitions to saved state if no remaining missions are left running.
         """
         if log.isEnabledFor(logging.TRACE):  # pragma: no cover
             log.trace("%r/%s args=%s kwargs=%s",
                       self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        next_state = self._pre_mission_state
-        result = self._mission_manager.abort_mission()
-        if result is not None:
-            # problems; do not make transition:
-            next_state = None
-        else:
+        mission_id = kwargs.get('mission_id', None)
+        if mission_id is None:
+            raise FSMError('mission_run: missing mission_id argument')
+
+        result = self._mission_manager.abort_mission(mission_id)
+
+        remaining = self._mission_manager.get_number_of_running_missions()
+        if remaining == 0:
+            next_state = self._pre_mission_state
             self._pre_mission_state = None
+        else:
+            next_state = None
 
         return next_state, result
 
     def _handler_mission_kill(self, *args, **kwargs):
         """
-        Kills the ongoing mission execution. Transitions to saved state prior
-        to the execution.
+        Kills the execution of the mission indicated with the kwarg 'mission_id'.
+        Transitions to saved state if no remaining missions are left running.
         """
         if log.isEnabledFor(logging.TRACE):  # pragma: no cover
             log.trace("%r/%s args=%s kwargs=%s",
                       self._platform_id, self.get_agent_state(), str(args), str(kwargs))
 
-        next_state = self._pre_mission_state
-        result = self._mission_manager.kill_mission()
-        if result is not None:
-            # problems; do not make transition:
-            next_state = None
-        else:
+        mission_id = kwargs.get('mission_id', None)
+        if mission_id is None:
+            raise FSMError('mission_run: missing mission_id argument')
+
+        result = self._mission_manager.kill_mission(mission_id)
+
+        remaining = self._mission_manager.get_number_of_running_missions()
+        if remaining == 0:
+            next_state = self._pre_mission_state
             self._pre_mission_state = None
+        else:
+            next_state = None
 
         return next_state, result
 

--- a/ion/agents/platform/test/test_mission_manager.py
+++ b/ion/agents/platform/test/test_mission_manager.py
@@ -56,20 +56,11 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
         finally:  # attempt shutdown anyway
             self._shutdown(True)  # NOTE: shutdown always with recursion=True
 
-    def _set_mission(self, yaml_filename):
-        log.debug('[mm] _set_mission: setting agent param mission = %s', yaml_filename)
-        self._pa_client.set_agent({'mission': yaml_filename})
-
-    def _get_mission(self):
-        mission = self._pa_client.get_agent(['mission'])['mission']
-        self.assertIsNotNone(mission)
-        log.debug('[mm] _get_mission: agent param mission = %s', mission)
-        return mission
-
-    def _run_mission(self):
-        cmd = AgentCommand(command=PlatformAgentEvent.RUN_MISSION)
+    def _run_mission(self, mission_id, mission_yml):
+        kwargs = dict(mission_id=mission_id, mission_yml=mission_yml)
+        cmd = AgentCommand(command=PlatformAgentEvent.RUN_MISSION, kwargs=kwargs)
         retval = self._execute_agent(cmd)
-        log.debug('[mm] _run_mission: RUN_MISSION return: %s', retval)
+        log.debug('[mm] _run_mission mission_id=%s: RUN_MISSION return: %s', mission_id, retval)
 
     def _await_mission_completion(self, mission_state, max_wait=None):
         """
@@ -158,9 +149,11 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
         )
         log.info('[mm] mission event subscriber started')
 
-        # now set and run mission:
-        self._set_mission(generated_filename)
-        self._run_mission()
+        # now run mission:
+        mission_id = generated_filename
+        mission_yml = generated_filename # TODO: change to actual contents
+        # once underlying method is implemented
+        self._run_mission(mission_id, mission_yml)
 
         state = self._get_state()
         if state == mission_state:

--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -396,7 +396,6 @@ class TestPlatformAgent(BaseIntTestPlatform):
             'alerts',
             'aggstatus',
             'rollup_status',
-            'mission',
         ]
         res_pars_all = []
         res_cmds_all = [


### PR DESCRIPTION
Previous "mission" agent parameter mechanism removed.
Instead, directly pass mission_id and mission_yml arguments to RUN_MISSION; and mission_id to ABORT_ and KILL_MISSION
Tests updated and verified.

@edwardhunter please merge

@bobfrat FYI
