### PR TITLE
M101: initial version of instrument stable ids based on PRE:* entries in alt_ids

### DIFF
--- a/ion/agents/platform/mission_manager.py
+++ b/ion/agents/platform/mission_manager.py
@@ -86,7 +86,8 @@ class MissionManager(object):
             raise BadRequest('run_mission: mission_id=%r is already running', mission_id)
 
         try:
-            mission_loader, mission_scheduler = self._create_mission_scheduler(mission_id, mission_yml)
+            mission_loader, mission_scheduler, instrument_objs = \
+                self._create_mission_scheduler(mission_id, mission_yml)
         except Exception as ex:
             log.exception('[mm] run_mission: mission_id=%r _create_mission_scheduler exception', mission_id)
             return
@@ -106,7 +107,9 @@ class MissionManager(object):
             for mission_entry in mission_entries:
                 instrument_ids = mission_entry.get('instrument_id', [])
                 for instrument_id in instrument_ids:
-                    self._remove_exclusive_access(instrument_id, mission_id)
+                    if instrument_id in instrument_objs:
+                        resource_id = instrument_objs[instrument_id].resource_id
+                        self._remove_exclusive_access(instrument_id, resource_id, mission_id)
 
             log.debug('[mm] completed mission_id=%r (#running missions=%s)',
                       mission_id, len(self._running_missions))
@@ -154,7 +157,7 @@ class MissionManager(object):
         @param mission_id
         @param mission_yml
 
-        @return (mission_loader, mission_scheduler)
+        @return (mission_loader, mission_scheduler, instrument_objs)
         @raise  Exception the first exception while requesting exclusive
                 access to a child instrument. All other successful
                 such requests, if any, are reverted.
@@ -169,16 +172,24 @@ class MissionManager(object):
             log.debug('[mm] _create_mission_scheduler: _ia_clients=\n%s',
                       self._agent._pp.pformat(self._agent._ia_clients))
 
-        # get instrument IDs and clients for the valid running instruments:
-        instruments = {}
+        # {stable_id: obj, ...} objects of valid running instruments:
+        instrument_objs = {}
         for (instrument_id, obj) in self._agent._ia_clients.iteritems():
-            if isinstance(obj, dict):
-                # it's valid instrument.
-                if instrument_id != obj.resource_id:
-                    log.error('[mm] _create_mission_scheduler: instrument_id=%s, '
-                              'resource_id=%s', instrument_id, obj.resource_id)
+            if isinstance(obj, dict):   # dict means it's valid instrument.
+                # get first "PRE:*" ID from obj.alt_ids:
+                pres = [alt_id for alt_id in obj.alt_ids if alt_id.startswith('PRE:')]
+                if not pres:
+                    raise Exception('No stable ID found for instrument_id=%r. alt_ids=%s' % (
+                                    instrument_id, obj.alt_ids))
+                stable_id = pres[0]
+                log.debug('[mm] _create_mission_scheduler: instrument_id=%r, stable_id=%r,'
+                          ' resource_id=%r', instrument_id, stable_id, obj.resource_id)
 
-                instruments[obj.resource_id] = obj.ia_client
+                instrument_objs[stable_id] = obj
+
+        # {stable_id: client, ...} dict for scheduler
+        instruments_for_scheduler = dict((stable_id, obj.ia_client) for
+                                         stable_id, obj in instrument_objs.iteritems())
 
         mission_entries = mission_loader.mission_entries
 
@@ -186,7 +197,7 @@ class MissionManager(object):
         instrument_ids = set()
         for mission_entry in mission_entries:
             for instrument_id in mission_entry.get('instrument_id', []):
-                if instrument_id in instruments:
+                if instrument_id in instrument_objs:
                     instrument_ids.add(instrument_id)
 
         # get exclusive access to those instruments. If any one fails,
@@ -194,13 +205,15 @@ class MissionManager(object):
         instrument_ids_ok = set()
         exception = None
         for instrument_id in instrument_ids:
+            resource_id = instrument_objs[instrument_id].resource_id
             try:
-                self._get_exclusive_access(instrument_id, mission_id)
+                self._get_exclusive_access(instrument_id, resource_id, mission_id)
                 instrument_ids_ok.add(instrument_id)
             except Exception as ex:
                 exception = ex
                 log.warn('[xa] _create_mission_scheduler: exclusive access request to'
-                         ' resource_id=%r failed: %s', instrument_id, exception)
+                         ' resource_id=%r, instrument_id=%r failed: %s',
+                         resource_id, instrument_id, exception)
                 break
 
         if exception:
@@ -208,29 +221,31 @@ class MissionManager(object):
                 log.warn('[xa] _create_mission_scheduler: reverting exclusive access '
                          'to the resources: %s', instrument_ids_ok)
                 for instrument_id in instrument_ids_ok:
+                    resource_id = instrument_objs[instrument_id].resource_id
                     try:
-                        self._remove_exclusive_access(instrument_id, mission_id)
+                        self._remove_exclusive_access(resource_id, mission_id)
                     except Exception as ex:
                         # just log warning an continue
                         log.warn('[xa] exception while reverting exclusive access to '
-                                 'resource_id=%r: %s', instrument_id, ex)
+                                 'resource_id=%r, instrument_id=%r: %s', resource_id, instrument_id, ex)
 
             raise exception
 
         mission_scheduler = MissionScheduler(self._agent,
-                                             instruments,
+                                             instruments_for_scheduler,
                                              mission_entries)
         log.debug('[mm] _create_mission_scheduler: MissionScheduler created. entries=%s',
                   mission_entries)
-        return mission_loader, mission_scheduler
+        return mission_loader, mission_scheduler, instrument_objs
 
-    def _get_exclusive_access(self, resource_id, mission_id):
+    def _get_exclusive_access(self, instrument_id, resource_id, mission_id):
         """
         Gets exclusive access for the given resource_id. The actual request is
         only done once for the same resource_id, but we keep track of the
         associated mission_id such that the exclusive access is removed when
         no missions remain referencing the resource_id.
 
+        @param instrument_id        for logging
         @param resource_id
         @param mission_id
         """
@@ -247,20 +262,20 @@ class MissionManager(object):
                           'previous call with mission_id=%r', resource_id, mission_ids[0])
             return
 
-        log.debug('[xa] _get_exclusive_access: resource_id=%s, actor_id=%r, provider=%r',
-                  resource_id, self._actor_id, self._provider_id)
+        log.debug('[xa] _get_exclusive_access: instrument_id=%r resource_id=%r, actor_id=%r, provider=%r',
+                  instrument_id, resource_id, self._actor_id, self._provider_id)
 
         # TODO proper handling of BadRequest exception upon failure to obtain
         # exclusive access. For now, just logging ghe exception.
         try:
-            commitment_id = self._do_get_exclusive_access(resource_id)
+            commitment_id = self._do_get_exclusive_access(instrument_id, resource_id)
             self._exaccess[resource_id] = dict(commitment_id=commitment_id,
                                                mission_ids=[mission_id])
         except BadRequest:
-            log.exception('[xa] _get_exclusive_access: resource_id=%r, mission_id=%r',
-                          resource_id, mission_id)
+            log.exception('[xa] _get_exclusive_access: instrument_id=%r resource_id=%r, mission_id=%r',
+                          instrument_id, resource_id, mission_id)
 
-    def _do_get_exclusive_access(self, resource_id):
+    def _do_get_exclusive_access(self, instrument_id, resource_id):
         """
         Gets exclusive access to a given resource.
 
@@ -288,8 +303,8 @@ class MissionManager(object):
 
         # we are initially opting for only "phase 2" -- just acquire_resource:
         commitment_id = self.ORG.acquire_resource(arxp, headers=self._actor_header)
-        log.debug('[xa] AcquireResourceExclusiveProposal: '
-                  'resource_id=%s -> commitment_id=%s', resource_id, commitment_id)
+        log.debug('[xa] AcquireResourceExclusiveProposal: instrument_id=%r '
+                  'resource_id=%s -> commitment_id=%s', instrument_id, resource_id, commitment_id)
         return commitment_id
 
         # #####################################################################
@@ -311,49 +326,53 @@ class MissionManager(object):
         # log.debug('[xa] _get_exclusive_access/AcquireResourceExclusiveProposal: '
         #           'resource_id=%s -> arxp_response=%s', resource_id, arxp_response)
 
-    def _remove_exclusive_access(self, resource_id, mission_id):
+    def _remove_exclusive_access(self, instrument_id, resource_id, mission_id):
         """
         Removes the exclusive access for the given resource_id. The actual
         removal is only done if there are no more missions associated.
 
+        @param instrument_id      for logging
         @param resource_id
         @param mission_id
         """
         if not resource_id in self._exaccess:
-            log.warn('[xa] not associated with exclusive access resource_id=%r', resource_id)
+            log.warn('[xa] not associated with exclusive access resource_id=%r instrument_id=%r',
+                     resource_id, instrument_id)
             return
 
         mission_ids = self._exaccess[resource_id]['mission_ids']
         if not mission_id in mission_ids:
-            log.warn('[xa] not associated with exclusive access resource_id=%r', resource_id)
+            log.warn('[xa] not associated with exclusive access resource_id=%r instrument_id=%r',
+                     resource_id, instrument_id)
             return
 
         mission_ids.remove(mission_id)
 
         if len(mission_ids) > 0:
-            log.debug('[xa] exclusive access association removed: resource_id=%r -> mission_id=%r',
-                      resource_id, mission_id)
+            log.debug('[xa] exclusive access association removed: resource_id=%r -> mission_id=%r, instrument_id=%r',
+                      resource_id, mission_id, instrument_id)
             return
 
         # no more mission_ids associated, so release the exclusive access:
         commitment_id = self._exaccess[resource_id]['commitment_id']
         del self._exaccess[resource_id]
-        self._do_remove_exclusive_access(commitment_id, resource_id)
+        self._do_remove_exclusive_access(commitment_id, instrument_id, resource_id)
 
-    def _do_remove_exclusive_access(self, commitment_id, resource_id):
+    def _do_remove_exclusive_access(self, commitment_id, instrument_id, resource_id):
         """
         Does the actual release of the exclusive access.
 
         @param commitment_id   commitment to the released
+        @param instrument_id   associated ID for logging purposes
         @param resource_id     associated resource ID for logging purposes
         """
         # TODO: any exception below is just logged out; need different handling?
         try:
             ret = self.ORG.release_commitment(commitment_id)
-            log.debug('[xa] exclusive access removed: resource_id=%r: '
+            log.debug('[xa] exclusive access removed: resource_id=%r instrument_id=%r: '
                       'ORG.release_commitment(commitment_id=%r) returned=%r',
-                      resource_id, commitment_id, ret)
+                      resource_id, instrument_id, commitment_id, ret)
 
         except Exception as ex:
-            log.exception('[xa] resource_id=%r: ORG.release_commitment(commitment_id=%r)',
-                          resource_id, commitment_id)
+            log.exception('[xa] resource_id=%r instrument_id=%r: ORG.release_commitment(commitment_id=%r)',
+                          resource_id, instrument_id, commitment_id)

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -1952,7 +1952,8 @@ class PlatformAgent(ResourceAgent):
         # get InstrumentsNode, corresponding CFG, and resource_id:
         inode = self._pnode.instruments[instrument_id]
         i_CFG = inode.CFG
-        i_resource_id = i_CFG.get("agent", {}).get("resource_id", None)
+        agent_CFG = i_CFG.get("agent", {})
+        i_resource_id = agent_CFG.get("resource_id", None)
 
         if i_resource_id is None:
             log.error("PlatformAgent._launch_instrument_agent: agent.resource_id must be present for child %r" % instrument_id)
@@ -2019,7 +2020,8 @@ class PlatformAgent(ResourceAgent):
 
         self._ia_clients[instrument_id] = DotDict(ia_client=ia_client,
                                                   pid=pid,
-                                                  resource_id=i_resource_id)
+                                                  resource_id=i_resource_id,
+                                                  alt_ids=agent_CFG.get("alt_ids", []))
 
         self._status_manager.instrument_launched(ia_client, i_resource_id)
 

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -154,7 +154,8 @@ instruments_dict = {
         'DEV_PORT'  : 4002,
         'DATA_PORT' : 5002,
         'CMD_PORT'  : 6002,
-        'PA_BINARY' : "port_agent"
+        'PA_BINARY' : "port_agent",
+        'alt_ids'   : ["PRE:SBE37_SIM_02"]
     },
 
     "SBE37_SIM_03": {
@@ -162,7 +163,8 @@ instruments_dict = {
         'DEV_PORT'  : 4003,
         'DATA_PORT' : 5003,
         'CMD_PORT'  : 6003,
-        'PA_BINARY' : "port_agent"
+        'PA_BINARY' : "port_agent",
+        'alt_ids'   : ["PRE:SBE37_SIM_03"]
     },
 
     "SBE37_SIM_04": {
@@ -969,11 +971,11 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
                                                   alerts=[temp_alert_def, late_data_alert_def])
 
         instrument_agent_instance_obj.agent_config = agent_config
+        instrument_agent_instance_obj.alt_ids = instr_info.get('alt_ids', [])
 
         instrument_agent_instance_id = self.IMS.create_instrument_agent_instance(instrument_agent_instance_obj)
 
         # data products
-
 
         org_id = self.RR2.create(org_obj)
 

--- a/ion/agents/platform/test/mission_RSN_simulator0C.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator0C.yml
@@ -15,7 +15,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [SBE37_SIM_02]
+    instrumentID: ['PRE:SBE37_SIM_02']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -30,15 +30,15 @@ mission:
         parentID: 
         eventID: 
     preMissionSequence:
-      - command: SBE37_SIM_02, set_resource(INTERVAL{3})
+      - command: PRE:SBE37_SIM_02, set_resource(INTERVAL{3})
         onError: retry
     missionSequence:
-      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
         onError: retry
       - command: wait(0.2)
         onError:
-      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
         onError: retry
     postMissionSequence:
-      - command: SBE37_SIM_02, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_02, execute_agent(RESET)
         onError: retry

--- a/ion/agents/platform/test/mission_RSN_simulator0S.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator0S.yml
@@ -15,7 +15,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [SBE37_SIM_02]
+    instrumentID: ['PRE:SBE37_SIM_02']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -34,7 +34,7 @@ mission:
       - command: wait(0.2)
         onError:
     postMissionSequence:
-      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
         onError: retry
-      - command: SBE37_SIM_02, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_02, execute_agent(RESET)
         onError: retry

--- a/ion/agents/platform/test/mission_RSN_simulator1.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator1.yml
@@ -13,7 +13,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [SBE37_SIM_02, SBE37_SIM_03]
+    instrumentID: ['PRE:SBE37_SIM_02', 'PRE:SBE37_SIM_03']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -28,33 +28,33 @@ mission:
         parentID: 
         eventID: 
     preMissionSequence:
-      - command: SBE37_SIM_02, set_resource(INTERVAL{3})
+      - command: PRE:SBE37_SIM_02, set_resource(INTERVAL{3})
         onError: retry
-      - command: SBE37_SIM_02, execute_resource(CLOCK_SYNC)
+      - command: PRE:SBE37_SIM_02, execute_resource(CLOCK_SYNC)
         onError: skip
-      # - command: SBE37_SIM_03, set_resource(INTERVAL{3})
+      # - command: PRE:SBE37_SIM_03, set_resource(INTERVAL{3})
       #   onError: retry
     missionSequence:
-      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
         onError: retry
       - command: wait(1)
         onError:
-      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
         onError: retry
-      # - command: SBE37_SIM_03, execute_resource(START_AUTOSAMPLE)
+      # - command: PRE:SBE37_SIM_03, execute_resource(START_AUTOSAMPLE)
       #   onError: retry
       # - command: wait(1)
       #   onError:
-      # - command: SBE37_SIM_03, execute_resource(STOP_AUTOSAMPLE)
+      # - command: PRE:SBE37_SIM_03, execute_resource(STOP_AUTOSAMPLE)
       #   onError: retry
     postMissionSequence:
-      - command: SBE37_SIM_02, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_02, execute_agent(RESET)
         onError: retry
-      - command: SBE37_SIM_03, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_03, execute_agent(RESET)
         onError: retry
 
   # - missionThread:
-  #   instrumentID: [SBE37_SIM_03]
+  #   instrumentID: [PRE:SBE37_SIM_03]
   #   errorHandling:
   #     default: retry
   #     maxRetries: 3
@@ -66,23 +66,23 @@ mission:
   #       value:
   #       units:
   #     event:
-  #       parentID: SBE37_SIM_02
+  #       parentID: PRE:SBE37_SIM_02
   #       eventID: STOP_AUTOSAMPLE
   #   preMissionSequence:
-  #     # - command: SBE37_SIM_02, set_resource(INTERVAL{3})
+  #     # - command: PRE:SBE37_SIM_02, set_resource(INTERVAL{3})
   #     #   onError: retry
-  #     # - command: SBE37_SIM_03, set_resource(INTERVAL{3})
+  #     # - command: PRE:SBE37_SIM_03, set_resource(INTERVAL{3})
   #     #   onError: retry
   #   missionSequence:
-  #     - command: SBE37_SIM_03, execute_resource(START_AUTOSAMPLE)
+  #     - command: PRE:SBE37_SIM_03, execute_resource(START_AUTOSAMPLE)
   #       onError: retry
   #     - command: wait(1)
   #       onError:
-  #     - command: SBE37_SIM_03, execute_resource(STOP_AUTOSAMPLE)
+  #     - command: PRE:SBE37_SIM_03, execute_resource(STOP_AUTOSAMPLE)
   #       onError: retry
   #   postMissionSequence:
-  #     # - command: SBE37_SIM_02, execute_agent(RESET)
+  #     # - command: PRE:SBE37_SIM_02, execute_agent(RESET)
   #     #   onError: retry
-  #     # - command: SBE37_SIM_03, execute_agent(RESET)
+  #     # - command: PRE:SBE37_SIM_03, execute_agent(RESET)
   #     #   onError: retry
 

--- a/ion/agents/platform/test/mission_RSN_simulator_abort.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator_abort.yml
@@ -14,7 +14,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [SBE37_SIM_02]
+    instrumentID: ['PRE:SBE37_SIM_02']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -29,18 +29,18 @@ mission:
         parentID: 
         eventID: 
     preMissionSequence:
-      - command: SBE37_SIM_02, set_resource(INTERVAL{3})
+      - command: PRE:SBE37_SIM_02, set_resource(INTERVAL{3})
         onError: retry
     missionSequence:
-      - command: SBE37_SIM_02, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_02, execute_agent(RESET)
         onError: retry
         # The following command is not allowed in UNINITIALIZED state
-      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
         onError: abort
       - command: wait(0.2)
         onError:
-      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
         onError: retry
     postMissionSequence:
-      - command: SBE37_SIM_02, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_02, execute_agent(RESET)
         onError: retry

--- a/ion/agents/platform/test/mission_RSN_simulator_event.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator_event.yml
@@ -15,7 +15,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [SBE37_SIM_02]
+    instrumentID: ['PRE:SBE37_SIM_02']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -30,21 +30,21 @@ mission:
         parentID: 
         eventID: 
     preMissionSequence:
-      - command: SBE37_SIM_02, set_resource(INTERVAL{3})
+      - command: PRE:SBE37_SIM_02, set_resource(INTERVAL{3})
         onError: retry
     missionSequence:
-      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
         onError: retry
       - command: wait(0.2)
         onError:
-      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
         onError: retry
     postMissionSequence:
-      - command: SBE37_SIM_02, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_02, execute_agent(RESET)
         onError: retry
 
   - missionThread:
-    instrumentID: [SBE37_SIM_03]
+    instrumentID: ['PRE:SBE37_SIM_03']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -56,11 +56,11 @@ mission:
         value:
         units:
       event:
-        parentID: SBE37_SIM_02
+        parentID: PRE:SBE37_SIM_02
         eventID: STOP_AUTOSAMPLE
     preMissionSequence:
-      - command: SBE37_SIM_03, set_resource(INTERVAL{1})
+      - command: PRE:SBE37_SIM_03, set_resource(INTERVAL{1})
         onError: retry
     missionSequence:
-      - command: SBE37_SIM_03, execute_resource(ACQUIRE_SAMPLE)
+      - command: PRE:SBE37_SIM_03, execute_resource(ACQUIRE_SAMPLE)
         onError: retry

--- a/ion/agents/platform/test/mission_RSN_simulator_multiple_threads.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator_multiple_threads.yml
@@ -44,7 +44,7 @@ mission:
         onError: retry
 
   - missionThread:
-    instrumentID: ['SBE37_SIM_03']
+    instrumentID: ['PRE:SBE37_SIM_03']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -59,15 +59,15 @@ mission:
         parentID: 
         eventID: 
     preMissionSequence:
-      - command: SBE37_SIM_03, set_resource(INTERVAL{1})
+      - command: PRE:SBE37_SIM_03, set_resource(INTERVAL{1})
         onError: retry
     missionSequence:
-      - command: SBE37_SIM_03, execute_resource(START_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_03, execute_resource(START_AUTOSAMPLE)
         onError: retry
       - command: wait(0.2)
         onError:
-      - command: SBE37_SIM_03, execute_resource(STOP_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_03, execute_resource(STOP_AUTOSAMPLE)
         onError: retry
     postMissionSequence:
-      - command: SBE37_SIM_03, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_03, execute_agent(RESET)
         onError: retry

--- a/ion/agents/platform/test/mission_RSN_simulator_multiple_threads.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator_multiple_threads.yml
@@ -15,7 +15,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [SBE37_SIM_02]
+    instrumentID: ['PRE:SBE37_SIM_02']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -30,21 +30,21 @@ mission:
         parentID: 
         eventID: 
     preMissionSequence:
-      - command: SBE37_SIM_02, set_resource(INTERVAL{1})
+      - command: PRE:SBE37_SIM_02, set_resource(INTERVAL{1})
         onError: retry
     missionSequence:
-      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
         onError: retry
       - command: wait(0.2)
         onError:
-      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
         onError: retry
     postMissionSequence:
-      - command: SBE37_SIM_02, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_02, execute_agent(RESET)
         onError: retry
 
   - missionThread:
-    instrumentID: [SBE37_SIM_03]
+    instrumentID: ['SBE37_SIM_03']
     errorHandling:
       default: retry
       maxRetries: 3

--- a/ion/agents/platform/test/mission_RSN_simulator_ports.yml
+++ b/ion/agents/platform/test/mission_RSN_simulator_ports.yml
@@ -14,7 +14,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [LJ01D, SBE37_SIM_02]
+    instrumentID: [LJ01D, 'PRE:SBE37_SIM_02']
     errorHandling:
       default: retry
       maxRetries: 3
@@ -31,17 +31,17 @@ mission:
     preMissionSequence:
       - command: LJ01D, execute_resource(TURN_ON_PORT{1})
         onError: abort
-      - command: SBE37_SIM_02, set_resource(INTERVAL{3})
+      - command: PRE:SBE37_SIM_02, set_resource(INTERVAL{3})
         onError: retry
     missionSequence:
-      - command: SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(START_AUTOSAMPLE)
         onError: retry
       - command: wait(0.2)
         onError:
-      - command: SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
+      - command: PRE:SBE37_SIM_02, execute_resource(STOP_AUTOSAMPLE)
         onError: retry
     postMissionSequence:
-      - command: SBE37_SIM_02, execute_agent(RESET)
+      - command: PRE:SBE37_SIM_02, execute_agent(RESET)
         onError: retry
       - command: LJ01D, execute_resource(TURN_OFF_PORT{1})
         onError: retry

--- a/ion/agents/platform/test/multi_mission_1.yml
+++ b/ion/agents/platform/test/multi_mission_1.yml
@@ -11,7 +11,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [SBE37_SIM_02]
+    instrumentID: ['PRE:SBE37_SIM_02']
     errorHandling:
       default: retry
       maxRetries: 1

--- a/ion/agents/platform/test/multi_mission_2.yml
+++ b/ion/agents/platform/test/multi_mission_2.yml
@@ -11,7 +11,7 @@ platform:
 
 mission:
   - missionThread:
-    instrumentID: [SBE37_SIM_03]
+    instrumentID: ['PRE:SBE37_SIM_03']
     errorHandling:
       default: retry
       maxRetries: 1

--- a/ion/agents/platform/test/test_mission_manager.py
+++ b/ion/agents/platform/test/test_mission_manager.py
@@ -84,18 +84,8 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
         log.debug('[mm] _run_mission mission_id=%s: RUN_MISSION return: %s', mission_id, retval)
 
     def _get_processed_yml(self, instr_keys, mission_filename):
-        # TODO determine appropriate instrument identification mechanism as the
-        # instrument keys (like SBE37_SIM_02) are basically only known in
-        # the scope of the tests. In the following, we transform the mission
-        # file so the instrument keys are replaced by the corresponding
-        # instrument_device_id's:
         with open(mission_filename) as f:
             mission_yml = f.read()
-        for instr_key in instr_keys:
-            i_obj = self._get_instrument(instr_key)
-            resource_id = i_obj.instrument_device_id
-            log.debug('[mm] replacing %s to %s', instr_key, resource_id)
-            mission_yml = mission_yml.replace(instr_key, resource_id)
         log.debug('[mm] mission_yml=%s', mission_yml)
         return mission_yml
 

--- a/ion/services/sa/instrument/agent_configuration_builder.py
+++ b/ion/services/sa/instrument/agent_configuration_builder.py
@@ -123,7 +123,6 @@ class AgentConfigurationBuilder(object):
 
         for p in self._predicates_to_cache():
             self.RR2.clear_cached_predicate(p)
-            
 
     def _lookup_means(self):
         """
@@ -165,7 +164,6 @@ class AgentConfigurationBuilder(object):
         #check_keys([PRED.hasAgentInstance, PRED.hasModel, PRED.hasAgentDefinition])
         check_keys([PRED.hasAgentInstance, PRED.hasAgentDefinition])
         assert RT.ProcessDefinition in self.associated_objects
-
 
     def set_agent_instance_object(self, agent_instance_obj):
         """
@@ -265,7 +263,6 @@ class AgentConfigurationBuilder(object):
 
         return result
 
-
     def _generate_stream_config(self):
         log.debug("_generate_stream_config for %s", self.agent_instance_obj.name)
         dsm = self.clients.dataset_management
@@ -349,6 +346,8 @@ class AgentConfigurationBuilder(object):
         if self.agent_instance_obj.saved_agent_state:
             agent_config["prior_state"] = self.agent_instance_obj.saved_agent_state
 
+        agent_config['alt_ids'] = self.agent_instance_obj.alt_ids
+
         return agent_config
 
     def _generate_alerts_config(self):
@@ -392,7 +391,6 @@ class AgentConfigurationBuilder(object):
 
         return agent_config
 
-
     def _summarize_children(self, config_dict):
         ret = dict([(v['instance_name'], self._summarize_children(v))
                                 for k, v in config_dict["children"].iteritems()])
@@ -435,7 +433,6 @@ class AgentConfigurationBuilder(object):
         self.generated_config = True
 
         return agent_config
-
 
     def record_launch_parameters(self, agent_config):
         """
@@ -614,7 +611,6 @@ class AgentConfigurationBuilder(object):
                          product_id, device_obj.name, device_obj._id)
 
         self.associated_objects = ret
-
 
     def _get_device(self):
         self._check_associations()


### PR DESCRIPTION
@edwardhunter / @bobfrat please review 

worth noting:
- For integration test purposes, according to our keys for the SBE simulators,  I'm using alt_ids of the form "PRE:SBE_", that is, using the prefix "PRE:" (as suggested to appear in real alt_ids).  The suffix can be anything but I'm using the same SBE37_ just to easily correlate visually in the logs.
- All YAML files that we are testing at the moment haven been updated. Note that per YAML syntax rules, it's  necessary to enclose those IDs (because of the colon) in quotes in some places.
- Those YAML files are now loaded as given (no more replacement to resource ids)
- Focus now is on the integration tests -- nothing yet done on ion_loader or similar
- all tests completing OK

Please review.
