### PR TITLE
additional platform agent tests to check robustness

### DIFF
--- a/ion/agents/platform/mission_manager.py
+++ b/ion/agents/platform/mission_manager.py
@@ -11,7 +11,6 @@
 __author__ = 'Carlos Rueda'
 
 
-
 from pyon.public import log
 import logging
 from ion.agents.mission_executive import MissionLoader
@@ -168,6 +167,11 @@ class MissionManager(object):
 
     def _create_mission_scheduler(self, mission_id, mission_yml):
         """
+        - loads the mission
+        - verifies instruments associated
+        - gets exclusive access to those instruments
+        - creates MissionScheduler
+
         @param mission_id
         @param mission_yml
 
@@ -242,7 +246,7 @@ class MissionManager(object):
                 for instrument_id in instrument_ids_ok:
                     resource_id = instrument_objs[instrument_id].resource_id
                     try:
-                        self._remove_exclusive_access(resource_id, mission_id)
+                        self._remove_exclusive_access(instrument_id, resource_id, mission_id)
                     except Exception as ex:
                         # just log warning an continue
                         log.warn('%r: [xa] exception while reverting exclusive access to resource_id=%r, '

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -2315,10 +2315,9 @@ class PlatformAgent(ResourceAgent):
                 children were processed OK.
         """
 
-        expected_state = None
         children_with_errors = self._instruments_execute_agent(
             command=DriverEvent.START_AUTOSAMPLE,
-            expected_state=expected_state)
+            expected_state=ResourceAgentState.STREAMING)
 
         return children_with_errors
 

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -1044,7 +1044,7 @@ class PlatformAgent(ResourceAgent):
 
         if log.isEnabledFor(logging.TRACE):  # pragma: no cover
             if not child_resource_id in self._ia_clients and \
-               not child_resource_id in self._ia_clients:
+               not child_resource_id in self._pa_clients:
                 log.trace("%r: OOIION-1077 _child_running: %r is not a direct child",
                           self._platform_id, child_resource_id)
 

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -255,9 +255,9 @@ class PlatformAgent(ResourceAgent):
         # appropriate mechanism to guarantee patched values are seen.
         #
         cfg_timeout = self.CFG.get_safe("endpoint.receive.timeout", 0)
-        log.info("=== %r: CFG.endpoint.receive.timeout = %s", platform_id, cfg_timeout)
+        log.info("%r: === CFG.endpoint.receive.timeout = %s", platform_id, cfg_timeout)
         if cfg_timeout < 180:
-            log.warn("!!! %r: CFG.endpoint.receive.timeout=%s < 180. "
+            log.warn("%r: !!! CFG.endpoint.receive.timeout=%s < 180. "
                      "You may want to review your pyon{.local}.yml, @patch.dict, "
                      "etc. or adjust the code in this method as appropriate. "
                      "For now, will use 180 based on previous testing.",
@@ -286,7 +286,7 @@ class PlatformAgent(ResourceAgent):
           separate greenlet).
         """
         super(PlatformAgent, self).on_start()
-        log.info('platform agent is running: on_start called.')
+        log.info('%r: platform agent is running: on_start called.', self._platform_id)
 
         # Set up alert manager.
         self._aam = PlatformAgentAlertManager(self)
@@ -345,11 +345,11 @@ class PlatformAgent(ResourceAgent):
 
         self._driver_config = self.CFG.get('driver_config', None)
         if None is self._driver_config:
-            msg = "'driver_config' key not in configuration"
+            msg = "%r: 'driver_config' key not in configuration" % self._platform_id
             log.error(msg)
             raise PlatformConfigurationException(msg=msg)
 
-        log.debug("driver_config: %s", self._driver_config)
+        log.debug("%r: driver_config: %s", self._platform_id, self._driver_config)
 
         for k in ['dvr_mod', 'dvr_cls']:
             if not k in self._driver_config:
@@ -368,19 +368,20 @@ class PlatformAgent(ResourceAgent):
 
         # get PlatformNode corresponding to this agent:
         self._pnode = self._network_definition.pnodes[self._platform_id]
-        log.debug("PlatformAgent._validate_configuration: _pnode = %s", self._pnode)
+        log.debug("%r: _validate_configuration: _pnode = %s", self._platform_id, self._pnode)
 
         self._children_resource_ids = self._get_children_resource_ids()
 
         if 'ports' in self._driver_config:
             # Remove this device from the ports information, the driver does not use this
             platform_port = self._driver_config['ports'].pop(self.resource_id, None)
-            log.debug('_validate_configuration removed platform port info from ports config for driver.  dev_id:  %s   platform_port: %s', self.resource_id, platform_port)
+            log.debug('%r: _validate_configuration removed platform port info from ports config for driver.  '
+                      'dev_id:  %s   platform_port: %s', self._platform_id, self.resource_id, platform_port)
 
         ppid = self._plat_config.get('parent_platform_id', None)
         if ppid:
             self._parent_platform_id = ppid
-            log.debug("_parent_platform_id set to: %s", self._parent_platform_id)
+            log.debug("%r: _parent_platform_id set to: %s", self._platform_id, self._parent_platform_id)
 
         self._provider_id = self.CFG.get('provider_id', None)
         if self._provider_id is None:
@@ -574,7 +575,7 @@ class PlatformAgent(ResourceAgent):
         """
         Disconnects the driver.
         """
-        log.debug("%r: triggering driver event DISCONNECT")
+        log.debug("%r: triggering driver event DISCONNECT", self._platform_id)
         kwargs = dict(recursion=recursion)
         self._trigger_driver_event(PlatformDriverEvent.DISCONNECT, **kwargs)
 
@@ -603,7 +604,7 @@ class PlatformAgent(ResourceAgent):
         if self._plat_driver:
             # disconnect driver if connected:
             driver_state = self._plat_driver._fsm.get_current_state()
-            log.debug("_reset_this_platform: driver_state = %s", driver_state)
+            log.debug("%r: _reset_this_platform: driver_state = %s", self._platform_id, driver_state)
             if driver_state == PlatformDriverState.CONNECTED:
                 self._trigger_driver_event(PlatformDriverEvent.DISCONNECT)
             # destroy driver:
@@ -804,8 +805,8 @@ class PlatformAgent(ResourceAgent):
         driver_class  = self._driver_config['dvr_cls']
 
         if log.isEnabledFor(logging.DEBUG):
-            log.debug('%r: creating driver: driver_module=%s driver_class=%s' % (
-                self._platform_id, driver_module, driver_class))
+            log.debug('%r: creating driver: driver_module=%s driver_class=%s',
+                      self._platform_id, driver_module, driver_class)
 
         try:
             module = __import__(driver_module, fromlist=[driver_class])
@@ -822,8 +823,7 @@ class PlatformAgent(ResourceAgent):
 
         self._plat_driver = driver
 
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("%r: driver created: %s" % (self._platform_id, str(driver)))
+        log.debug("%r: driver created: %s", self._platform_id, driver)
 
     def _trigger_driver_event(self, event, **kwargs):
         """
@@ -836,22 +836,20 @@ class PlatformAgent(ResourceAgent):
         """
         Configures the platform driver object for this platform agent.
         """
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug('%r: configuring driver: %s' % (self._platform_id, self._driver_config))
+        log.debug('%r: configuring driver: %s', self._platform_id, self._driver_config)
 
         self._trigger_driver_event(PlatformDriverEvent.CONFIGURE, driver_config=self._driver_config)
 
         curr_state = self._plat_driver._fsm.get_current_state()
         if PlatformDriverState.DISCONNECTED != curr_state:
-            msg = "PlatformAgent._configure_driver: expected driver state to be %s but got %s" % (
-                  PlatformDriverState.DISCONNECTED, curr_state)
+            msg = "%r: _configure_driver: expected driver state to be %s but got %s" % (
+                  self._platform_id, PlatformDriverState.DISCONNECTED, curr_state)
             log.error(msg)
             raise PlatformDriverException(msg)
 
         self._resource_schema = self._plat_driver.get_config_metadata()
 
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("%r: driver configured." % self._platform_id)
+        log.debug("%r: driver configured.", self._platform_id)
 
     def _get_attribute_values(self, attrs):
         """
@@ -889,8 +887,7 @@ class PlatformAgent(ResourceAgent):
             return
 
         else:
-            log.warn('%r: driver_event not handled: %s',
-                     self._platform_id, str(type(driver_event)))
+            log.warn('%r: driver_event not handled: %s', self._platform_id, str(type(driver_event)))
             return
 
     def _async_driver_event_state_change(self, state):
@@ -1114,9 +1111,7 @@ class PlatformAgent(ResourceAgent):
         @param cmd        the command to execute
         @param sub_id     for logging
         """
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("%r: _execute_agent: cmd=%r %s=%r ...",
-                      self._platform_id, cmd.command, poi, sub_id)
+        log.debug("%r: _execute_agent: cmd=%r %s=%r ...", self._platform_id, cmd.command, poi, sub_id)
 
         time_start = time.time()
 
@@ -1125,7 +1120,7 @@ class PlatformAgent(ResourceAgent):
         elif DriverEvent.has(cmd.command) :
             retval = a_client.execute_resource(cmd, timeout=self._timeout)
         else:
-            log.error('_execute_agent invalid command: %s is not ResourceAgentEvent or DriverEvent', cmd)
+            log.error('%r: _execute_agent invalid command: %s is not ResourceAgentEvent or DriverEvent', self._platform_id, cmd)
 
         if log.isEnabledFor(logging.DEBUG):
             elapsed_time = time.time() - time_start
@@ -1146,13 +1141,11 @@ class PlatformAgent(ResourceAgent):
         """
         recursion = kwargs.get('recursion', None)
         if recursion is None:
-            log.info("%r: %s called with no recursion parameter. "
-                     "Using recursion=True by default.",
+            log.info("%r: %s called with no recursion parameter. Using recursion=True by default.",
                      self._platform_id, method_name)
             recursion = True
         else:
-            log.info("%r: %s called with recursion parameter: %r",
-                     self._platform_id, method_name, recursion)
+            log.info("%r: %s called with recursion parameter: %r", self._platform_id, method_name, recursion)
             recursion = bool(recursion)
 
         return recursion
@@ -1290,8 +1283,7 @@ class PlatformAgent(ResourceAgent):
             # TODO if any, what kind of state check should be done? For the
             # moment don't do any state verification.
             state = pa_client.get_agent_state()
-            log.debug("%r: [LL] sub-platform agent already running=%r, "
-                      "sub_resource_id=%s, state=%s",
+            log.debug("%r: [LL] sub-platform agent already running=%r, sub_resource_id=%s, state=%s",
                       self._platform_id, subplatform_id, sub_resource_id, state)
         else:
             #
@@ -1320,14 +1312,12 @@ class PlatformAgent(ResourceAgent):
             pa_client = self._create_resource_agent_client(subplatform_id, sub_resource_id)
 
             # wait until UNINITIALIZED:
-            log.debug("%r: [LL] Got pa_client for sub-platform agent %r. Waiting "
-                      "for UNINITIALIZED state...",
+            log.debug("%r: [LL] Got pa_client for sub-platform agent %r. Waiting for UNINITIALIZED state...",
                       self._platform_id, subplatform_id)
 
             self._await_state(asyn_res, subscriber)
 
-            log.debug("%r: [LL] ok, my sub-platform agent %r is now in "
-                      "UNINITIALIZED state",
+            log.debug("%r: [LL] ok, my sub-platform agent %r is now in UNINITIALIZED state",
                       self._platform_id, subplatform_id)
 
         # here, sub-platform agent process is running.
@@ -1404,9 +1394,7 @@ class PlatformAgent(ResourceAgent):
 
         try:
             retval = self._execute_platform_agent(dd.pa_client, cmd, subplatform_id)
-            if log.isEnabledFor(logging.DEBUG):
-                log.debug("%r: _initialize_subplatform %r  retval = %s",
-                          self._platform_id, subplatform_id, str(retval))
+            log.debug("%r: _initialize_subplatform %r  retval = %s", self._platform_id, subplatform_id, retval)
         except Exception as ex:
             err_msg = str(ex)
 
@@ -1441,8 +1429,7 @@ class PlatformAgent(ResourceAgent):
 
         @return dict with failing children. Empty if all ok.
         """
-        log.debug("%r: _subplatforms_initialize. _pa_clients=%s",
-                  self._platform_id, self._pa_clients)
+        log.debug("%r: _subplatforms_initialize. _pa_clients=%s", self._platform_id, self._pa_clients)
 
         subplatform_ids = self._pa_clients.keys()
         children_with_errors = {}
@@ -3300,7 +3287,7 @@ class PlatformAgent(ResourceAgent):
             next_state = PlatformAgentState.MONITORING
 
         except Exception:
-            log.exception("error in _start_resource_monitoring") #, exc_Info=True)
+            log.exception("%r: error in _start_resource_monitoring", self._platform_id) #, exc_Info=True)
             raise
 
         return (next_state, result)
@@ -3321,7 +3308,7 @@ class PlatformAgent(ResourceAgent):
             next_state = PlatformAgentState.COMMAND
 
         except Exception:
-            log.exception("error in _stop_resource_monitoring") #, exc_Info=True)
+            log.exception("%r: error in _stop_resource_monitoring", self._platform_id) #, exc_Info=True)
             raise
 
         return (next_state, result)
@@ -3336,8 +3323,7 @@ class PlatformAgent(ResourceAgent):
         and starts reconnection greenlet.
         """
         super(PlatformAgent, self)._common_state_enter(*args, **kwargs)
-        log.error("%r: (LC) lost connection to the device. Will attempt to reconnect...",
-                  self._platform_id)
+        log.error("%r: (LC) lost connection to the device. Will attempt to reconnect...", self._platform_id)
 
         self._event_publisher.publish_event(
             event_type='ResourceAgentConnectionLostErrorEvent',
@@ -3372,8 +3358,7 @@ class PlatformAgent(ResourceAgent):
 
     def _handler_lost_connection_autoreconnect(self, *args, **kwargs):
 
-        log.debug("%r: (LC) _handler_lost_connection_autoreconnect: trying CONNECT...",
-                  self._platform_id)
+        log.debug("%r: (LC) _handler_lost_connection_autoreconnect: trying CONNECT...", self._platform_id)
         try:
             driver_state = self._trigger_driver_event(PlatformDriverEvent.CONNECT)
 
@@ -3395,8 +3380,7 @@ class PlatformAgent(ResourceAgent):
 
         next_state = self._state_when_lost
 
-        log.debug("%r: (LC) _handler_lost_connection_autoreconnect: next_state=%s",
-                  self._platform_id, next_state)
+        log.debug("%r: (LC) _handler_lost_connection_autoreconnect: next_state=%s", self._platform_id, next_state)
 
         return next_state, None
 
@@ -3483,12 +3467,12 @@ class PlatformAgent(ResourceAgent):
         missions are executing, EXIT_MISSION is triggered to return to saved state.
         """
         time_start = time.time()
-        log.debug('[mm] _run_mission: running mission_id=%r ...', mission_id)
+        log.debug('%r: [mm] _run_mission: running mission_id=%r ...', self._platform_id, mission_id)
         self._mission_manager.run_mission(mission_id, mission_loader, mission_scheduler, instrument_objs)
 
         elapsed_time = time.time() - time_start
-        log.debug('[mm] _run_mission: completed mission_id=%s. elapsed_time=%s',
-                  mission_id, elapsed_time)
+        log.debug('%r: [mm] _run_mission: completed mission_id=%s. elapsed_time=%s',
+                  self._platform_id, mission_id, elapsed_time)
 
         remaining = self._mission_manager.get_number_of_running_missions()
         if remaining == 0:
@@ -3497,11 +3481,11 @@ class PlatformAgent(ResourceAgent):
             curr_state = self.get_agent_state()
             if curr_state in [PlatformAgentState.MISSION_COMMAND,
                               PlatformAgentState.MISSION_STREAMING]:
-                log.debug('[mm] _run_mission: triggering EXIT_MISSION')
+                log.debug('%r: [mm] _run_mission: triggering EXIT_MISSION', self._platform_id)
                 self._fsm.on_event(PlatformAgentEvent.EXIT_MISSION)
             else:
-                log.warn('[mm] _run_mission: not triggering EXIT_MISSION: FSM not in '
-                         'mission substate (%s)', curr_state)
+                log.warn('%r: [mm] _run_mission: not triggering EXIT_MISSION: FSM not in '
+                         'mission substate (%s)', self._platform_id, curr_state)
 
     def _handler_mission_run(self, *args, **kwargs):
         """
@@ -3603,7 +3587,7 @@ class PlatformAgent(ResourceAgent):
         actual processing during on_start.
         """
 
-        log.debug("%r: _configure_aparams: aparams=%s" % (self._platform_id, aparams))
+        log.debug("%r: _configure_aparams: aparams=%s", self._platform_id, aparams)
 
         self._configure_aparams_arg = None
 
@@ -3627,8 +3611,8 @@ class PlatformAgent(ResourceAgent):
 
         # If specified and configed, build the alerts aparam.
         aparam_alerts_config = self.CFG.get('aparam_alerts_config', None)
-        log.debug("%r: _configure_aparams: aparam_alerts_config=%s" % (
-                  self._platform_id, aparam_alerts_config))
+        log.debug("%r: _configure_aparams: aparam_alerts_config=%s",
+                  self._platform_id, aparam_alerts_config)
         if aparam_alerts_config and 'alerts' in aparams:
             self.aparam_set_alerts(aparam_alerts_config)
 
@@ -3636,7 +3620,7 @@ class PlatformAgent(ResourceAgent):
         """
         Restore agent/resource configuration and state.
         """
-        log.warn("%r: PlatformAgent._restore_resource not implemented yet" % self._platform_id)
+        log.warn("%r: PlatformAgent._restore_resource not implemented yet", self._platform_id)
 
     ##############################################################
     # Base class overrides for state and cmd error alerts.

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -2001,11 +2001,8 @@ class PlatformAgent(ResourceAgent):
 
             pid = self._launcher.launch_instrument(instrument_id, i_CFG)
 
-            log.debug("OOIION-1077 launched instrument:\n"
-                      " instrument_id = %r\n"
-                      " pid           = %r\n"
-                      " i_resource_id = %r",
-                      instrument_id, pid, i_resource_id)
+            log.debug("%r: OOIION-1077 launched instrument: instrument_id=%r pid=%r i_resource_id=%r",
+                      self._platform_id, instrument_id, pid, i_resource_id)
 
             ia_client = self._create_resource_agent_client(instrument_id, i_resource_id)
 

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -102,10 +102,8 @@ class PlatformAgent(ResourceAgent):
     Platform resource agent.
     """
 
-    # Override to publish specific types of events
-    COMMAND_EVENT_TYPE = "DeviceCommandEvent" #TODO how this works?
+    COMMAND_EVENT_TYPE = "DeviceCommandEvent"
 
-    # Override to set specific origin type
     ORIGIN_TYPE = "PlatformDevice"
 
     def __init__(self):

--- a/ion/agents/platform/platform_driver.py
+++ b/ion/agents/platform/platform_driver.py
@@ -447,7 +447,7 @@ class PlatformDriver(object):
         except PlatformDriverException as e:
             result = None
             next_state = None
-            log.error("Error in platform driver configuration", e)
+            log.error("%r: Error in platform driver configuration", self._platform_id, e)
 
         return next_state, result
 
@@ -611,7 +611,7 @@ class PlatformDriver(object):
         Subclasses can override to indicate specific parameters and add new
         handlers (typically for the CONNECTED state).
         """
-        log.debug("constructing base platform driver FSM")
+        log.debug("%r: constructing base platform driver FSM", self._platform_id)
 
         self._fsm = ThreadSafeFSM(states, events, enter_event, exit_event)
 

--- a/ion/agents/platform/status_manager.py
+++ b/ion/agents/platform/status_manager.py
@@ -540,8 +540,8 @@ class StatusManager(object):
                   self._platform_id, evt, evt.sub_type)
 
         if not sub_type in expected_subtypes:
-            log.error("StatusManager._got_device_status_event: Unexpected sub_type=%r. Expecting one of %r" 
-                      % (sub_type, expected_subtypes))
+            log.error("%r: _got_device_status_event: Unexpected sub_type=%r. Expecting one of %r",
+                      self._platform_id, sub_type, expected_subtypes)
             return
 
         with self._lock:

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -354,7 +354,6 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         This method captures the current value of CFG.endpoint.receive.timeout
         to be used in some operations provided by the class.
         """
-        from pyon.public import CFG
         self._receive_timeout = CFG.endpoint.receive.timeout
         log.info("self._receive_timeout = %s", self._receive_timeout)
 

--- a/ion/agents/platform/test/test_platform_agent_robustness.py
+++ b/ion/agents/platform/test/test_platform_agent_robustness.py
@@ -5,6 +5,7 @@
 __author__ = 'Carlos Rueda'
 
 # bin/nosetests -sv ion/agents/platform/test/test_platform_agent_robustness.py:TestPlatformRobustness.test_instrument_reset_externally
+# bin/nosetests -sv ion/agents/platform/test/test_platform_agent_robustness.py:TestPlatformRobustness.test_adverse_activation_sequence
 
 from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform, instruments_dict
 from pyon.public import log, CFG
@@ -31,12 +32,6 @@ class FakeProcess(LocalContextMixin):
 class TestPlatformRobustness(BaseIntTestPlatform):
 
     def _launch_network(self, p_root, recursion=True):
-        def start():
-            self._ping_agent()
-            self._initialize(recursion)
-            self._go_active(recursion)
-            self._run(recursion)
-
         def shutdown():
             try:
                 self._go_inactive(recursion)
@@ -47,16 +42,14 @@ class TestPlatformRobustness(BaseIntTestPlatform):
         self._start_platform(p_root)
         self.addCleanup(self._stop_platform, p_root)
         self.addCleanup(shutdown)
-        log.info('launching network')
-        start()
 
     def test_instrument_reset_externally(self):
         #
-        # A network of one platform with 2 instruments is launched and put in command state;
-        # then one of the instruments is directly reset here simulating some external situation;
-        # then the network is shutdown following regular sequence;
-        # The test should complete fine: the already reset child instrument should not
-        # cause issue during the reset sequence from parent platform agent.
+        # - a network of one platform with 2 instruments is launched and put in command state
+        # - one of the instruments is directly reset here simulating some external situation
+        # - network is shutdown following regular sequence
+        # - test should complete fine: the already reset child instrument should not
+        #   cause issue during the reset sequence from parent platform agent.
         #
         # During the shutdown sequence the following should be logged out by the platform prior to trying
         # the GO_INACTIVE command to the (already reset) instrument:
@@ -66,14 +59,21 @@ class TestPlatformRobustness(BaseIntTestPlatform):
         #       command='RESOURCE_AGENT_EVENT_GO_INACTIVE', comp=-1, actl=decr, acceptable_state=True
         #
         self._set_receive_timeout()
+        recursion = True
 
         instr_keys = ['SBE37_SIM_01', 'SBE37_SIM_02']
-
         p_root = self._set_up_single_platform_with_some_instruments(instr_keys)
-        self._launch_network(p_root)
+        self._launch_network(p_root, recursion)
 
         i_obj = self._get_instrument(instr_keys[0])
         ia_client = self._create_resource_agent_client(i_obj.instrument_device_id)
+
+        # command sequence:
+        self._ping_agent()
+        self._initialize(recursion)
+        self._go_active(recursion)
+        self._run(recursion)
+
         self.assertEqual(ia_client.get_agent_state(), ResourceAgentState.COMMAND)
 
         # reset the instrument
@@ -84,3 +84,72 @@ class TestPlatformRobustness(BaseIntTestPlatform):
         self.assertEqual(ia_client.get_agent_state(), ResourceAgentState.UNINITIALIZED)
 
         # and let the test complete with regular shutdown sequence.
+
+    def test_adverse_activation_sequence(self):
+        #
+        # - initialize network (so all agents get INITIALIZED)
+        # - externally reset an instrument (so that instrument gets to UNINITIALIZED)
+        # - activate network (so a "device_failed_command" event should be published because
+        #   instrument is not INITIALIZED)
+        # - verify publication of the "device_failed_command" event
+        # - similarly, "run" the network
+        # - verify publication of 2nd "device_failed_command" event
+        #
+        # note: the platform successfully completes the GO_ACTIVE and RUN commands even with the failed child;
+        # see https://confluence.oceanobservatories.org/display/CIDev/Platform+commands
+        #
+        self._set_receive_timeout()
+        recursion = True
+
+        instr_keys = ['SBE37_SIM_01']
+        p_root = self._set_up_single_platform_with_some_instruments(instr_keys)
+        self._launch_network(p_root, recursion)
+
+        i_obj = self._get_instrument(instr_keys[0])
+        ia_client = self._create_resource_agent_client(i_obj.instrument_device_id)
+
+        # initialize the network
+        self._ping_agent()
+        self._initialize(recursion)
+
+        self.assertEqual(ia_client.get_agent_state(), ResourceAgentState.INACTIVE)
+
+        # reset the instrument before we continue the activation of the network
+        log.debug("resetting instrument %r", instr_keys[0])
+        cmd = AgentCommand(command=ResourceAgentEvent.RESET)
+        retval = ia_client.execute_agent(cmd, timeout=self._receive_timeout)
+        log.debug("reset instrument %r returned: %s", instr_keys[0], retval)
+        self.assertEqual(ia_client.get_agent_state(), ResourceAgentState.UNINITIALIZED)
+
+        # prepare to receive "device_failed_command" event during GO_ACTIVE:
+        # (See StatusManager.publish_device_failed_command_event)
+        async_event_result, events_received = self._start_event_subscriber2(
+            count=1,
+            event_type="DeviceStatusEvent",
+            origin_type="PlatformDevice",
+            sub_type="device_failed_command"
+        )
+
+        # activate network:
+        self._go_active(recursion)
+
+        # verify publication of "device_failed_command" event
+        async_event_result.get(timeout=self._receive_timeout)
+        self.assertEquals(len(events_received), 1)
+        event_received = events_received[0]
+        log.info("DeviceStatusEvents received (%d): %s", len(events_received), event_received)
+        self.assertGreaterEqual(len(event_received.values), 1)
+        failed_resource_id = event_received.values[0]
+        self.assertEquals(i_obj.instrument_device_id, failed_resource_id)
+
+        # "run" network:
+        self._run(recursion)
+
+        # verify publication of 2nd "device_failed_command" event
+        async_event_result.get(timeout=self._receive_timeout)
+        self.assertEquals(len(events_received), 2)
+        event_received = events_received[1]
+        log.info("DeviceStatusEvents received (%d): %s", len(events_received), event_received)
+        self.assertGreaterEqual(len(event_received.values), 1)
+        failed_resource_id = event_received.values[0]
+        self.assertEquals(i_obj.instrument_device_id, failed_resource_id)

--- a/ion/agents/platform/test/test_platform_agent_robustness.py
+++ b/ion/agents/platform/test/test_platform_agent_robustness.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+"""Additional tests focused on robustness and destructive testing"""
+
+__author__ = 'Carlos Rueda'
+
+# bin/nosetests -sv ion/agents/platform/test/test_platform_agent_robustness.py:TestPlatformRobustness.test_instrument_reset_externally
+
+from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform, instruments_dict
+from pyon.public import log, CFG
+from pyon.util.context import LocalContextMixin
+from pyon.agent.agent import ResourceAgentState, ResourceAgentEvent
+from interface.objects import AgentCommand
+
+from mock import patch
+import unittest
+import os
+
+
+class FakeProcess(LocalContextMixin):
+    """
+    A fake process used because the test case is not an ion process.
+    """
+    name = ''
+    id=''
+    process_type = ''
+
+
+@patch.dict(CFG, {'endpoint': {'receive': {'timeout': 180}}})
+@unittest.skipIf((not os.getenv('PYCC_MODE', False)) and os.getenv('CEI_LAUNCH_TEST', False), 'Skip until tests support launch port agent configurations.')
+class TestPlatformRobustness(BaseIntTestPlatform):
+
+    def _launch_network(self, p_root, recursion=True):
+        def start():
+            self._ping_agent()
+            self._initialize(recursion)
+            self._go_active(recursion)
+            self._run(recursion)
+
+        def shutdown():
+            try:
+                self._go_inactive(recursion)
+                self._reset(recursion)
+            finally:  # attempt shutdown anyway
+                self._shutdown(True)  # NOTE: shutdown always with recursion=True
+
+        self._start_platform(p_root)
+        self.addCleanup(self._stop_platform, p_root)
+        self.addCleanup(shutdown)
+        log.info('launching network')
+        start()
+
+    def test_instrument_reset_externally(self):
+        #
+        # A network of one platform with 2 instruments is launched and put in command state;
+        # then one of the instruments is directly reset here simulating some external situation;
+        # then the network is shutdown following regular sequence;
+        # The test should complete fine: the already reset child instrument should not
+        # cause issue during the reset sequence from parent platform agent.
+        #
+        # During the shutdown sequence the following should be logged out by the platform prior to trying
+        # the GO_INACTIVE command to the (already reset) instrument:
+        # ion.agents.platform.platform_agent:2195 'LJ01D': instrument '8761366c8d734a4ba886606c3a47b621':
+        #       current_state='RESOURCE_AGENT_STATE_UNINITIALIZED'
+        #       expected_state='RESOURCE_AGENT_STATE_INACTIVE'
+        #       command='RESOURCE_AGENT_EVENT_GO_INACTIVE', comp=-1, actl=decr, acceptable_state=True
+        #
+        self._set_receive_timeout()
+
+        instr_keys = ['SBE37_SIM_01', 'SBE37_SIM_02']
+
+        p_root = self._set_up_single_platform_with_some_instruments(instr_keys)
+        self._launch_network(p_root)
+
+        i_obj = self._get_instrument(instr_keys[0])
+        ia_client = self._create_resource_agent_client(i_obj.instrument_device_id)
+        self.assertEqual(ia_client.get_agent_state(), ResourceAgentState.COMMAND)
+
+        # reset the instrument
+        log.debug("resetting instrument %r", instr_keys[0])
+        cmd = AgentCommand(command=ResourceAgentEvent.RESET)
+        retval = ia_client.execute_agent(cmd, timeout=self._receive_timeout)
+        log.debug("reset instrument %r returned: %s", instr_keys[0], retval)
+        self.assertEqual(ia_client.get_agent_state(), ResourceAgentState.UNINITIALIZED)
+
+        # and let the test complete with regular shutdown sequence.

--- a/ion/services/sa/observatory/test/test_platform_launch.py
+++ b/ion/services/sa/observatory/test/test_platform_launch.py
@@ -12,7 +12,6 @@ __author__ = 'Carlos Rueda, Maurice Manning, Ian Katz'
 # launch and shutdown of the various platforms in the hierarchy.
 #
 
-# developer conveniences:
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_platform
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_single_deployed_platform
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_hierarchy
@@ -28,7 +27,7 @@ __author__ = 'Carlos Rueda, Maurice Manning, Ian Katz'
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_13_platforms_and_8_instruments
 # bin/nosetests -sv ion/services/sa/observatory/test/test_platform_launch.py:TestPlatformLaunch.test_platform_device_extended_attributes
 
-from unittest import skip
+from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform, instruments_dict
 from mock import patch
 import gevent
 import unittest
@@ -38,7 +37,6 @@ from pyon.agent.agent import ResourceAgentState
 from pyon.util.context import LocalContextMixin
 from pyon.public import log, CFG, RT
 from ion.services.sa.test.helpers import any_old
-from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform, instruments_dict
 
 from interface.objects import ComputedIntValue, ComputedValueAvailability, ComputedListValue, ComputedDictValue
 from interface.objects import AggregateStatusType, DeviceStatusType
@@ -382,7 +380,6 @@ class TestPlatformLaunch(BaseIntTestPlatform):
 
         self._run_startup_commands()
 
-    @skip("Runs fine but waiting for comments to enable in general")
     @patch.dict(CFG, {'endpoint': {'receive': {'timeout': 420}}})
     def test_13_platforms_and_8_instruments(self):
         #


### PR DESCRIPTION
@edwardhunter please review/merge

Noteworthy:
- re-enabled test of launching network of 13 platforms and 8 instruments (in test_platform_launch.py)
- new test_platform_agent_robustness.py with tests exercising adverse sequences (instrument reset externally; activation/deactivation and reception of device_failed_command events; combination of agents put into streaming; instrument terminated externally and graceful handling by platform)
- more strict verification of expected mission events (not only verifying the expected number but also the contents of such events)

@bobfrat FYI 
