### PR TITLE
platform agent/driver/ci-oms adjustments and more clean-up

### DIFF
--- a/ion/agents/platform/exceptions.py
+++ b/ion/agents/platform/exceptions.py
@@ -41,14 +41,6 @@ class PlatformConfigurationException(PlatformException):
     pass
 
 
-class PlatformDefinitionException(PlatformException):
-    """
-    Exception related with the definition of a platform network or any
-    particular platform node or other sub-component.
-    """
-    pass
-
-
 class PlatformDriverException(PlatformException):
     """
     Exception related to basic PlatformDriver functionality or configuration.

--- a/ion/agents/platform/exceptions.py
+++ b/ion/agents/platform/exceptions.py
@@ -11,10 +11,10 @@ __author__ = 'Carlos Rueda'
 __license__ = 'Apache 2.0'
 
 
-from ooi.exception import ApplicationException
+from pyon.core.exception import IonException
 
 
-class PlatformException(ApplicationException):
+class PlatformException(IonException):
     """
     Base class for platform related exceptions.
     """

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -1301,8 +1301,7 @@ class PlatformAgent(ResourceAgent):
             # it is actually running.
 
             # get PID:
-            # TODO is there a more public method to get the pid?
-            pid = ResourceAgentClient._get_agent_process_id(sub_resource_id)
+            pid = pa_client.get_agent_process_id()
 
             log.debug("%r: [LL] my child is already running: %r. pid=%s",
                       self._platform_id, subplatform_id, pid)
@@ -1994,8 +1993,7 @@ class PlatformAgent(ResourceAgent):
             # it is running.
 
             # get PID:
-            # TODO is there a more public method to get the pid?
-            pid = ResourceAgentClient._get_agent_process_id(i_resource_id)
+            pid = ia_client.get_agent_process_id()
 
         except NotFound:
             # not running.

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -375,7 +375,7 @@ class PlatformAgent(ResourceAgent):
             msg = "PlatformAgent._validate_configuration: platform ID %r not equal to ID %r of node." % (self._platform_id, self._pnode.platform_id)
             log.error(msg)
 
-        log.debug("PlatformAgent._validate_configuration: self._pnode = %s" %self._pnode)
+        log.debug("PlatformAgent._validate_configuration: _pnode = %s", self._pnode)
 
         self._children_resource_ids = self._get_children_resource_ids()
 
@@ -393,28 +393,10 @@ class PlatformAgent(ResourceAgent):
             log.warn("%r: platform attributes taken from network definition: %s",
                      self._platform_id, self._platform_attributes)
 
-        #
-        # set platform ports:
-        # TODO the ports may probably be applicable only in particular
-        # drivers (like in RSN), so move these there if that's the case.
-        #
         if 'ports' in self._driver_config:
-            ports = self._driver_config['ports']
-
             # Remove this device from the ports information, the driver does not use this
             platform_port = self._driver_config['ports'].pop(self.resource_id, None)
             log.debug('_validate_configuration removed platform port info from ports config for driver.  dev_id:  %s   platform_port: %s', self.resource_id, platform_port)
-
-            self._platform_ports = ports
-            log.debug("%r: platform ports taken from driver_config: %s",
-                      self._platform_id, self._platform_ports)
-        else:
-            self._platform_ports = {}
-            for port_id, port in self._pnode.ports.iteritems():
-                self._platform_ports[port_id] = dict(port_id=port_id,
-                                                     network=port.network)
-            log.warn("%r: platform ports taken from network definition: %s",
-                     self._platform_id, self._platform_ports)
 
         ppid = self._plat_config.get('parent_platform_id', None)
         if ppid:

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -371,10 +371,6 @@ class PlatformAgent(ResourceAgent):
 
         # get PlatformNode corresponding to this agent:
         self._pnode = self._network_definition.pnodes[self._platform_id]
-        if self._pnode.platform_id != self._platform_id:
-            msg = "PlatformAgent._validate_configuration: platform ID %r not equal to ID %r of node." % (self._platform_id, self._pnode.platform_id)
-            log.error(msg)
-
         log.debug("PlatformAgent._validate_configuration: _pnode = %s", self._pnode)
 
         self._children_resource_ids = self._get_children_resource_ids()

--- a/ion/agents/platform/platform_driver.py
+++ b/ion/agents/platform/platform_driver.py
@@ -277,6 +277,20 @@ class PlatformDriver(object):
         """
         raise NotImplementedError()  #pragma: no cover
 
+    def get_attributes(self):
+        """
+        To be implemented by subclass.
+        Returns the attributes of this platform. This is used by the agent
+        for attribute monitoring purposes.
+
+        @retval {attr_id: dict, ...}
+                dict indexed by attribute ID with associated properties.
+
+        @raise PlatformConnectionException  If the connection to the external
+               platform is lost.
+        """
+        raise NotImplementedError()  #pragma: no cover
+
     def get_attribute_values(self, attrs):
         """
         To be implemented by subclass.

--- a/ion/agents/platform/rsn/rsn_platform_driver.py
+++ b/ion/agents/platform/rsn/rsn_platform_driver.py
@@ -354,6 +354,11 @@ class RSNPlatformDriver(PlatformDriver):
         """
         return self._pnode.subplatforms.keys()
 
+    def get_attributes(self):
+        attrs = self._driver_config.get('attributes', {})
+        log.debug("%r: get_attributes=%s", self._platform_id, attrs)
+        return attrs
+
     def get_attribute_values(self, attrs):
         """
         """

--- a/ion/agents/platform/rsn/rsn_platform_driver.py
+++ b/ion/agents/platform/rsn/rsn_platform_driver.py
@@ -82,9 +82,7 @@ class RSNPlatformDriver(PlatformDriver):
         self._rsn_oms = None
 
         # TODO(OOIION-1495) review the following. Commented out for the moment.
-        # But yes, we would probably need some concept of currently "active
-        # ports", probably defined as those where there are active instruments
-        #  associated.
+        # What does "ports that have devices attached" mean?
         """
         # Simple list of active ports in this deployment configuration:
         # (this should be all the ports that have devices attached. Used in go_active processing
@@ -142,19 +140,14 @@ class RSNPlatformDriver(PlatformDriver):
                 self._instr_port_map[instr_id] = port_id
         log.debug("%r: _instr_port_map: %s", self._platform_id, self._instr_port_map)
 
-        # TODO(OOIION-1495) review the following added logic Commented out
-        # for the moment. We need to determine where and how exactly port
-        # information is maintained.
+        # TODO(OOIION-1495) review the following added logic.
+        # Per recent discussions there would be two main sources for platform
+        # port information: 1- from ongoing deployment; 2- from direct port
+        # configuration when no ongoing deployment available.
         """
-        # validate and process ports
-        if not 'ports' in driver_config:
-            log.error("port information not present in driver_config = %s", driver_config)
-            raise PlatformDriverException(msg="driver_config does not indicate 'ports'")
-
         # Create an IonObjectDeserializer
         ior = IonObjectRegistry()
         ion_deserializer = IonObjectDeserializer(obj_registry=ior)
-
 
         port_info_dict = driver_config['ports']
         for device_id, platform_port_serialized in port_info_dict.iteritems():
@@ -167,8 +160,6 @@ class RSNPlatformDriver(PlatformDriver):
                 #strip leading zeros from port numbers as OMS stores as strings w/o leading zeros
                 port_string = str( int(ooi_rd.port) )
                 self._active_ports.append(port_string)
-
-
         """
     def configure(self, driver_config):
         """
@@ -318,8 +309,7 @@ class RSNPlatformDriver(PlatformDriver):
         # TODO(OOIION-1495) review the following. Only change is the use
         # of self._pnode.ports instead of self._active_ports,
         # while we address the "active ports" concept mentioned above.
-        # Also, it is probably OK to turn off all ports in this "disconnect
-        # driver" operation.
+        # BTW, is it OK to turn off ports in this "disconnect driver" operation?
 
         # power off all ports with connected devices
         if recursion:

--- a/ion/agents/platform/rsn/rsn_platform_driver.py
+++ b/ion/agents/platform/rsn/rsn_platform_driver.py
@@ -655,34 +655,17 @@ class RSNPlatformDriver(PlatformDriver):
         return result
 
     def _get_ports(self):
-        ports = {}
-        for port_id, port in self._pnode.ports.iteritems():
-            ports[port_id] = {'state':   port.state}
-        log.debug("%r: _get_ports: %s", self._platform_id, ports)
-        return ports
-
-        # TODO(OOIION-1495) review the following
-        """
-        ports = {}
-
-        # todo remove until NetworkDefinition is brought in alignment See OOIION-1495.
-        #for port_id, port in self._pnode.ports.iteritems():
-        #    ports[port_id] = {'network': port.network,
-        #                      'state':   port.state}
-
-        if self._rsn_oms is None:
-            raise PlatformConnectionException("Cannot turn_on_platform_port: _rsn_oms object required (created via connect() call)")
 
         try:
             response = self._rsn_oms.port.get_platform_ports(self._platform_id)
             ports = response[self._platform_id]
 
         except Exception as e:
-            raise PlatformConnectionException(msg="Cannot turn_on_platform_port: %s" % str(e))
+            msg = "Cannot get_platform_ports(platform_id=%r): %s" % (self._platform_id, e)
+            raise PlatformConnectionException(msg=msg)
 
         log.debug("%r: _get_ports: %s", self._platform_id, ports)
         return ports
-        """
 
     ##############################################################
     # CONNECTED event handlers we add in this subclass

--- a/ion/agents/platform/util/network.py
+++ b/ion/agents/platform/util/network.py
@@ -100,7 +100,6 @@ class PortNode(BaseNode):
         BaseNode.__init__(self)
         self._port_id = str(port_id)
         self._instrument_ids = []
-        self._state = None
 
     def __repr__(self):
         return "PortNode{port_id=%r, instrument_ids=%r}" % (
@@ -109,13 +108,6 @@ class PortNode(BaseNode):
     @property
     def port_id(self):
         return self._port_id
-
-    @property
-    def state(self):
-        return self._state
-
-    def set_state(self, state):
-        self._state = state
 
     @property
     def instrument_ids(self):
@@ -144,10 +136,6 @@ class PortNode(BaseNode):
         if self.port_id != other.port_id:
             return "Port IDs are different: %r != %r" % (
                 self.port_id, other.port_id)
-
-        if self.state != other.state:
-            return "Port state values are different: %r != %r" % (
-                self.state, other.state)
 
         # compare instruments:
         instrument_ids = set(self.instrument_ids)

--- a/ion/agents/platform/util/network_util.py
+++ b/ion/agents/platform/util/network_util.py
@@ -317,6 +317,8 @@ class NetworkUtil(object):
                          "_add_ports_to_platform_node(): 'port_id' not in port_info")
                 port_id = port_info['port_id']
                 port = PortNode(port_id)
+                for instrument_id in port_info.get('instrument_ids', []):
+                    port.add_instrument_id(instrument_id)
                 pn.add_port(port)
 
         def build_platform_node(CFG, parent_node):
@@ -338,10 +340,6 @@ class NetworkUtil(object):
             _add_attrs_to_platform_node(attributes.itervalues(), pn)
 
             # ports:
-            # TODO(OOIION-1495) the following was commented out,
-            # but we need to capture the ports, at least under the current logic.
-            # remove until network checkpoint needs are defined.
-            # port info can be retrieve from active deployment
             _add_ports_to_platform_node(ports.itervalues(), pn)
 
             # children:

--- a/ion/agents/platform/util/network_util.py
+++ b/ion/agents/platform/util/network_util.py
@@ -5,6 +5,8 @@
 @file    ion/agents/platform/util/network_util.py
 @author  Carlos Rueda
 @brief   Utilities related with platform network definition
+         Note that this module is also used by simulator so it does not
+         import any ION modules.
 """
 
 __author__ = 'Carlos Rueda'
@@ -16,10 +18,15 @@ from ion.agents.platform.util.network import AttrNode
 from ion.agents.platform.util.network import PortNode
 from ion.agents.platform.util.network import InstrumentNode
 from ion.agents.platform.util.network import NetworkDefinition
-from ion.agents.platform.exceptions import PlatformDefinitionException
 
 import yaml
 from collections import OrderedDict
+
+
+class NetworkDefinitionException(Exception):
+    def __init__(self, msg=''):
+        super(NetworkDefinitionException, self).__init__()
+        self.msg = msg
 
 
 class NetworkUtil(object):
@@ -282,7 +289,7 @@ class NetworkUtil(object):
         @param CFG CI agent configuration
         @return A NetworkDefinition object
 
-        @raise PlatformDefinitionException device_type is not 'PlatformDevice'
+        @raise NetworkDefinitionException device_type is not 'PlatformDevice'
         """
 
         # verify CFG corresponds to PlatformDevice:
@@ -375,7 +382,7 @@ def _get_attr_id(attr_defn):
     elif 'attr_name' in attr_defn and 'attr_instance' in attr_defn:
         attr_id = "%s|%s" % (attr_defn['attr_name'], attr_defn['attr_instance'])
     else:
-        raise PlatformDefinitionException(
+        raise NetworkDefinitionException(
             "Attribute definition does now include 'attr_name' nor 'attr_instance'. "
             "attr_defn = %s" % attr_defn)
 
@@ -384,4 +391,4 @@ def _get_attr_id(attr_defn):
 
 def _require(cond, msg=""):
     if not cond:
-        raise PlatformDefinitionException(msg)
+        raise NetworkDefinitionException(msg)

--- a/ion/agents/platform/util/network_util.py
+++ b/ion/agents/platform/util/network_util.py
@@ -55,7 +55,6 @@ class NetworkUtil(object):
                     _require('port_id' in port_info)
                     port_id = port_info['port_id']
                     port = PortNode(port_id)
-                    port.set_state(port_info.get('state', None))
                     if 'instruments' in port_info:
                         for instrument in port_info['instruments']:
                             instrument_id = instrument['instrument_id']

--- a/ion/agents/platform/util/test/test_network_util.py
+++ b/ion/agents/platform/util/test/test_network_util.py
@@ -20,7 +20,7 @@ from pyon.public import log
 import logging
 
 from ion.agents.platform.util.network_util import NetworkUtil
-from ion.agents.platform.exceptions import PlatformDefinitionException
+from ion.agents.platform.util.network_util import NetworkDefinitionException
 
 from pyon.util.containers import DotDict
 
@@ -59,7 +59,7 @@ class Test(IonUnitTestCase):
         })
 
         # device_type
-        with self.assertRaises(PlatformDefinitionException):
+        with self.assertRaises(NetworkDefinitionException):
             NetworkUtil.create_network_definition_from_ci_config(CFG)
 
         CFG = DotDict({
@@ -67,7 +67,7 @@ class Test(IonUnitTestCase):
         })
 
         # missing platform_id
-        with self.assertRaises(PlatformDefinitionException):
+        with self.assertRaises(NetworkDefinitionException):
             NetworkUtil.create_network_definition_from_ci_config(CFG)
 
         CFG = DotDict({
@@ -79,7 +79,7 @@ class Test(IonUnitTestCase):
         })
 
         # missing driver_config
-        with self.assertRaises(PlatformDefinitionException):
+        with self.assertRaises(NetworkDefinitionException):
             NetworkUtil.create_network_definition_from_ci_config(CFG)
 
     def test_create_network_definition_from_ci_config(self):

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -103,10 +103,7 @@ class TestPlatformLaunch(BaseIntTestPlatform):
         log.debug("platform state: %s", state)
         self.assertEquals(ResourceAgentState.COMMAND, state)
 
-        ports = self._get_ports()
-        log.info("_get_ports = %s", ports)
-        for dev_id, state_dict in ports.iteritems():
-            self.assertEquals(state_dict['state'], None)
+        self._get_ports()
 
     def test_hierarchy(self):
         #


### PR DESCRIPTION
- more clean-up related with platform ports and OOIION-1495, including fixes to potential references to NoneType as a dict
- get port status in platform driver via request to RSN OMS (not from config)
- platform attribute definitions retrieved from call to platform driver (not from config)
- raise IonException-derived exceptions in PlatformAgent's on_init and on_start upon any problems with configuration. This fixes misalignment with expected behavior.

@edwardhunter please review/merge
