### PR TITLE
OOIION-1728: fix array initialization in construction of deployment extension resource

### DIFF
--- a/ion/services/sa/observatory/observatory_management_service.py
+++ b/ion/services/sa/observatory/observatory_management_service.py
@@ -1421,7 +1421,7 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
                     platform_device_ids.add(a.o)
 
         # get sites (portals)
-        extended_deployment.computed.portals = ComputedListValue(status=ComputedValueAvailability.PROVIDED, value=[extended_deployment.site])
+        extended_deployment.computed.portals = ComputedListValue(status=ComputedValueAvailability.PROVIDED, value=[])
         subsite_ids = set()
         device_by_site = { extended_deployment.site._id: extended_deployment.device._id }
         for did in platform_device_ids:
@@ -1466,10 +1466,10 @@ class ObservatoryManagementService(BaseObservatoryManagementService):
 
         extended_deployment.instrument_models = [ model_by_id[model_id_by_device[d._id]] for d in extended_deployment.instrument_devices ]
         extended_deployment.platform_models = [ model_by_id[model_id_by_device[d._id]] for d in extended_deployment.platform_devices ]
-        extended_deployment.portal_instruments = [ device_by_id[device_by_site[p._id]]
-                                                   if p._id in device_by_site and device_by_site[p._id] in device_by_id
-                                                   else None
-                                                   for p in extended_deployment.computed.portals.value ]
+        for p in extended_deployment.computed.portals.value:
+            if p._id in device_by_site and device_by_site[p._id] in device_by_id:
+                extended_deployment.portal_instruments.append( device_by_id[device_by_site[p._id]] )
+
 
         # TODO -- all status values
         #

--- a/ion/services/sa/observatory/test/test_deployment.py
+++ b/ion/services/sa/observatory/test/test_deployment.py
@@ -343,6 +343,12 @@ class TestDeployment(IonIntegrationTestCase):
         deployment_obj = self.RR2.read(res.deployment_id)
         self.assertEquals(deployment_obj.lcstate, LCS.DEPLOYED)
 
+        extended_deployment = self.omsclient.get_deployment_extension(res.deployment_id)
+        # two sites in this test
+        self.assertEquals(len(extended_deployment.computed.portals.value), 2)
+        # only one portal instrument
+        self.assertEquals(len(extended_deployment.portal_instruments), 1)
+
         log.debug("deactivatin deployment, expecting success")
         self.omsclient.deactivate_deployment(res.deployment_id)
 


### PR DESCRIPTION
fix array initialization in construction of deployment extension resource, add test to verify that there are no duplicates in lists.

@mmisinger please review
@wbollenbacher please review
