### PR TITLE
Fix leaked processes in some platform agent tests

### DIFF
--- a/ion/agents/platform/test/test_mission_manager.py
+++ b/ion/agents/platform/test/test_mission_manager.py
@@ -3,11 +3,11 @@
 """
 @package ion.agents.platform.test.test_mission_manager
 @file    ion/agents/platform/test/test_mission_manager.py
-@author  Carlos Rueda
+@author  Carlos Rueda, Bob Fratantonio
 @brief   Test cases for platform agent integrated with mission scheduler
 """
 
-__author__ = 'Carlos Rueda'
+__author__ = 'Carlos Rueda, Bob Fratantonio'
 
 
 # bin/nosetests -sv --nologcapture ion/agents/platform/test/test_mission_manager.py:TestPlatformAgentMission.test_simple_mission_command_state
@@ -480,7 +480,7 @@ class TestPlatformAgentMission(BaseIntTestPlatform):
         #
         # Shallow profiler mission example from mock profiler
         # Mission plan to be started in COMMAND state.
-        # Should receive 9 events from mission executive if successful
+        # Should receive 12 events from mission executive if successful
         #
         expected_events = [
             {'sub_type': 'STARTING', 'mission_thread_id': '',  'execution_status': MissionExecutionStatus.OK},

--- a/ion/agents/platform/test/test_platform_agent_robustness.py
+++ b/ion/agents/platform/test/test_platform_agent_robustness.py
@@ -372,4 +372,4 @@ class TestPlatformRobustness(BaseIntTestPlatform):
             try:
                 self.IMS.stop_platform_agent_instance(o_obj.platform_agent_instance_id)
             except Exception as ex:
-                log.warn("Error while trying IMS.stop_platform_agent_instance(%r)", o_obj.platform_device_id, ex)
+                log.warn("Error while trying IMS.stop_platform_agent_instance(%r)", o_obj.platform_agent_instance_id, ex)

--- a/ion/agents/platform/test/test_platform_agent_robustness.py
+++ b/ion/agents/platform/test/test_platform_agent_robustness.py
@@ -329,17 +329,8 @@ class TestPlatformRobustness(BaseIntTestPlatform):
         # - TERMINATED lifecycle event from sub-platform when stopped should be published
         # - shutdown sequence of the test should complete without issues.
         #
-        # NOTE: However, there will be two leaked processes corresponding to the orphaned
-        # sub-platforms of LV01B:
-        #
-        # Process leak report
-        # Test                                                                       Leaked Processes
-        # ========================================================================== ==================================================================
-        # TestPlatformRobustness.test_with_intermediate_subplatform_directly_stopped
-        #                                                                            ('PlatformAgent_LJ01B1e97fe2656984d41ac58c5ce75f31208', 'RUNNING')
-        #                                                                            ('PlatformAgent_MJ01Bdf3ffb7e10ed4e649bdc437a14b5fc9f', 'RUNNING')
-        #
-        # TODO: determine how to handle this case.
+        # NOTE: we explicitly stop the processes corresponding to the orphaned
+        # sub-platforms of LV01B (LJ01B and MJ01B), so they don't get reported as leaked.
         #
         self._set_receive_timeout()
         recursion = True
@@ -372,3 +363,13 @@ class TestPlatformRobustness(BaseIntTestPlatform):
         log.info("ProcessLifecycleEvent received: %s", event_received)
         self.assertEquals(platform_pid, event_received.origin)
         self.assertEquals(ProcessStateEnum.TERMINATED, event_received.state)
+
+        # we know there would be two orphaned processes (corresponding to the sub-platforms of LV01B),
+        # so, explicitly stop them here:
+        for orphaned in ['LJ01B', 'MJ01B']:
+            o_obj = self._get_platform(orphaned)
+            log.info("stopping orphaned sub-platform %r platform_agent_instance_id=%r", orphaned, o_obj.platform_agent_instance_id)
+            try:
+                self.IMS.stop_platform_agent_instance(o_obj.platform_agent_instance_id)
+            except Exception as ex:
+                log.warn("Error while trying IMS.stop_platform_agent_instance(%r)", o_obj.platform_device_id, ex)

--- a/ion/agents/platform/test/test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/test_platform_agent_with_rsn.py
@@ -124,8 +124,6 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self.addCleanup(done)
 
     def _turn_on_port(self, port_id=None):
-        # TODO real settings and corresp verification
-
         src = self.__class__.__name__
         port_id = port_id or self.PORT_ID
         kwargs = dict(port_id=port_id, src=src)
@@ -137,8 +135,6 @@ class TestPlatformAgent(BaseIntTestPlatform):
         self.assertEquals(result[port_id], NormalResponse.PORT_TURNED_ON)
 
     def _turn_off_port(self, port_id=None):
-        # TODO real settings and corresp verification
-
         src = self.__class__.__name__
         port_id = port_id or self.PORT_ID
         kwargs = dict(port_id=port_id, src=src)


### PR DESCRIPTION
Fixed leaked processes recently introduced in platform agent tests (last observed in http://buildbot.oceanobservatories.org:8010/builders/coi_pycc/builds/2257/steps/sa/logs/stdio):
- TestPlatformAgent.test_resource_monitoring_recursion_parameter
- TestPlatformRobustness.test_with_intermediate_subplatform_directly_stopped

@edwardhunter please merge

@bobfrat fyi
