### PR TITLE
revert removal of method mistakenly considered to be unneeded

### DIFF
--- a/ion/agents/platform/util/network_util.py
+++ b/ion/agents/platform/util/network_util.py
@@ -28,6 +28,64 @@ class NetworkUtil(object):
     """
 
     @staticmethod
+    def create_node_network(network_map):
+        """
+        Creates a node network according to the given map (this map is
+        the format used by the CI-OMS interface to represent the topology).
+        Various verifications are performed here resulting in an exception
+        being thrown if the definition is invalid:
+         - no duplicate platform_id
+         - dummy root (with id '') is present
+         - only one regular root node.
+
+        @param network_map [(platform_id, parent_platform_id), ...]
+
+        @return { platform_id: PlatformNode }
+
+        @raise PlatformDefinitionException
+        """
+        pnodes = {}
+        for platform_id, parent_platform_id in network_map:
+            if not platform_id:
+                raise PlatformDefinitionException(
+                    "platform_id in tuple can not be %r" % platform_id)
+
+            if parent_platform_id is None:
+                parent_platform_id = ''
+
+            if parent_platform_id in pnodes:
+                parent = pnodes[parent_platform_id]
+            else:
+                parent = pnodes[parent_platform_id] = PlatformNode(parent_platform_id)
+
+            if platform_id in pnodes:
+                platform = pnodes[platform_id]
+                previous_parent = platform.parent
+            else:
+                platform = pnodes[platform_id] = PlatformNode(platform_id)
+                previous_parent = None
+
+            if previous_parent is not None and previous_parent.platform_id != parent_platform_id:
+                raise PlatformDefinitionException(
+                    "Duplicate tuple for platform_id=%r but different "
+                    "parent_platform_ids: %r and %r" % (
+                        platform_id,
+                        platform.parent.platform_id, parent_platform_id))
+
+            if platform_id not in parent._subplatforms:
+                parent.add_subplatform(platform)
+
+        if not '' in pnodes:
+            raise PlatformDefinitionException("Expecting dummy root in node network dict")
+        dummy_root = pnodes['']
+        if len(dummy_root.subplatforms) != 1:
+            raise PlatformDefinitionException(
+                "Expecting a single root in node network dict, but got %s" % (
+                dummy_root.subplatforms))
+
+        return pnodes
+
+    @staticmethod
     def deserialize_network_definition(ser):
         """
         Creates a NetworkDefinition object by deserializing the given argument.

--- a/ion/agents/platform/util/test/test_network_util.py
+++ b/ion/agents/platform/util/test/test_network_util.py
@@ -35,6 +35,38 @@ import unittest
 @attr('UNIT', group='sa')
 class Test(IonUnitTestCase):
 
+    def test_create_node_network(self):
+
+        # small valid map:
+        plat_map = [('R', ''), ('a', 'R'), ]
+        pnodes = NetworkUtil.create_node_network(plat_map)
+        for p, q in plat_map: self.assertTrue(p in pnodes and q in pnodes)
+
+        # duplicate 'a' but valid (same parent)
+        plat_map = [('R', ''), ('a', 'R'), ('a', 'R')]
+        NetworkUtil.create_node_network(plat_map)
+        for p, q in plat_map: self.assertTrue(p in pnodes and q in pnodes)
+
+        with self.assertRaises(PlatformDefinitionException):
+            # invalid empty map
+            plat_map = []
+            NetworkUtil.create_node_network(plat_map)
+
+        with self.assertRaises(PlatformDefinitionException):
+            # no dummy root (id = '')
+            plat_map = [('R', 'x')]
+            NetworkUtil.create_node_network(plat_map)
+
+        with self.assertRaises(PlatformDefinitionException):
+            # multiple regular roots
+            plat_map = [('R1', ''), ('R2', ''), ]
+            NetworkUtil.create_node_network(plat_map)
+
+        with self.assertRaises(PlatformDefinitionException):
+            # duplicate 'a' but invalid (diff parents)
+            plat_map = [('R', ''), ('a', 'R'), ('a', 'x')]
+            NetworkUtil.create_node_network(plat_map)
+
     def test_serialization_deserialization(self):
         # create NetworkDefinition object by de-serializing the simulated network:
         ndef = NetworkUtil.deserialize_network_definition(


### PR DESCRIPTION
Should fix the 46 platform related failed tests noted in http://buildbot.oceanobservatories.org:8010/builders/coi_pycc/builds/2195/steps/sa/logs/stdio upon a mistake on my part.

@jamie-cyber1 / @edwardhunter please merge
