### PR TITLE
Fix ooiion 1991: platform agents do not re-validate resurrected descendent child agent

### DIFF
--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -1002,8 +1002,8 @@ class PlatformAgent(ResourceAgent):
 
     def _child_running(self, child_resource_id):
         """
-        Called by StatusManager upon the reception of any regular status
-        event from a child as an indication that the child is running.
+        Called by StatusManager upon the reception of some event indicating that
+        a child is running.
         Here we "revalidate" the child in case it was invalidated.
         This is done in a separate greenlet to return quikcly to the event
         handler in the status manager. The greenlet does a number of attempts
@@ -1014,7 +1014,7 @@ class PlatformAgent(ResourceAgent):
 
         @param child_resource_id
         """
-
+        log.debug("%r: [rvc] _child_running: %r", self._platform_id, child_resource_id)
         with self._children_being_validated_lock:
             if child_resource_id in self._children_being_validated:
                 return
@@ -1048,6 +1048,9 @@ class PlatformAgent(ResourceAgent):
         # TODO synchronize access to self._ia_clients or self._pa_clients in
         # general.
         #
+
+        log.debug("%r: [rvc] _validate_child_greenlet: %r  is_instrument=%r",
+                  self._platform_id, child_resource_id, is_instrument)
         max_attempts = 12
         attempt_period = 5   # so 12 x 5 = 60 secs max attempt time
 
@@ -1772,6 +1775,7 @@ class PlatformAgent(ResourceAgent):
         @return dict with children having caused some error. Empty if all
                 children were processed OK.
         """
+        log.debug("%r: _subplatforms_shutdown_and_terminate: pa_clients=%s", self._platform_id, self._pa_clients)
         subplatform_ids = self._pa_clients.keys()
 
         children_with_errors = {}

--- a/ion/agents/platform/platform_agent.py
+++ b/ion/agents/platform/platform_agent.py
@@ -139,19 +139,12 @@ class PlatformAgent(ResourceAgent):
         # PlatformResourceMonitor
         self._platform_resource_monitor = None
 
-        # _pa_clients: {subplatform_id: DotDict(ra_client=ResourceAgentClient, ...), ...}
+        # _ra_clients: {resource_id: DotDict(ra_client=ResourceAgentClient, ...), ...}
         # (ra_client entry will be _INVALIDATED_CHILD when that child is invalidated).
-        # *NOTE*: the index here is actually the resource_id of the platform agent,
-        # but the code variables used to index this dict are often named "subplatform_id".
-        self._pa_clients = {}
+        self._ra_clients = {}
 
         # see on_init
         self._launcher = None
-
-        # _ia_clients: {instrument_id: DotDict(ra_client=ResourceAgentClient, ...), ...}
-        # (ra_client entry will be _INVALIDATED_CHILD when that child is invalidated).
-        # *NOTE*: instrument_id here is the resource_id of the instrument agent.
-        self._ia_clients = {}
 
         # self.CFG.endpoint.receive.timeout -- see on_init
         self._timeout = None
@@ -965,23 +958,19 @@ class PlatformAgent(ResourceAgent):
 
         return a_client
 
-    def _invalidate_instrument_child(self, child_resource_id):
-        self._ia_clients[child_resource_id]['ra_client'] = _INVALIDATED_CHILD
+    def _invalidate_child(self, child_resource_id):
+        self._ra_clients[child_resource_id]['ra_client'] = _INVALIDATED_CHILD
 
-    def _invalidate_platform_child(self, child_resource_id):
-        self._pa_clients[child_resource_id]['ra_client'] = _INVALIDATED_CHILD
-
-    def _is_invalid_instrument_child(self, child_resource_id):
-        return self._ia_clients[child_resource_id]['ra_client'] == _INVALIDATED_CHILD
-
-    def _is_invalid_platform_child(self, child_resource_id):
-        return self._pa_clients[child_resource_id]['ra_client'] == _INVALIDATED_CHILD
+    def _is_invalid_child(self, child_resource_id):
+        return self._ra_clients[child_resource_id]['ra_client'] == _INVALIDATED_CHILD
 
     def _get_valid_instrument_clients(self):
-        return dict((k, v) for k, v in self._ia_clients.iteritems() if v['ra_client'] != _INVALIDATED_CHILD)
+        return dict((k, v) for k, v in self._ra_clients.iteritems()
+                    if 'instrument_id' in v and v['ra_client'] != _INVALIDATED_CHILD)
 
     def _get_valid_platform_clients(self):
-        return dict((k, v) for k, v in self._pa_clients.iteritems() if v['ra_client'] != _INVALIDATED_CHILD)
+        return dict((k, v) for k, v in self._ra_clients.iteritems()
+                    if 'platform_id' in v and v['ra_client'] != _INVALIDATED_CHILD)
 
     def _child_terminated(self, child_resource_id):
         """
@@ -991,16 +980,12 @@ class PlatformAgent(ResourceAgent):
 
         @param child_resource_id
         """
-        if child_resource_id in self._ia_clients:
-            self._invalidate_instrument_child(child_resource_id)
-            log.debug("%r: OOIION-1077 _child_terminated: instrument: %r",
-                      self._platform_id, child_resource_id)
-            return
-
-        if child_resource_id in self._pa_clients:
-            self._invalidate_platform_child(child_resource_id)
-            log.debug("%r: OOIION-1077 _child_terminated: sub-platform: %r",
-                      self._platform_id, child_resource_id)
+        if child_resource_id in self._ra_clients:
+            self._invalidate_child(child_resource_id)
+            if log.isEnabledFor(logging.DEBUG):
+                kind = 'sub-platform' if 'platform_id' in self._ra_clients[child_resource_id] else 'instrument'
+                log.debug("%r: OOIION-1077 _child_terminated: %s: %r",
+                          self._platform_id, kind, child_resource_id)
             return
 
         log.trace("%r: OOIION-1077 _child_terminated: %r is not a direct child",
@@ -1013,9 +998,7 @@ class PlatformAgent(ResourceAgent):
         notified by the status manager as terminated and that
         have not been revalidated.
         """
-        res      = [i_id for i_id in self._ia_clients if self._is_invalid_instrument_child(i_id)]
-        res.extend([p_id for p_id in self._pa_clients if self._is_invalid_platform_child(p_id)])
-        return res
+        return [i_id for i_id in self._ra_clients if self._is_invalid_child(i_id)]
 
     def _child_running(self, child_resource_id):
         """
@@ -1036,42 +1019,30 @@ class PlatformAgent(ResourceAgent):
             if child_resource_id in self._children_being_validated:
                 return
 
-            if child_resource_id in self._ia_clients and self._is_invalid_instrument_child(child_resource_id):
-                self._children_being_validated.add(child_resource_id)
-                log.info("%r: OOIION-1077 starting _validate_child_greenlet for "
-                         "instrument: %r", self._platform_id, child_resource_id)
-                Greenlet.spawn(self._validate_child_greenlet, child_resource_id, True)
+            if child_resource_id in self._ra_clients:
+                if self._is_invalid_child(child_resource_id):
+                    self._children_being_validated.add(child_resource_id)
+                    log.info("%r: OOIION-1077 starting _validate_child_greenlet for %r",
+                             self._platform_id, child_resource_id)
+                    Greenlet.spawn(self._validate_child_greenlet, child_resource_id)
                 return
 
-            if child_resource_id in self._pa_clients and self._is_invalid_platform_child(child_resource_id):
-                self._children_being_validated.add(child_resource_id)
-                log.info("%r: OOIION-1077 starting _validate_child_greenlet for "
-                         "platform: %r", self._platform_id, child_resource_id)
-                Greenlet.spawn(self._validate_child_greenlet, child_resource_id, False)
-                return
-
-        if log.isEnabledFor(logging.TRACE):  # pragma: no cover
-            if not child_resource_id in self._ia_clients and \
-               not child_resource_id in self._pa_clients:
+            elif log.isEnabledFor(logging.TRACE):  # pragma: no cover
                 log.trace("%r: OOIION-1077 _child_running: %r is not a direct child",
                           self._platform_id, child_resource_id)
 
-    def _validate_child_greenlet(self, child_resource_id, is_instrument):
+    def _validate_child_greenlet(self, child_resource_id):
         #
-        # TODO synchronize access to self._ia_clients or self._pa_clients in
-        # general.
+        # TODO synchronize access to self._ra_clients in general.
         #
 
-        log.debug("%r: [rvc] _validate_child_greenlet: %r  is_instrument=%r",
-                  self._platform_id, child_resource_id, is_instrument)
+        log.debug("%r: [rvc] _validate_child_greenlet: %r", self._platform_id, child_resource_id)
         max_attempts = 12
         attempt_period = 5   # so 12 x 5 = 60 secs max attempt time
 
         attempt = 0
         last_exc = None
         trace = None
-
-        dic = self._ia_clients if is_instrument else self._pa_clients
 
         while attempt <= max_attempts:
             attempt += 1
@@ -1083,7 +1054,7 @@ class PlatformAgent(ResourceAgent):
             try:
                 a_client = self._create_resource_agent_client(child_resource_id,
                                                               child_resource_id)
-                dic[child_resource_id]['ra_client'] = a_client
+                self._ra_clients[child_resource_id]['ra_client'] = a_client
 
                 log.info("%r: OOIION-1077 _child_running: revalidated child "
                          "with resource_id=%r", self._platform_id, child_resource_id)
@@ -1239,7 +1210,7 @@ class PlatformAgent(ResourceAgent):
         Launches a sub-platform agent (if not already running) and waits until
         the sub-platform transitions to UNINITIALIZED state.
         It creates corresponding ResourceAgentClient,
-        sets entry self._pa_clients[sub_resource_id] (where sub_resource_id is the
+        sets entry self._ra_clients[sub_resource_id] (where sub_resource_id is the
         associated resource ID of the platform),
         and publishes device_added event.
 
@@ -1319,7 +1290,7 @@ class PlatformAgent(ResourceAgent):
 
         # here, sub-platform agent process is running.
 
-        self._pa_clients[sub_resource_id] = DotDict(ra_client=pa_client,
+        self._ra_clients[sub_resource_id] = DotDict(ra_client=pa_client,
                                                     resource_id=sub_resource_id,
                                                     platform_id=subplatform_id)
 
@@ -1335,10 +1306,9 @@ class PlatformAgent(ResourceAgent):
 
         @return None if completed OK, otherwise an error message.
         """
-        log.debug("%r: _ping_subplatform -> %r,  _pa_clients=%s",
-                  self._platform_id, subplatform_id, self._pa_clients)
+        log.debug("%r: _ping_subplatform -> %r", self._platform_id, subplatform_id)
 
-        dd = self._pa_clients[subplatform_id]
+        dd = self._ra_clients[subplatform_id]
 
         err_msg = None
         try:
@@ -1378,7 +1348,7 @@ class PlatformAgent(ResourceAgent):
 
         # now, do initialize:
         err_msg = None
-        dd = self._pa_clients[subplatform_id]
+        dd = self._ra_clients[subplatform_id]
 
         sub_state = dd.ra_client.get_agent_state()
         if PlatformAgentState.INACTIVE == sub_state:
@@ -1405,13 +1375,15 @@ class PlatformAgent(ResourceAgent):
     def _subplatforms_launch(self):
         """
         Launches all my configured sub-platforms storing the corresponding
-        ResourceAgentClient objects in _pa_clients.
+        ResourceAgentClient objects in _ra_clients.
 
         Note that any failure while trying to launch a child agent is just logged out.
         """
         # TODO failure in a child agent launch should probably abort the whole launch?
 
-        self._pa_clients.clear()
+        # remove any previous platform entries in _ra_clients:
+        self._ra_clients = dict((k, v) for k, v in self._ra_clients.iteritems() if 'platform_id' not in v)
+
         subplatform_ids = self._pnode.subplatforms.keys()
         if not len(subplatform_ids):
             return
@@ -1424,7 +1396,7 @@ class PlatformAgent(ResourceAgent):
                 log.exception("%r: _subplatforms_launch: exception while launching sub-platform %r",
                               self._platform_id, subplatform_id)
 
-        log.debug("%r: _subplatforms_launch completed. _pa_clients=%s", self._platform_id, self._pa_clients)
+        log.debug("%r: _subplatforms_launch completed.", self._platform_id)
 
     def _subplatforms_initialize(self):
         """
@@ -1435,9 +1407,9 @@ class PlatformAgent(ResourceAgent):
 
         @return dict with failing children. Empty if all ok.
         """
-        log.debug("%r: _subplatforms_initialize. _pa_clients=%s", self._platform_id, self._pa_clients)
+        log.debug("%r: _subplatforms_initialize.", self._platform_id)
 
-        subplatform_ids = self._pa_clients.keys()
+        subplatform_ids = [k for k, v in self._ra_clients.iteritems() if 'platform_id' in v]
         children_with_errors = {}
 
         if not len(subplatform_ids):
@@ -1485,7 +1457,7 @@ class PlatformAgent(ResourceAgent):
         @return dict with children having caused some error. Empty if all
                 children were processed OK.
         """
-        subplatform_ids = self._pa_clients.keys()
+        subplatform_ids = [k for k, v in self._ra_clients.iteritems() if 'platform_id' in v]
 
         children_with_errors = {}
 
@@ -1679,14 +1651,14 @@ class PlatformAgent(ResourceAgent):
                 Otherwise a string with an error message.
         """
 
-        if self._is_invalid_platform_child(subplatform_id):
+        if self._is_invalid_child(subplatform_id):
             log.warn("%r: OOIION-1077 sub-platform has been invalidated or "
                      "could not be re-validated: %r",
                      self._platform_id, subplatform_id)
             # consider this no error to continue shutdown sequence:
             return None
 
-        dd = self._pa_clients[subplatform_id]
+        dd = self._ra_clients[subplatform_id]
         cmd = AgentCommand(command=PlatformAgentEvent.SHUTDOWN, kwargs=dict(recursion=True))
 
         def shutdown():
@@ -1769,15 +1741,17 @@ class PlatformAgent(ResourceAgent):
         @return dict with children having caused some error. Empty if all
                 children were processed OK.
         """
-        log.debug("%r: _subplatforms_shutdown_and_terminate: pa_clients=%s", self._platform_id, self._pa_clients)
-        subplatform_ids = self._pa_clients.keys()
-
         children_with_errors = {}
-        if len(subplatform_ids):
-            for subplatform_id in subplatform_ids:
-                err_msg = self._shutdown_and_terminate_subplatform(subplatform_id)
-                if err_msg is not None:
-                    children_with_errors[subplatform_id] = err_msg
+
+        # Act only on the children that are not invalidated:
+        valid_clients = self._get_valid_platform_clients()
+
+        log.debug("%r: _subplatforms_shutdown_and_terminate: platform clients=%s", self._platform_id, valid_clients)
+
+        for subplatform_id in valid_clients:
+            err_msg = self._shutdown_and_terminate_subplatform(subplatform_id)
+            if err_msg is not None:
+                children_with_errors[subplatform_id] = err_msg
 
         return children_with_errors
 
@@ -1840,7 +1814,7 @@ class PlatformAgent(ResourceAgent):
         log.debug("%r: _ping_instrument -> %r",
                   self._platform_id, instrument_id)
 
-        dd = self._ia_clients[instrument_id]
+        dd = self._ra_clients[instrument_id]
 
         err_msg = None
         try:
@@ -1879,7 +1853,7 @@ class PlatformAgent(ResourceAgent):
 
         # now, do initialize:
         err_msg = None
-        dd = self._ia_clients[instrument_id]
+        dd = self._ra_clients[instrument_id]
 
         sub_state = dd.ra_client.get_agent_state()
         if InstrumentAgentState.INACTIVE == sub_state:
@@ -1977,8 +1951,9 @@ class PlatformAgent(ResourceAgent):
 
         # here, instrument agent process is running.
 
-        self._ia_clients[instrument_id] = DotDict(ra_client=ia_client,
+        self._ra_clients[instrument_id] = DotDict(ra_client=ia_client,
                                                   resource_id=i_resource_id,
+                                                  instrument_id=i_resource_id,
                                                   alt_ids=agent_CFG.get("alt_ids", []))
 
         self._status_manager.instrument_launched(ia_client, i_resource_id)
@@ -1986,12 +1961,14 @@ class PlatformAgent(ResourceAgent):
     def _instruments_launch(self):
         """
         Launches all my configured instruments storing the corresponding
-        ResourceAgentClient objects in _ia_clients.
+        ResourceAgentClient objects in _ra_clients.
         Note that any failure while trying to launch a child agent is just logged out.
         """
         # TODO failure in a child agent launch should probably abort the whole launch?
 
-        self._ia_clients.clear()
+        # remove any previous instrument entries in _ra_clients:
+        self._ra_clients = dict((k, v) for k, v in self._ra_clients.iteritems() if 'instrument_id' not in v)
+
         instrument_ids = self._pnode.instruments.keys()
         if not len(instrument_ids):
             return
@@ -2004,7 +1981,7 @@ class PlatformAgent(ResourceAgent):
                 log.exception("%r: _instruments_launch: exception while launching instrument %r",
                               self._platform_id, instrument_id)
 
-        log.debug("%r: _instruments_launch completed. _ia_clients=%s", self._platform_id, self._ia_clients)
+        log.debug("%r: _instruments_launch completed.", self._platform_id)
 
     def _instruments_initialize(self):
         """
@@ -2014,7 +1991,7 @@ class PlatformAgent(ResourceAgent):
 
         @return dict with failing children. Empty if all ok.
         """
-        instrument_ids = self._ia_clients.keys()
+        instrument_ids = [k for k, v in self._ra_clients.iteritems() if 'instrument_id' in v]
         children_with_errors = {}
 
         if not len(instrument_ids):
@@ -2314,20 +2291,20 @@ class PlatformAgent(ResourceAgent):
                 Otherwise a string with an error message.
         """
 
-        if self._is_invalid_instrument_child(instrument_id):
+        if self._is_invalid_child(instrument_id):
             log.warn("%r: OOIION-1077 instrument has been invalidated or "
                      "could not be re-validated: %r",
                      self._platform_id, instrument_id)
             # consider this no error to continue shutdown sequence:
             return None
 
-        dd = self._ia_clients[instrument_id]
+        dd = self._ra_clients[instrument_id]
         cmd = AgentCommand(command=ResourceAgentEvent.RESET)
 
         def reset():
             log.debug("%r: resetting %r", self._platform_id, instrument_id)
 
-            ia_client = self._ia_clients[instrument_id].ra_client
+            ia_client = self._ra_clients[instrument_id].ra_client
 
             # do not reset if instrument already in UNINITIALIZED:
             if ResourceAgentState.UNINITIALIZED == ia_client.get_agent_state():
@@ -2407,6 +2384,8 @@ class PlatformAgent(ResourceAgent):
 
         # Act only on the children that are not invalidated:
         valid_clients = self._get_valid_instrument_clients()
+
+        log.debug("%r: _instruments_shutdown_and_terminate: instrument clients=%s", self._platform_id, valid_clients)
 
         for instrument_id in valid_clients:
             err_msg = self._shutdown_and_terminate_instrument(instrument_id)

--- a/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
+++ b/ion/agents/platform/test/base_test_platform_agent_with_rsn.py
@@ -457,6 +457,14 @@ class BaseIntTestPlatform(IonIntegrationTestCase, HelperTestMixin):
 
         return async_event_result, events_received
 
+    def _start_ResourceAgentLifecycleEvent_subscriber(self, origin, origin_type, sub_type, count=1):
+        return self._start_event_subscriber2(
+            count=count,
+            event_type="ResourceAgentLifecycleEvent",
+            origin_type=origin_type,
+            sub_type=sub_type,
+            origin=origin)
+
     def _stop_event_subscribers(self):
         """
         Stops the event subscribers on cleanup.

--- a/ion/agents/platform/test/test_platform_agent_robustness.py
+++ b/ion/agents/platform/test/test_platform_agent_robustness.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Additional tests focused on robustness and destructive testing"""
+"""Additional tests focused on robustness testing"""
 
 __author__ = 'Carlos Rueda'
 
@@ -10,8 +10,10 @@ __author__ = 'Carlos Rueda'
 # bin/nosetests -sv ion/agents/platform/test/test_platform_agent_robustness.py:TestPlatformRobustness.test_with_instrument_directly_stopped
 # bin/nosetests -sv ion/agents/platform/test/test_platform_agent_robustness.py:TestPlatformRobustness.test_with_leaf_subplatform_directly_stopped
 # bin/nosetests -sv ion/agents/platform/test/test_platform_agent_robustness.py:TestPlatformRobustness.test_with_intermediate_subplatform_directly_stopped
+# bin/nosetests -sv ion/agents/platform/test/test_platform_agent_robustness.py:TestPlatformRobustness.test_with_intermediate_subplatform_directly_stopped_then_restarted
 
-from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform, instruments_dict
+from ion.agents.platform.test.base_test_platform_agent_with_rsn import BaseIntTestPlatform
+from ion.agents.platform.status_manager import publish_event_for_diagnostics
 from pyon.public import log, CFG
 from pyon.util.context import LocalContextMixin
 from pyon.agent.agent import ResourceAgentState, ResourceAgentEvent
@@ -19,6 +21,7 @@ from interface.objects import AgentCommand
 from interface.objects import ProcessStateEnum
 
 from gevent.timeout import Timeout
+import gevent
 from mock import patch
 import unittest
 import os
@@ -373,3 +376,99 @@ class TestPlatformRobustness(BaseIntTestPlatform):
                 self.IMS.stop_platform_agent_instance(o_obj.platform_agent_instance_id)
             except Exception as ex:
                 log.warn("Error while trying IMS.stop_platform_agent_instance(%r)", o_obj.platform_agent_instance_id, ex)
+
+    def test_with_intermediate_subplatform_directly_stopped_then_restarted(self):
+        #
+        # Similar to test_with_intermediate_subplatform_directly_stopped but the sub-platform is then
+        # relaunched to verify that it is "revalidated" for subsequent processing.
+        # We can visually verify this via the publish_event_for_diagnostics utility.
+        # The test should complete without any issues.
+        #
+        self._set_receive_timeout()
+        recursion = True
+
+        p_root = self._set_up_platform_hierarchy_with_some_instruments([])
+        self._launch_network(p_root, recursion)
+
+        log.info('platforms in the launched network (%d): %s', len(self._setup_platforms), self._setup_platforms.keys())
+        p_obj = self._get_platform('LV01B')
+        pa_client = self._create_resource_agent_client(p_obj.platform_device_id)
+
+        self._ping_agent()
+        self._initialize(recursion)
+        self._go_active(recursion)
+        self._run(recursion)
+        self._assert_agent_client_state(pa_client, ResourceAgentState.COMMAND)
+
+        # use associated process ID for the subscription:
+        platform_pid = pa_client.get_agent_process_id()
+        async_event_result, events_received = self._start_ProcessLifecycleEvent_subscriber(platform_pid)
+
+        # directly stop sub-platform
+        log.info("stopping sub-platform %r", p_obj.platform_device_id)
+        self.IMS.stop_platform_agent_instance(p_obj.platform_agent_instance_id)
+
+        # verify publication of TERMINATED lifecycle event from sub-platform when stopped
+        async_event_result.get(timeout=self._receive_timeout)
+        self.assertEquals(len(events_received), 1)
+        event_received = events_received[0]
+        log.info("ProcessLifecycleEvent received: %s", event_received)
+        self.assertEquals(platform_pid, event_received.origin)
+        self.assertEquals(ProcessStateEnum.TERMINATED, event_received.state)
+
+        gevent.sleep(3)
+
+        publish_event_for_diagnostics()  # should show the invalidated child for parent Node1B:
+        # INFO ... ion.agents.platform.status_manager:1019 'Node1B'/RESOURCE_AGENT_STATE_COMMAND: (a7f865c34f534e60a14e5f0f8ef2fd53) status report triggered by diagnostic event:
+        #                                            AGGREGATE_COMMS     AGGREGATE_DATA      AGGREGATE_LOCATION  AGGREGATE_POWER
+        #         26215ffcf7c94260a99e9c9d103f22f9 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         0e07bc623af64a3a8f61465329451de7 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         a914714894b844a8b42724fe9208fde4 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         02d5a770fba8405c868cc8d55bbbb8d3 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         b19f89585e7c43789b60beac5ddec43c : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         a2f81525ab1e425da808191f9bbe945d : STATUS_UNKNOWN      STATUS_UNKNOWN      STATUS_UNKNOWN      STATUS_UNKNOWN
+        #         6ff02a90e34643fe87ecf262a33437cd : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         83b4f74ab1db4c70ae63072336083ac3 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         7639e530740a48a8b299d0d19dcf7abe : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         88b143e311514121adc544c5933f92a6 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         b1453122a5a64ac6868cfc39e12e4e50 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         c996ff0478a6449da62955859020ee50 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #                                aggstatus : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #                            rollup_status : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #
+        #                     invalidated_children : ['a2f81525ab1e425da808191f9bbe945d']
+
+        gevent.sleep(3)
+
+        ############################################
+        # relaunch the intermediate sub-platform:
+        log.info("relaunching sub-platform 'LV01B': %r", p_obj.platform_device_id)
+        pa_client = self._start_a_platform(p_obj)
+        self._ping_agent(pa_client)
+        # recursion=False because LV01B's children are already in COMMAND
+        self._initialize(recursion=False, pa_client=pa_client)
+        self._go_active(recursion=False, pa_client=pa_client)
+        self._run(recursion=False, pa_client=pa_client)
+
+        # wait for a bit to allow ancestors to re-validate the child, in particular for the parent Node1B:
+        gevent.sleep(10)
+
+        publish_event_for_diagnostics()  # should show the child re-validated:
+        # INFO ... ion.agents.platform.status_manager:1019 'Node1B'/RESOURCE_AGENT_STATE_COMMAND: (a7f865c34f534e60a14e5f0f8ef2fd53) status report triggered by diagnostic event:
+        #                                            AGGREGATE_COMMS     AGGREGATE_DATA      AGGREGATE_LOCATION  AGGREGATE_POWER
+        #         26215ffcf7c94260a99e9c9d103f22f9 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         0e07bc623af64a3a8f61465329451de7 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         a914714894b844a8b42724fe9208fde4 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         02d5a770fba8405c868cc8d55bbbb8d3 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         b19f89585e7c43789b60beac5ddec43c : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         a2f81525ab1e425da808191f9bbe945d : STATUS_UNKNOWN      STATUS_UNKNOWN      STATUS_UNKNOWN      STATUS_UNKNOWN
+        #         6ff02a90e34643fe87ecf262a33437cd : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         83b4f74ab1db4c70ae63072336083ac3 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         7639e530740a48a8b299d0d19dcf7abe : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         88b143e311514121adc544c5933f92a6 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         b1453122a5a64ac6868cfc39e12e4e50 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #         c996ff0478a6449da62955859020ee50 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #                                aggstatus : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #                            rollup_status : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
+        #
+        #                     invalidated_children : []

--- a/ion/agents/platform/test/test_platform_agent_robustness.py
+++ b/ion/agents/platform/test/test_platform_agent_robustness.py
@@ -67,14 +67,6 @@ class TestPlatformRobustness(BaseIntTestPlatform):
             origin=p_root.platform_device_id,
             sub_type="device_failed_command")
 
-    def _start_ResourceAgentLifecycleEvent_subscriber(self, origin, origin_type, sub_type, count=1):
-        return self._start_event_subscriber2(
-            count=count,
-            event_type="ResourceAgentLifecycleEvent",
-            origin_type=origin_type,
-            sub_type=sub_type,
-            origin=origin)
-
     def _instrument_initialize(self, instr_key, ia_client):
         self._instrument_execute_agent(instr_key, ia_client, ResourceAgentEvent.INITIALIZE, ResourceAgentState.INACTIVE)
 


### PR DESCRIPTION
Fix https://jira.oceanobservatories.org/tasks/browse/OOIION-1991

@edwardhunter please review and merge.

Test: test_platform_agent_robustness.py:TestPlatformRobustness.test_with_intermediate_subplatform_directly_stopped_then_restarted

Launches a multi-level platform network, then stops one of the intermediate platforms, then re-starts that platform to verify that it gets revalidated for subsequent processing. This is visually verified via the publish_event_for_diagnostics utility, which is called after the stop and then after the re-start. The following is logged out by the parent Node1B platform at those two points:

After the stop of the child:

```
2014-07-08 14:55:36,201 INFO resource_agent-ProcessDefinition_for_PlatformAgent_PlatformAgent_137ddb809934a4282b09f73dd60fc2d26-listen-5 ion.agents.platform.status_manager:1019 'Node1B'/RESOURCE_AGENT_STATE_COMMAND: (624187f8ca88450e89e8e95b0160e816) status report triggered by diagnostic event:
                                           AGGREGATE_COMMS     AGGREGATE_DATA      AGGREGATE_LOCATION  AGGREGATE_POWER
        8108b6fca7ee4bef8eff13a05c790ab8 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        7909ba57578b4de1a441885e15cdaa61 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        8d5ede3469db4f58bb2a6fca3b885630 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        e05954f109fb4e0885233e204d41e3ba : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        20d265d574ae44d0834a0f90c0216dde : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        15c6ffe7121e4f6eaf812bf4abda2338 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        acb3f8aa929b4e898ff763768610f014 : STATUS_UNKNOWN      STATUS_UNKNOWN      STATUS_UNKNOWN      STATUS_UNKNOWN
        1bc677df77604c31ad382b9df70f516b : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        c107f1d1972a44709b388642e4814d23 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        99389c4f25a941bf8e64bc8a7d714183 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        2268ac0ab11341e7b67895dfde6642c3 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        ff03ac66dd194fce85cb21d9fc90d0f3 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
                               aggstatus : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
                           rollup_status : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK

                    invalidated_children : ['acb3f8aa929b4e898ff763768610f014']
```

And then after the re-start of that child:

```
2014-07-08 14:55:50,452 INFO resource_agent-ProcessDefinition_for_PlatformAgent_PlatformAgent_137ddb809934a4282b09f73dd60fc2d26-listen-5 ion.agents.platform.status_manager:1019 'Node1B'/RESOURCE_AGENT_STATE_COMMAND: (624187f8ca88450e89e8e95b0160e816) status report triggered by diagnostic event:
                                           AGGREGATE_COMMS     AGGREGATE_DATA      AGGREGATE_LOCATION  AGGREGATE_POWER
        8108b6fca7ee4bef8eff13a05c790ab8 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        7909ba57578b4de1a441885e15cdaa61 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        8d5ede3469db4f58bb2a6fca3b885630 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        e05954f109fb4e0885233e204d41e3ba : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        20d265d574ae44d0834a0f90c0216dde : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        15c6ffe7121e4f6eaf812bf4abda2338 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        acb3f8aa929b4e898ff763768610f014 : STATUS_UNKNOWN      STATUS_UNKNOWN      STATUS_UNKNOWN      STATUS_UNKNOWN
        1bc677df77604c31ad382b9df70f516b : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        c107f1d1972a44709b388642e4814d23 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        99389c4f25a941bf8e64bc8a7d714183 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        2268ac0ab11341e7b67895dfde6642c3 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
        ff03ac66dd194fce85cb21d9fc90d0f3 : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
                               aggstatus : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK
                           rollup_status : STATUS_OK           STATUS_OK           STATUS_OK           STATUS_OK

                    invalidated_children : []
```
