### PR TITLE
Platform agent: propagate streaming cmd to sub-platforms and/or insteumentss according to recursion parameter

### DIFF
--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -1636,7 +1636,10 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         retval = self._execute_agent(cmd)
         self._assert_state(PlatformAgentState.COMMAND)
 
-    def _start_resource_monitoring(self, recursion=True):
+    def _start_resource_monitoring(self, recursion=3):
+        """
+        @param recursion by default 3 to propagate to both sub-platforms and instruments
+        """
         kwargs = dict(recursion=recursion)
         cmd = AgentCommand(command=PlatformAgentEvent.START_MONITORING, kwargs=kwargs)
         retval = self._execute_agent(cmd)
@@ -1649,7 +1652,10 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
         self.assertTrue(len(self._samples_received) >= 1)
         log.info("Received samples: %s", len(self._samples_received))
 
-    def _stop_resource_monitoring(self, recursion=True):
+    def _stop_resource_monitoring(self, recursion=3):
+        """
+        @param recursion by default 3 to propagate to both sub-platforms and instruments
+        """
         kwargs = dict(recursion=recursion)
         cmd = AgentCommand(command=PlatformAgentEvent.STOP_MONITORING, kwargs=kwargs)
         retval = self._execute_agent(cmd)

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -1559,6 +1559,9 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
     def _assert_state(self, state):
         self.assertEquals(self._get_state(), state)
 
+    def _assert_agent_client_state(self, a_client, state):
+        self.assertEqual(state, a_client.get_agent_state())
+
     def _execute_agent(self, cmd):
         log.info("_execute_agent: cmd=%r kwargs=%r; timeout=%s ...",
                  cmd.command, cmd.kwargs, self._receive_timeout)

--- a/ion/agents/platform/test/test_platform_agent_robustness.py
+++ b/ion/agents/platform/test/test_platform_agent_robustness.py
@@ -106,9 +106,6 @@ class TestPlatformRobustness(BaseIntTestPlatform):
         if expected_state:
             self.assertEqual(expected_state, ia_client.get_agent_state())
 
-    def _assert_agent_client_state(self, a_client, state):
-        self.assertEqual(state, a_client.get_agent_state())
-
     ###################
     # tests
     ###################


### PR DESCRIPTION
As agreed today, added logic to allow the START_MONITORING/STREAMING to get propagated or not to sub-platforms and/or instruments depending on the recursion parameter.  The default behaviour continues to be propagation to both instruments and sub-platforms.

Test test_resource_monitoring_recursion_parameter included to exercise the 4 possible values for the recursion parameter: 0 = no propagation at all; 1 = only propagate to instruments; 2 = only propagate to sub-platforms; 3 = propagate to both instrs and sub-plats.

@edwardhunter please review/merge

@bobfrat fyi
