### PR TITLE
port-instrument associations

### DIFF
--- a/ion/agents/platform/rsn/rsn_platform_driver.py
+++ b/ion/agents/platform/rsn/rsn_platform_driver.py
@@ -253,9 +253,6 @@ class RSNPlatformDriver(PlatformDriver):
                got unexpected response.
         """
         log.debug("%r: pinging OMS...", self._platform_id)
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot ping: _rsn_oms object required (created via connect() call)")
-
         try:
             retval = self._rsn_oms.hello.ping()
         except Exception as e:
@@ -328,8 +325,6 @@ class RSNPlatformDriver(PlatformDriver):
     def get_metadata(self):
         """
         """
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot get_platform_metadata: _rsn_oms object required (created via connect() call)")
         try:
             retval = self._rsn_oms.config.get_platform_metadata(self._platform_id)
         except Exception as e:
@@ -358,9 +353,6 @@ class RSNPlatformDriver(PlatformDriver):
         if not isinstance(attrs, (list, tuple)):
             raise PlatformException('get_attribute_values: attrs argument must be a '
                                     'list [(attrName, from_time), ...]. Given: %s', attrs)
-
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot get_platform_attribute_values: _rsn_oms object required (created via connect() call)")
 
         # convert the ION system time from_time to NTP, as this is the time
         # format used by the RSN OMS interface:
@@ -462,9 +454,6 @@ class RSNPlatformDriver(PlatformDriver):
         """
         """
         log.debug("set_attribute_values: attrs = %s", attrs)
-
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot set_platform_attribute_values: _rsn_oms object required (created via connect() call)")
 
         error_vals = self._validate_set_attribute_values(attrs)
         if len(error_vals) > 0:
@@ -574,9 +563,6 @@ class RSNPlatformDriver(PlatformDriver):
         log.debug("%r: connect_instrument: port_id=%r instrument_id=%r attributes=%s",
                   self._platform_id, port_id, instrument_id, attributes)
 
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot connect_instrument: _rsn_oms object required (created via connect() call)")
-
         try:
             response = self._rsn_oms.instr.connect_instrument(self._platform_id,
                                                               port_id,
@@ -609,9 +595,6 @@ class RSNPlatformDriver(PlatformDriver):
         log.debug("%r: disconnect_instrument: port_id=%r instrument_id=%r",
                   self._platform_id, port_id, instrument_id)
 
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot disconnect_instrument: _rsn_oms object required (created via connect() call)")
-
         try:
             response = self._rsn_oms.instr.disconnect_instrument(self._platform_id,
                                                                  port_id,
@@ -641,9 +624,6 @@ class RSNPlatformDriver(PlatformDriver):
         log.debug("%r: get_connected_instruments: port_id=%s",
                   self._platform_id, port_id)
 
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot get_connected_instruments: _rsn_oms object required (created via connect() call)")
-
         try:
             response = self._rsn_oms.instr.get_connected_instruments(self._platform_id,
                                                                      port_id)
@@ -662,9 +642,6 @@ class RSNPlatformDriver(PlatformDriver):
         log.debug("%r: turning on port: port_id=%s",
                   self._platform_id, port_id)
 
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot turn_on_platform_port: _rsn_oms object required (created via connect() call)")
-
         try:
             response = self._rsn_oms.port.turn_on_platform_port(self._platform_id,
                                                                 port_id)
@@ -682,9 +659,6 @@ class RSNPlatformDriver(PlatformDriver):
     def turn_off_port(self, port_id):
         log.debug("%r: turning off port: port_id=%s",
                   self._platform_id, port_id)
-
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot turn_off_platform_port: _rsn_oms object required (created via connect() call)")
 
         try:
             response = self._rsn_oms.port.turn_off_platform_port(self._platform_id,
@@ -708,10 +682,6 @@ class RSNPlatformDriver(PlatformDriver):
         Registers given url for all event types.
         """
         log.debug("%r: registering event listener: %s", self._platform_id, url)
-
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot _register_event_listener: _rsn_oms object required (created via connect() call)")
-
         try:
             already_registered = self._rsn_oms.event.get_registered_event_listeners()
         except Exception as e:
@@ -735,10 +705,6 @@ class RSNPlatformDriver(PlatformDriver):
         Unregisters given url for all event types.
         """
         log.debug("%r: unregistering event listener: %s", self._platform_id, url)
-
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot _unregister_event_listener: _rsn_oms object required (created via connect() call)")
-
         try:
             result = self._rsn_oms.event.unregister_event_listener(url)
         except Exception as e:
@@ -803,10 +769,6 @@ class RSNPlatformDriver(PlatformDriver):
         @return SHA1 hash value as string of hexadecimal digits.
         """
         log.debug("%r: get_checksum...", self._platform_id)
-
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot get_checksum: _rsn_oms object required (created via connect() call)")
-
         try:
             response = self._rsn_oms.config.get_checksum(self._platform_id)
         except Exception as e:

--- a/ion/agents/platform/rsn/simulator/network.yml
+++ b/ion/agents/platform/rsn/simulator/network.yml
@@ -211,7 +211,11 @@ network:
             monitor_cycle_seconds: 10
           ports:
           - port_id: Node1D_port_1
+            instruments:
+            - instrument_id: SBE37_SIM_01
           - port_id: Node1D_port_2
+            instruments:
+            - instrument_id: SBE37_SIM_02
           subplatforms:
           - platform_id: MJ01C
             platform_types: []
@@ -297,7 +301,12 @@ network:
                 monitor_cycle_seconds: 4
               ports:
               - port_id: 1
+                instruments:
+                - instrument_id: SBE37_SIM_02
+                - instrument_id: SBE37_SIM_03
               - port_id: 2
+                instruments:
+                - instrument_id: SBE37_SIM_04
         - platform_id: LV01C
           platform_types: []
           attrs:

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -304,7 +304,12 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
             pnode = self._network_definition.pnodes[platform_id]
             dic = {}
             for port_id, port in pnode.ports.iteritems():
-                dic[port_id] = dict(port_id=port_id)
+                instr_dict = {}
+                for i in port.instruments.itervalues():
+                    attrs = i.attrs.copy()
+                    attrs['instrument_id'] = i.instrument_id
+                    instr_dict[i.instrument_id] = attrs
+                dic[port_id] = dict(port_id=port_id, instruments=instr_dict)
             self._platform_ports[platform_id] = dic
         log.trace("_platform_ports: %s", self._pp.pformat(self._platform_ports))
 

--- a/ion/agents/platform/test/test_mission_manager.py
+++ b/ion/agents/platform/test/test_mission_manager.py
@@ -84,12 +84,15 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
             log.warn('[mm] _await_mission_completion: timeout, elapsed=%s, '
                      'still in state=%s', elapsed, mission_state)
 
-    def _test_simple_mission(self, mission_filename, in_command_state, max_wait=None):
+    def _test_simple_mission(self, instr_keys, mission_filename, in_command_state, max_wait=None):
         """
         Verifies mission execution, mainly as coordinated from platform agent
         and with some verifications related with expected mission event
         publications.
 
+        @param instr_keys
+                    Instruments to associate with parent platform; these
+                    should be ones referenced in the mission plan.
         @param mission_filename
         @param in_command_state
                     True to start mission execution in COMMAND state.
@@ -111,9 +114,6 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
             mission_state = PlatformAgentState.MISSION_STREAMING
 
         # start everything up to platform agent in COMMAND state.
-        # Instruments launched here are the ones referenced in the mission
-        # file below.
-        instr_keys = ['SBE37_SIM_02']
         p_root = self._set_up_single_platform_with_some_instruments(instr_keys)
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
@@ -229,6 +229,7 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
         # With mission plan to be started in COMMAND state.
         #
         self._test_simple_mission(
+            ['SBE37_SIM_02'],
             "ion/agents/platform/test/mission_RSN_simulator0C.yml",
             in_command_state=True,
             max_wait=200 + 300)
@@ -238,6 +239,7 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
         # With mission plan to be started in MONITORING state.
         #
         self._test_simple_mission(
+            ['SBE37_SIM_02'],
             "ion/agents/platform/test/mission_RSN_simulator0S.yml",
             in_command_state=False,
             max_wait=200 + 300)


### PR DESCRIPTION
@edwardhunter please review and merge.

One of the new tests:

```
bin/nosetests -sv  --with-pycc ion/agents/platform/test/test_platform_agent_with_rsn.py:TestPlatformAgent.test_turn_on_and_off_port_given_instrument
```

Note, this is a good progress but the overall port-instrument associations handling is _not_ complete yet, as it involves quite a few places also because this is related with long outstanding pending revision, https://jira.oceanobservatories.org/tasks/browse/OOIION-1495
