### PR TITLE
minor refactor in platform driver's get_resource_capabilities

### DIFF
--- a/ion/agents/platform/rsn/rsn_platform_driver.py
+++ b/ion/agents/platform/rsn/rsn_platform_driver.py
@@ -110,11 +110,8 @@ class RSNPlatformDriver(PlatformDriver):
         # external event listener: created in _start_event_dispatch
         self._event_listener = None
 
-    def _filter_capabilities(self, events):
-        """
-        """
-        events_out = [x for x in events if RSNPlatformDriverCapability.has(x)]
-        return events_out
+    def _get_capability_enum_class(self):
+        return RSNPlatformDriverCapability
 
     def validate_driver_configuration(self, driver_config):
         """

--- a/ion/agents/platform/rsn/rsn_platform_driver.py
+++ b/ion/agents/platform/rsn/rsn_platform_driver.py
@@ -110,7 +110,10 @@ class RSNPlatformDriver(PlatformDriver):
         # external event listener: created in _start_event_dispatch
         self._event_listener = None
 
-    def _get_capability_enum_class(self):
+    def get_platform_driver_event_class(self):
+        return RSNPlatformDriverEvent
+
+    def get_platform_driver_capability_class(self):
         return RSNPlatformDriverCapability
 
     def validate_driver_configuration(self, driver_config):


### PR DESCRIPTION
with new option to retrieve actual capability enum class attributes (instead of the corresp values, which continues to be the default behaviour). This will help make the mission executive more general.

@edwardhunter please merge

@bobfrat :  You can then call:

``` python
    res_cmds, res_params = self.platform_agent._plat_driver.get_resource_capabilities(cmd_attrs=True)
```

and `res_cmds` will be the actual class attributes, so this will help with your scheme of things in the mission executive.
